### PR TITLE
Core hssize

### DIFF
--- a/components/core/core.js
+++ b/components/core/core.js
@@ -174,7 +174,7 @@ define(['angular', 'angular-gettext', 'translations', 'ol', 'map', 'drag', 'api'
                             var element = $("div[hs]");
                             var map = $("#map");
                             var sidebarElem = $('.panelspace');
-                            if (element.width() != sidebarElem.width()) {
+                            if (element.width() > sidebarElem.width()) {
                                 map.width(element.width() - sidebarElem.width());
                             } else {
                                 map.width(0);


### PR DESCRIPTION
New initialization system for Core.js and therefore whole HS app.

After proposed changes only function in HS directive Link should be:
```
link: function(scope, element) {
       Core.init(element,"parent");
}
```
Core.init should be syntactic sugar for all possibilities of initialization. First parameter is taken from link function. 
Second parameter options:
1. No second parameter (undefined) - fullscreenmode - same as in our examples
2. "self" - Size is taken from CSS style of HS element
3. "parent" - Size is taken from computed size of HS element parent
4. "id" - Size is taken from computed size of another element (not sure about use-case)

WARNING: Change might not be fully compatible with all apps in production (it is compatible with examples), these might require to change link function to Core.init(element,"parent"/"self"). Thats why I created separate branch.