### PR TITLE
Fix crash with deprecated config

### DIFF
--- a/components/layout/layout.service.js
+++ b/components/layout/layout.service.js
@@ -471,6 +471,9 @@ export default [
       $log.warn(
         'config.locationButtonVisible parameter is deprecated. Use config.panelsEnabled.geolocationButton instead'
       );
+      if (angular.isUndefined(config.componentsEnabled)) {
+        config.componentsEnabled = {};
+      }
       if (angular.isUndefined(config.componentsEnabled.geolocationButton)) {
         config.componentsEnabled.geolocationButton =
           config.locationButtonVisible;


### PR DESCRIPTION
This fix returns backwards compatibility with
config.locationButtonVisible parameter
closes #611