### PR TITLE
Dynamically set publicPath in webpack lazy loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('dist/hslayers-ng.js');
+module.exports = require('dist/hslayers-ng.main.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5656,6 +5656,11 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "dynamic-pub-path-plugin": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/dynamic-pub-path-plugin/-/dynamic-pub-path-plugin-0.0.4.tgz",
+      "integrity": "sha512-Kq2GDgkyl/2V+8mp14ouDIgKVXv+CbgvOJUcDIrg/uZovifDDk3KVH2NAz3h+ap/786X3fkjP79Bog0Bmgs13g=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "bootstrap": ">=4.4.1",
     "clipboard": "^2.0.4",
     "cors-anywhere": "^0.4.1",
+    "dynamic-pub-path-plugin": "0.0.4",
     "gyronorm": "^2.0.6",
     "hammerjs": "^2.0.8",
     "hoek": "6.1.3",

--- a/scripts/webpack.common.js
+++ b/scripts/webpack.common.js
@@ -12,6 +12,7 @@
 const path = require('path');
 var WebpackBuildNotifierPlugin = require('webpack-build-notifier');
 const hslPaths = require(path.join( __dirname, '..', 'common_paths')); //TODO this should not be necessary
+const DynamicPubPathPlugin = require('dynamic-pub-path-plugin');
 
 module.exports = {
   entry: path.resolve(__dirname, '../app.js'),
@@ -30,6 +31,9 @@ module.exports = {
     ].concat(hslPaths.paths)
   },
   plugins: [
+    new DynamicPubPathPlugin({
+      'expression': `(window.HSL_PATH || './node_modules/hslayers-ng/dist/')`,
+    }),
     // Clean before build
     //new CleanWebpackPlugin()
     new WebpackBuildNotifierPlugin({


### PR DESCRIPTION
HSL_PATH variable can be used to control it. If its not set
./node_modules/hslayers-ng/dist/ will be used by default.
Lazy loading path problem was described in https://github.com/webpack/webpack/issues/7968
https://github.com/agoldis/webpack-require-from
https://github.com/webpack/webpack/issues/7077#issuecomment-383029585
but https://github.com/inferpse/dynamic-pub-path-plugin/blob/master/index.js
can be used for that.

fixes #664