### PR TITLE
Make attribution collapsible by default

### DIFF
--- a/components/map/map.service.js
+++ b/components/map/map.service.js
@@ -31,7 +31,7 @@ import {
   MousePosition,
   ScaleLine,
   defaults as controlDefaults,
-} from 'ol/control';
+  } from 'ol/control';
 import {
   always as alwaysCondition,
   never as neverCondition,
@@ -282,7 +282,12 @@ export default function (
    * @type {object}
    * @description Set of default map controls used in HSLayers, may be loaded from config file
    */
-  const defaultDesktopControls = controlDefaults();
+  const defaultDesktopControls = controlDefaults({
+    attributionOptions: {
+      collapsible: true,
+      collapsed: true,
+    }
+  });
 
   //creates custom default view control
   const setDefaultView = function (e) {
@@ -313,6 +318,7 @@ export default function (
 
   defaultDesktopControls.removeAt(1);
   defaultDesktopControls.push(new ScaleLine());
+
   defaultDesktopControls.push(defaultViewControl);
 
   const defaultMobileControls = controlDefaults({


### PR DESCRIPTION
I just realised that we will have to make double PRs when applying changes to AngularJS components – both to release-1.24 branch and to develop.
So I am adding this PR to merge also to develop, otherwise we will lost this commit on the main road.