### PR TITLE
Change angular/di and import/extensions ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,14 @@
     "no-console": "warn",
     "object-curly-spacing": "warn",
     "prefer-arrow-callback": "warn",
-    "space-before-function-paren": "off"
+    "space-before-function-paren": "off",
+    "angular/di": [
+      "error",
+      "array",
+      {
+        "matchNames": false
+      }
+    ]
   }
   /*"settings": {
     "import/resolver": "webpack"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,13 @@
     "object-curly-spacing": "warn",
     "prefer-arrow-callback": "warn",
     "space-before-function-paren": "off",
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never"
+      }
+    ],
     "angular/di": [
       "error",
       "array",


### PR DESCRIPTION
We use these two rules completely differently in our current codebase, but it's already unified, so no need to change our customs.