### PR TITLE
Fix empty getParamValue()

### DIFF
--- a/components/map/map.controller.js
+++ b/components/map/map.controller.js
@@ -55,7 +55,7 @@ export default function (
     init() {
       if (HsPermalinkUrlService.getParamValue('visible_layers')) {
         HsMapService.visibleLayersInUrl = HsPermalinkUrlService.getParamValue(
-          ''
+          'visible_layers'
         ).split(';');
       }
       HsMapService.init();


### PR DESCRIPTION
Fixes attempt to read empty URL parametre
Solves #688