### PR TITLE
Modified to use s4a.js via require shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gitsha.js
 hooks/
 /nbproject/private/
 /nbproject/
+.orig

--- a/components/core/core.js
+++ b/components/core/core.js
@@ -52,7 +52,8 @@ require.config({
         utils: hsl_path + 'components/utils',
         WFSCapabilities: requirejs.s.contexts._.config.paths.WFSCapabilities || hsl_path + 'components/format/hs.format.WFSCapabilities',
         WfsSource: requirejs.s.contexts._.config.paths.WfsSource || hsl_path + 'components/layers/hs.source.Wfs',
-        routing: hsl_path + 'components/routing/routing'
+        routing: hsl_path + 'components/routing/routing',
+        s4a: requirejs.s.contexts._.config.paths.s4a || hsl_path + 'bower_components/s4a-js/dist/s4a.min'
     },
     shim: {
         'angular': {

--- a/components/routing/routing.js
+++ b/components/routing/routing.js
@@ -2,8 +2,14 @@
  * @namespace hs.routing
  * @memberOf hs
  */
-define(['angular', 'ol', 'map', 'core'],
-    function(angular, ol) {
+define(['angular',
+        'ol',
+        's4a',
+        'map',
+        'core'
+    ], function(angular,
+        ol,
+        s4a) {
         angular.module('hs.routing', ['hs.map', 'hs.core'])
             .directive('hs.routing.directive', function() {
                 return {

--- a/examples/routing/hslayers.js
+++ b/examples/routing/hslayers.js
@@ -38,7 +38,11 @@ require.config({
         },
         dc: {
             deps: ['d3', 'crossfilter']
-        }
+        },
+        s4a: {
+            deps: ['ol', 'dc'],
+            exports: 's4a'            
+        }        
     }
 });
 

--- a/examples/routing/index.html
+++ b/examples/routing/index.html
@@ -12,7 +12,6 @@
         <div hs ng-app="hs" ng-controller="Main" style="position: relative;"></div>
         <script src="../../bower_components/jquery/dist/jquery.min.js"></script>
         <script src="../../bower_components/requirejs/require.js"></script>     
-        <script src="../../bower_components/s4a-js/dist/s4a.js" type="text/javascript"></script>
         <script src="hslayers.js"></script> 
     </body>
 </html>


### PR DESCRIPTION
@wohnout: At your convenience, review and merge.

- Added s4a to root require.js configuration
- Added s4a as dependency for routing.js scrip of routing module
- Added shim definition to hslayers.js config of specific example (to avoid loading it for all apps based on HSLayers NG)
- Removed manual load of library from routing example index.html