### PR TITLE
App dimensions for iPhone

### DIFF
--- a/components/core/core.service.js
+++ b/components/core/core.service.js
@@ -21,7 +21,7 @@ export default [
     layoutService,
     $log,
     $document,
-    utilsService
+    utilsService,
   ) {
     const me = {
       hslayersNgTemplate: require('../../hslayers.html'),
@@ -60,7 +60,7 @@ export default [
       sizeOptions: {
         element: undefined,
         windowedMap: undefined,
-        selector: undefined,
+        selector: undefined
       },
       language: 'en',
       setMainPanel: function (which, by_gui) {
@@ -229,6 +229,14 @@ export default [
             }
             const vh = w.innerHeight * 0.01;
             $document[0].documentElement.style.setProperty('--vh', `${vh}px`);
+
+            if (w.matchMedia('(orientation: portrait)').matches) {
+              document.getElementsByTagName('html')[0].style.height = '100vh';             
+              $timeout(() => {
+                document.getElementsByTagName('html')[0].style.height = '100%';
+              }, 500);
+
+            }
           },
           150,
           false,
@@ -387,7 +395,7 @@ export default [
         if (angular.isUndefined(config.componentsEnabled)) {
           config.componentsEnabled = {};
         }
-      },
+      }
     };
 
     let _puremapApp = false;
@@ -413,7 +421,7 @@ export default [
           config.componentsEnabled.mapControls = false;
           layoutService.sidebarVisible(false);
         }
-      },
+      }
     });
 
     if (me.exists('hs.sidebar.controller') /*&& me.puremapApp != true*/) {
@@ -440,5 +448,5 @@ export default [
             */
 
     return me;
-  },
+  }
 ];

--- a/components/core/core.service.js
+++ b/components/core/core.service.js
@@ -21,7 +21,7 @@ export default [
     layoutService,
     $log,
     $document,
-    utilsService,
+    utilsService
   ) {
     const me = {
       hslayersNgTemplate: require('../../hslayers.html'),
@@ -231,7 +231,7 @@ export default [
             $document[0].documentElement.style.setProperty('--vh', `${vh}px`);
 
             if (w.matchMedia('(orientation: portrait)').matches) {
-              document.getElementsByTagName('html')[0].style.height = '100vh';             
+              document.getElementsByTagName('html')[0].style.height = '100vh';
               $timeout(() => {
                 document.getElementsByTagName('html')[0].style.height = '100%';
               }, 500);

--- a/components/search/partials/searchinput.html
+++ b/components/search/partials/searchinput.html
@@ -1,16 +1,13 @@
 <div class="input-group">
     <div class="input-group-prepend">
-        <button ng-show="layoutService.smallWidth"
-            ng-click="searchInputVisible = !searchInputVisible" class="btn btn-light btn-outline-secondary"><i
+        <button ng-click="searchInputVisible = !searchInputVisible" class="btn btn-light btn-outline-secondary"><i
                 class="glyphicon icon-search" title="{{'Search'|translate}}"></i></button>
     </div>
-    <input ng-model="query"
-        ng-show="(!layoutService.smallWidth || searchInputVisible)"
-        class="form-control" class="hs-search-address-input" placeholder="{{'Search:'|translate}}" ng-change="queryChanged()" />
+    <input ng-model="query" ng-show="searchInputVisible" class="form-control"
+        class="hs-search-address-input" placeholder="{{'Search:'|translate}}" ng-change="queryChanged()" />
     <div class="input-group-append">
-        <button class="btn btn-light btn-outline-secondary"
-            ng-if="clearvisible" ng-click="clear()"><span aria-hidden="true"
-                class="close">×</span><span class="sr-only">
+        <button class="btn btn-light btn-outline-secondary" ng-if="clearvisible" ng-click="clear()"><span
+                aria-hidden="true" class="close">×</span><span class="sr-only">
                 <translate>Clear</translate>
             </span></button>
     </div>

--- a/components/search/search.controller.js
+++ b/components/search/search.controller.js
@@ -31,6 +31,7 @@ export default [
         Core.searchVisible(true);
         $scope.queryChanged();
       }
+      window.innerWidth < 767 ? $scope.searchInputVisible = false : $scope.searchInputVisible = true;
     };
 
     /**

--- a/components/sidebar/partials/sidebar.html
+++ b/components/sidebar/partials/sidebar.html
@@ -1,7 +1,7 @@
 <div class="hs-sidebar-list list-group">
     <a href="#" class="hs-sidebar-item list-group-item" ng-if="layoutService.sidebarToggleable" ng-click="toggleSidebar()">
         <i class="menu-icon"
-            ng-class="layoutService.sidebarExpanded ? (!layoutService.sidebarRight ? 'icon-chevron-left' : 'icon-chevron-right') : 'icon-slidersoff'"></i>
+            ng-class="layoutService.sidebarExpanded ? (!layoutService.sidebarRight ? 'icon-chevron-left' : 'icon-chevron-right') : (!layoutService.sidebarRight ? 'icon-chevron-right' : 'icon-chevron-left')"></i>
     </a>
 
     <a href="#" ng-repeat="button in sidebarService.buttons | orderBy:'order'" class="flex-fill hs-sidebar-item list-group-item"


### PR DESCRIPTION
- Scaling bug of app (iPhones only) after portrait -> landscape -> portrait rotation. State as seen in the picture bellow actually consists of two problem. Vertical shift of the conent is caused by bug descirbed here:
https://forums.macrumors.com/threads/is-this-a-mobile-safari-bug-white-space-appears-at-bottom-after-rotating-iphone.2209551/ Used proposed solution ( n. 13). 

Horizontal shift is caused by content overflowing to the side after the rotation, can be fixed by adding 'overflow:hidden' to #hs-app element.
![image](https://user-images.githubusercontent.com/44566616/79950118-def7a380-8476-11ea-8cd2-617f44d04740.png)
- Also changed sidebar toggle icon and after @fzadrazil's suggestion made search icon always visible
