### PR TITLE
Gettext removal from hsl

### DIFF
--- a/assets/locales/cs.json
+++ b/assets/locales/cs.json
@@ -143,7 +143,6 @@
     "individualStyle": "Individuální styl pro prvek",
     "definedStyle": "Definovaný styl",
     "fillOpacity": "Vyplňte neprůhlednost:",
-    
     "drawLayerMetadata": {
       "layerTitle": "Název vrstvy",
       "nameOfFolder": "Název složky v hierarchii správce vrstev",
@@ -156,7 +155,7 @@
       "removeLastPoint": "Odebrat poslední bod",
       "finishFeature": "Ukončit prvek"
     },
-    "drawLayer": "Nakreslete vrstvu"  
+    "drawLayer": "Nakreslete vrstvu"
   },
   "PERMALINK": {
     "newShare": "Nové sdílení",
@@ -277,5 +276,12 @@
   },
   "MAP": {
     "zoomToInitialWindow": "Přiblížit počáteční okno"
+  },
+  "GEOLOCATION": {
+    "locateMe": "Najděte mě",
+    "precision": "Přesnost",
+    "speed": "Rychlost",
+    "altitude": "Nadmořská výška",
+    "follow": "Následovat"
   }
 }

--- a/assets/locales/cs.json
+++ b/assets/locales/cs.json
@@ -283,5 +283,8 @@
     "speed": "Rychlost",
     "altitude": "Nadmořská výška",
     "follow": "Následovat"
+  },
+  "HISTORY": {
+    "toggleDropdown": "Přepnout rozbalovací nabídku"
   }
 }

--- a/assets/locales/cs.json
+++ b/assets/locales/cs.json
@@ -143,6 +143,7 @@
     "individualStyle": "Individuální styl pro prvek",
     "definedStyle": "Definovaný styl",
     "fillOpacity": "Vyplňte neprůhlednost:",
+    
     "drawLayerMetadata": {
       "layerTitle": "Název vrstvy",
       "nameOfFolder": "Název složky v hierarchii správce vrstev",
@@ -154,7 +155,8 @@
       "addDrawLayer": "Přidejte vrstvu kreslení",
       "removeLastPoint": "Odebrat poslední bod",
       "finishFeature": "Ukončit prvek"
-    }
+    },
+    "drawLayer": "Nakreslete vrstvu"  
   },
   "PERMALINK": {
     "newShare": "Nové sdílení",
@@ -266,5 +268,14 @@
       "SEARCH": "Vyhledejte lokaci",
       "DRAW": "Nakreslete nové prvky"
     }
+  },
+  "QUERY": {
+    "reallyDelete": "Opravdu tuto prvek smažte?",
+    "confirmDelete": "Potvrďte smazání",
+    "reallyDeleteAllFeaturesFrom": "Opravdu odstranit všechny prvek z vrstvy",
+    "coordinates": "Souřadnice"
+  },
+  "MAP": {
+    "zoomToInitialWindow": "Přiblížit počáteční okno"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -283,5 +283,8 @@
     "speed": "Speed",
     "altitude": "Altitude",
     "follow": "Follow"
+  },
+  "HISTORY": {
+    "toggleDropdown": "Toggle dropdown"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -154,7 +154,8 @@
       "addDrawLayer": "Add draw layer",
       "removeLastPoint": "Remove last point",
       "finishFeature": "Finish feature"
-    }
+    },
+    "drawLayer": "Draw layer"
   },
   "PERMALINK": {
     "newShare": "New share",
@@ -266,5 +267,14 @@
       "SEARCH": "Search for location",
       "DRAW": "Draw new features"
     }
+  },
+  "QUERY": {
+    "reallyDelete": "Really delete this feature?",
+    "confirmDelete": "Confirm delete",
+    "reallyDeleteAllFeaturesFrom": "Really delete all features from layer",
+    "coordinates": "Coordinates"
+  },
+  "MAP": {
+    "zoomToInitialWindow": "Zoom to initial window"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -276,5 +276,12 @@
   },
   "MAP": {
     "zoomToInitialWindow": "Zoom to initial window"
+  },
+  "GEOLOCATION": {
+    "locateMe": "Locate me",
+    "precision": "Precision",
+    "speed": "Speed",
+    "altitude": "Altitude",
+    "follow": "Follow"
   }
 }

--- a/assets/locales/lv.json
+++ b/assets/locales/lv.json
@@ -154,7 +154,8 @@
       "addDrawLayer": "Pievienot jaunu slāni",
       "removeLastPoint": "Noņemt pēdējo punktu",
       "finishFeature": "Pabeigt grafisko objektu"
-    }
+    },
+    "drawLayer": "Zīmēt slāni"
   },
   "PERMALINK": {
     "newShare": "Jauna kopīgošana",
@@ -266,5 +267,14 @@
       "SEARCH": "Meklēt atrašanās vietu",
       "DRAW": "Zīmēt jaunus grafiskos objektus"
     }
+  },
+  "QUERY": {
+    "reallyDelete": "Vai tiešām vēlaties dzēst šo grafisko objektu?",
+    "confirmDelete": "Apstiprināt dzēšanu",
+    "reallyDeleteAllFeaturesFrom": "Vai tiešām vēlaties izdzēst visus grafiskos objektus no slāņa",
+    "coordinates": "Koordinātes"
+  },
+  "MAP": {
+    "zoomToInitialWindow": "Pietuvināt sākotnējo logu"
   }
 }

--- a/assets/locales/lv.json
+++ b/assets/locales/lv.json
@@ -283,5 +283,8 @@
     "speed": "Ātrums",
     "altitude": "Augstums",
     "follow": "Sekot"
+  },
+  "HISTORY": {
+    "toggleDropdown": "Pārslēgt nolaižamo izvēlni"
   }
 }

--- a/assets/locales/lv.json
+++ b/assets/locales/lv.json
@@ -276,5 +276,12 @@
   },
   "MAP": {
     "zoomToInitialWindow": "Pietuvināt sākotnējo logu"
+  },
+  "GEOLOCATION": {
+    "locateMe": "Mana atrašanās vieta",
+    "precision": "Precizitāte",
+    "speed": "Ātrums",
+    "altitude": "Augstums",
+    "follow": "Sekot"
   }
 }

--- a/common/confirm/confirm-dialog.html
+++ b/common/confirm/confirm-dialog.html
@@ -1,18 +1,18 @@
-<div ng-class="{'in': $ctrl.modalVisible}" class="modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div [ngClass]="{'in': modalVisible}" class="modal" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" translate>
-                    {{$ctrl.title}}
+                <h4 class="modal-title">
+                    {{title}}
                 </h4>
-                <button type="button" ng-click="$ctrl.modalVisible = false" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only" translate="">Close</span></button>
+                <button type="button" (click)="modalVisible = false" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">{{'COMMON.close' | translate}}</span></button>
             </div>
             <div class="modal-body" style="overflow-y:auto">
-                {{$ctrl.message}}
+                {{message}}
             </div>
-            <div class="modal-footer" >
-                <button type="button" class="btn btn-primary" translate ng-click="$ctrl.yes()" [title]="'COMMON.yes' | translate" data-dismiss="modal">{{'COMMON.yes' | translate}}</button>
-                <button type="button" class="btn btn-secondary compositions-btn-cancel" [title]="'COMMON.no' | translate" ng-click="$ctrl.no()" data-dismiss="modal" translate>{{'COMMON.no' | translate}}</button>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" (click)="yes()" [title]="'COMMON.yes' | translate" data-dismiss="modal">{{'COMMON.yes' | translate}}</button>
+                <button type="button" class="btn btn-secondary compositions-btn-cancel" [title]="'COMMON.no' | translate" (click)="no()" data-dismiss="modal">{{'COMMON.no' | translate}}</button>      
             </div>
         </div>
     </div>

--- a/common/history-list/history-list.html
+++ b/common/history-list/history-list.html
@@ -1,5 +1,5 @@
 <button type="button" (click)="historyDropdownVisible=!historyDropdownVisible"
-    class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" title="Toggle dropdown"
+    class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" [title]="'HISTORY.toggleDropdown' | translate"
     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <div class="dropdown-menu" style="left: auto; right:0; width:325px; overflow: hidden"
         [ngClass]="{'show': historyDropdownVisible}">

--- a/common/history-list/history-list.module.ts
+++ b/common/history-list/history-list.module.ts
@@ -1,4 +1,3 @@
-import 'angular-cookies';
 import {BrowserModule} from '@angular/platform-browser';
 import {
   CUSTOM_ELEMENTS_SCHEMA,
@@ -10,13 +9,14 @@ import {CookieService} from 'ngx-cookie-service';
 import {FormsModule} from '@angular/forms';
 import {HsHistoryListComponent} from './history-list.component';
 import {HsHistoryListService} from './history-list.service';
+import {TranslateModule, TranslateStore} from '@ngx-translate/core';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
   declarations: [HsHistoryListComponent],
-  imports: [BrowserModule, FormsModule, CommonModule],
+  imports: [BrowserModule, FormsModule, CommonModule, TranslateModule],
   exports: [HsHistoryListComponent],
-  providers: [HsHistoryListService, CookieService],
+  providers: [HsHistoryListService, CookieService, TranslateStore],
   entryComponents: [HsHistoryListComponent],
 })
 export class HsHistoryListModule {}

--- a/components/add-layers/vector/add-layers-vector.module.ts
+++ b/components/add-layers/vector/add-layers-vector.module.ts
@@ -1,16 +1,19 @@
+import '../../language';
 import * as angular from 'angular';
 import addLayersVectorUrlParserService from './add-layers-vector-url-parser.service';
 import {HsAddLayersVectorService} from './add-layers-vector.service';
 
 /**
+ * @param service
+ * @param layoutService
  * @namespace hs.addLayersVector
  * @memberOf hs
  */
 angular
   .module('hs.addLayersVector', [
     'hs.styles',
-    'gettext',
     'hs.utils',
+    'hs.language',
     'hs.layout',
     'hs.map',
   ])
@@ -63,6 +66,7 @@ angular
 
       /**
        * Handler for adding nonwms service, file in template.
+       *
        * @memberof hs.addLayersVector.controller
        * @function add
        */

--- a/components/add-layers/vector/add-layers-vector.spec.ts
+++ b/components/add-layers/vector/add-layers-vector.spec.ts
@@ -28,17 +28,8 @@ describe('add-layers-vector', () => {
     angular
       .module('hs.layout', ['hs.core'])
       .service('HsLayoutService', HsLayoutService);
-
-    angular.module('gettext').filter('translate', (gettextCatalog) => {
-      /**
-       * @param input
-       * @param context
-       */
-      function filter(input, context) {
-        return gettextCatalog.getString(input, null, context);
-      }
-      filter.$stateful = true;
-      return filter;
+    angular.module('hs.language', []).service('HsLanguageService', function () {
+      this.getTranslation = function () {};
     });
 
     angular.mock.module('hs.addLayersVector');

--- a/components/add-layers/vector/add-vector-layer.directive.html
+++ b/components/add-layers/vector/add-vector-layer.directive.html
@@ -1,39 +1,45 @@
-<p><sub class="text-danger">*Note: if you link a file with coordinates other than World Geodetic System (lon/lat), please set the SRS in the "ADVANCED OPTIONS"</sub></p>
+<p><sub class="text-danger">*Note: if you link a file with coordinates other than World Geodetic System (lon/lat),
+        please set the SRS in the "ADVANCED OPTIONS"</sub></p>
 <form class="form-horizontal" role="form" ng-controller="HsAddLayersVectorController as vm">
     <hs.add-layers-url type="vector" url="vm.url"></hs.add-layers-url>
 
     <div class="form-group">
-        <label class="capabilities_label control-label" >Title</label>
-        <input class="form-control" ng-model="vm.title"/>
+        <label class="capabilities_label control-label">Title</label>
+        <input class="form-control" ng-model="vm.title" />
     </div>
 
     <div class="form-group">
-        <label class="capabilities_label control-label" >Abstract</label>
-        <textarea class="form-control" id='hs-ows-abstract' placeholder="Fill in descriptive text about map" ng-model="vm.abstract">
+        <label class="capabilities_label control-label">Abstract</label>
+        <textarea class="form-control" id='hs-ows-abstract' placeholder="Fill in descriptive text about map"
+            ng-model="vm.abstract">
         </textarea>
     </div>
 
-    <button type="button" class="btn btn-block btn-outline-secondary dropdown-toggle dropdown-toggle-split"  data-toggle="collapse" ng-click="vm.advancedPanelVisible = !vm.advancedPanelVisible" data-target=".hs-ows-vector-advanced" >
+    <button type="button" class="btn btn-block btn-outline-secondary dropdown-toggle dropdown-toggle-split"
+        data-toggle="collapse" ng-click="vm.advancedPanelVisible = !vm.advancedPanelVisible"
+        data-target=".hs-ows-vector-advanced">
         Advanced options
     </button>
 
     <div class="collapse hs-ows-vector-advanced" ng-class="{'show': vm.advancedPanelVisible}">
         <div class="form-group">
             <label class="capabilities_label control-label">SRS</label>
-            <input class="form-control" ng-model="vm.srs"/>
+            <input class="form-control" ng-model="vm.srs" />
         </div>
 
         <div class="form-group">
-            <label class="capabilities_label control-label" >Folder name</label>
-            <input class="form-control" ng-model="vm.folder_name"/>
+            <label class="capabilities_label control-label">Folder name</label>
+            <input class="form-control" ng-model="vm.folder_name" />
         </div>
 
         <div class="form-group">
-            <label class="capabilities_label control-label" >Extract styles</label>
-            <input type="checkbox" ng-model="vm.extract_styles"/>
+            <label class="capabilities_label control-label">Extract styles</label>
+            <input type="checkbox" ng-model="vm.extract_styles" />
         </div>
     </div>
 
-    <button class="btn btn-primary btn-block" ng-disabled="!vm.title" ng-click="vm.add()"><i class="icon-plus"></i> <>Add</></button>
+    <button class="btn btn-primary btn-block" ng-disabled="!vm.title" ng-click="vm.add()"><i class="icon-plus"></i>
+        Add
+    </button>
     </a>
 </form>

--- a/components/add-layers/vector/add-vector-layer.directive.html
+++ b/components/add-layers/vector/add-vector-layer.directive.html
@@ -3,17 +3,17 @@
     <hs.add-layers-url type="vector" url="vm.url"></hs.add-layers-url>
 
     <div class="form-group">
-        <label class="capabilities_label control-label" translate>Title</label>
+        <label class="capabilities_label control-label" >Title</label>
         <input class="form-control" ng-model="vm.title"/>
     </div>
 
     <div class="form-group">
-        <label class="capabilities_label control-label" translate>Abstract</label>
-        <textarea class="form-control" id='hs-ows-abstract' placeholder="{{'Fill in descriptive text about map'|translate}}" ng-model="vm.abstract">
+        <label class="capabilities_label control-label" >Abstract</label>
+        <textarea class="form-control" id='hs-ows-abstract' placeholder="Fill in descriptive text about map" ng-model="vm.abstract">
         </textarea>
     </div>
 
-    <button type="button" class="btn btn-block btn-outline-secondary dropdown-toggle dropdown-toggle-split"  data-toggle="collapse" ng-click="vm.advancedPanelVisible = !vm.advancedPanelVisible" data-target=".hs-ows-vector-advanced" translate>
+    <button type="button" class="btn btn-block btn-outline-secondary dropdown-toggle dropdown-toggle-split"  data-toggle="collapse" ng-click="vm.advancedPanelVisible = !vm.advancedPanelVisible" data-target=".hs-ows-vector-advanced" >
         Advanced options
     </button>
 
@@ -24,16 +24,16 @@
         </div>
 
         <div class="form-group">
-            <label class="capabilities_label control-label" translate>Folder name</label>
+            <label class="capabilities_label control-label" >Folder name</label>
             <input class="form-control" ng-model="vm.folder_name"/>
         </div>
 
         <div class="form-group">
-            <label class="capabilities_label control-label" translate>Extract styles</label>
+            <label class="capabilities_label control-label" >Extract styles</label>
             <input type="checkbox" ng-model="vm.extract_styles"/>
         </div>
     </div>
 
-    <button class="btn btn-primary btn-block" ng-disabled="!vm.title" ng-click="vm.add()"><i class="icon-plus"></i> <translate>Add</translate></button>
+    <button class="btn btn-primary btn-block" ng-disabled="!vm.title" ng-click="vm.add()"><i class="icon-plus"></i> <>Add</></button>
     </a>
 </form>

--- a/components/draw/draw.service.ts
+++ b/components/draw/draw.service.ts
@@ -4,6 +4,7 @@ import Vector from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
 import {Circle, Fill, Stroke, Style} from 'ol/style';
 import {Draw, Modify} from 'ol/interaction';
+import {HsLanguageService} from './../language/language.service';
 import {Layer} from 'ol/layer';
 
 import {HsConfig} from '../../config.service';
@@ -77,7 +78,8 @@ export class HsDrawService {
     private HsLogService: HsLogService,
     private HsConfig: HsConfig,
     private HsQueryBaseService: HsQueryBaseService,
-    private HsQueryVectorService: HsQueryVectorService
+    private HsQueryVectorService: HsQueryVectorService,
+    private HsLanguageService: HsLanguageService
   ) {
     this.keyUp = this.keyUp.bind(this);
     this.HsMapService.loaded().then((map) => {
@@ -115,7 +117,7 @@ export class HsDrawService {
   }
 
   saveDrawingLayer(addNewLayer = false): void {
-    let tmpTitle = 'Draw layer'; //this.gettext()
+    let tmpTitle = this.HsLanguageService.getTranslation('DRAW.drawLayer');
     const tmpLayer =
       addNewLayer === true
         ? null

--- a/components/draw/draw.spec.ts
+++ b/components/draw/draw.spec.ts
@@ -19,6 +19,7 @@ import {HsMapServiceMock} from '../map/map.service.mock';
 import {HsQueryBaseService} from '../query/query-base.service';
 import {HsQueryVectorService} from '../query/query-vector.service';
 
+import {HsLanguageService} from '../language/language.service';
 import {Polygon} from 'ol/geom';
 import {Vector as VectorSource} from 'ol/source';
 
@@ -26,6 +27,9 @@ class emptyMock {
   constructor() {}
 }
 class HsConfigMock {
+  constructor() {}
+}
+class HsLanguageMock {
   constructor() {}
 }
 
@@ -72,6 +76,7 @@ describe('HsDraw', () => {
       providers: [
         HsDrawService,
         {provide: HsLayoutService, useValue: mockLayoutService},
+        {provide: HsLanguageService, useValue: new HsLanguageMock()},
         {provide: HsMapService, useValue: new HsMapServiceMock()},
         {provide: HsLayerUtilsService, useValue: mockLayerUtilsService},
         {provide: HsConfig, useValue: new HsConfigMock()},

--- a/components/geolocation/geolocation.module.ts
+++ b/components/geolocation/geolocation.module.ts
@@ -11,6 +11,7 @@ import {HsGeolocationComponent} from './geolocation.component';
 import {HsGeolocationService} from './geolocation.service';
 import {HsLayoutModule} from './../layout/layout.module';
 import {HsPanelHelpersModule} from '../layout/panels/panel-helpers.module';
+import {TranslateModule, TranslateStore} from '@ngx-translate/core';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
@@ -21,9 +22,10 @@ import {HsPanelHelpersModule} from '../layout/panels/panel-helpers.module';
     CommonModule,
     HsPanelHelpersModule,
     HsLayoutModule,
+    TranslateModule,
   ],
   exports: [HsGeolocationComponent],
-  providers: [HsGeolocationService],
+  providers: [HsGeolocationService, TranslateStore],
   entryComponents: [HsGeolocationComponent],
 })
 export class HsGeolocationModule {}

--- a/components/geolocation/partials/geolocation.html
+++ b/components/geolocation/partials/geolocation.html
@@ -1,11 +1,11 @@
 <div class="hs-locate ol-unselectable ol-control hs-locateToggler" [hidden]="!geolocationVisible()"
     [ngClass]="{'ol-collapsed': collapsed}">
-    <button class="ol-has-tooltip blocate hs-locateToggler" title="Locate me" *ngIf="!HsGeolocationService.localization"
+    <button class="ol-has-tooltip blocate hs-locateToggler" [title]="'GEOLOCATION.locateMe' | translate" *ngIf="!HsGeolocationService.localization"
         type="button" (click)="HsGeolocationService.startLocalization()">
         <i class="glyphicon icon-gpsoff-gps hs-locateToggler"></i>
     </button>
     <button *ngIf="HsGeolocationService.localization" class="ol-has-tooltip blocate hs-locateToggler hs-locationButton"
-        type="button" (click)="HsGeolocationService.toggleTracking()" title="Locate me"
+        type="button" (click)="HsGeolocationService.toggleTracking()" [title]="'GEOLOCATION.locateMe' | translate"
         (dblclick)="HsGeolocationService.stopLocalization()">
         <i class="glyphicon hs-locateToggler"
             [ngClass]="(HsGeolocationService.following && HsGeolocationService.localization) ? 'icon-navigation' : 'icon-gpson'"></i>

--- a/components/geolocation/partials/geolocation_cordova.html
+++ b/components/geolocation/partials/geolocation_cordova.html
@@ -1,12 +1,12 @@
 <div class="locate-mobile ol-unselectable ol-control" (click)="blocateClick()" [ngClass]="{'ol-collapsed': collapsed}">
     <ul>
-        <li>Precision<span class="value">{{ accuracy }} m</span></li>
-        <li>Speed<span class="value">{{ speed }} km/h</span></li>
-        <li>Altitude <span class="value">{{ alt }} m</span></li>
+        <li>{{'GEOLOCATION.precision' | translate}}<span class="value">{{ accuracy }} m</span></li>
+        <li>{{'GEOLOCATION.speed' | translate}}<span class="value">{{ speed }} km/h</span></li>
+        <li>{{'GEOLOCATION.altitude' | translate}} <span class="value">{{ alt }} m</span></li>
         <!-- <li>Altitude: <span class='value'>{{ alt }} m (&#177;{{ altitudeAccuracy }} m)</span></li> -->
         <li><button type="button" [ngClass]="'btn btn-secondary but-xs' + (following() ? ' active' : '')"
                 (click)="following(!following())"
-                style="font: inherit;background-color: e6e6e6 !important;">Follow</button>
+                style="font: inherit;background-color: e6e6e6 !important;">{{'GEOLOCATION.follow' | translate}}</button>
             <button id="geolocation-switch(){}" type="button"
                 [ngClass]="'btn btn-secondary but-xs' + (Geolocation.gpsStatus ? ' active' : '')" (click)="switchGps()"
                 style="font: inherit;background-color: e6e6e6 !important;">{{ Geolocation.gpsSwitch }}</button></li>

--- a/components/geolocation/partials/geolocation_cordova.html
+++ b/components/geolocation/partials/geolocation_cordova.html
@@ -1,10 +1,9 @@
 <div class="locate-mobile ol-unselectable ol-control" (click)="blocateClick()" [ngClass]="{'ol-collapsed': collapsed}">
-
     <ul>
-        <li i18n>Precision<span class="value">{{ accuracy }} m</span></li>
-        <li i18n>Speed<span class="value">{{ speed }} km/h</span></li>
-        <li i18n>Altitude <span class="value">{{ alt }} m</span></li>
-        <!-- <li><translate>Altitude</translate>: <span class='value'>{{ alt }} m (&#177;{{ altitudeAccuracy }} m)</span></li> -->
+        <li>Precision<span class="value">{{ accuracy }} m</span></li>
+        <li>Speed<span class="value">{{ speed }} km/h</span></li>
+        <li>Altitude <span class="value">{{ alt }} m</span></li>
+        <!-- <li>Altitude: <span class='value'>{{ alt }} m (&#177;{{ altitudeAccuracy }} m)</span></li> -->
         <li><button type="button" [ngClass]="'btn btn-secondary but-xs' + (following() ? ' active' : '')"
                 (click)="following(!following())"
                 style="font: inherit;background-color: e6e6e6 !important;">Follow</button>

--- a/components/language/language.service.ts
+++ b/components/language/language.service.ts
@@ -44,8 +44,7 @@ export class HsLanguageService {
    * @memberof HsLanguageService
    * @public
    * @returns {Object} Returns available languages
-   * @description Get array of available languages based on translations.js
-   * or translations_extended.js files which have gettextCatalog services in them
+   * @description Get array of available languages based
    */
   listAvailableLanguages(): any {
     const language_code_name_map = {

--- a/components/map/map.module.ts
+++ b/components/map/map.module.ts
@@ -1,3 +1,4 @@
+import '../language';
 import '../permalink/share.module';
 import * as angular from 'angular';
 import mapController from './map.controller';
@@ -11,7 +12,7 @@ import {HsMapService} from './map.service';
  * @description Module containing service and controller for main map object (ol.Map).
  */
 angular
-  .module('hs.map', ['hs'])
+  .module('hs.map', ['hs.language'])
 
   /**
    * @module hs.map

--- a/components/map/map.service.js
+++ b/components/map/map.service.js
@@ -45,8 +45,8 @@ import {transform, transformExtent} from 'ol/proj';
  * @param $rootScope
  * @param HsUtilsService
  * @param HsLayoutService
+ * @param HsLanguageService
  * @param $timeout
- * @param gettext
  * @param $log
  */
 export class HsMapService {
@@ -55,8 +55,8 @@ export class HsMapService {
     $rootScope,
     HsUtilsService,
     HsLayoutService,
+    HsLanguageService,
     $timeout,
-    gettext,
     $log,
     HsEventBusService
   ) {
@@ -66,8 +66,8 @@ export class HsMapService {
       $rootScope,
       HsUtilsService,
       HsLayoutService,
+      HsLanguageService,
       $timeout,
-      gettext,
       $log,
       HsEventBusService,
     });
@@ -165,7 +165,7 @@ export class HsMapService {
       'ng-if',
       "layoutService.componentEnabled('defaultViewButton')"
     );
-    element.title = gettext('Zoom to initial window');
+    element.title = HsLanguageService.getTranslation('MAP.zoomToInitialWindow');
 
     button.appendChild(icon);
     element.appendChild(button);

--- a/components/map/map.spec.ts
+++ b/components/map/map.spec.ts
@@ -26,26 +26,17 @@ describe('hs.map', function () {
       .service('HsLayerUtilsService', function () {});
 
     angular.module('hs.layout', []).service('HsLayoutService', function () {});
-
-    angular.module('gettext').filter('translate', (gettextCatalog) => {
-      /**
-       * @param input
-       * @param context
-       */
-      function filter(input, context) {
-        return gettextCatalog.getString(input, null, context);
-      }
-      filter.$stateful = true;
-      return filter;
+    angular.module('hs.language', []).service('HsLanguageService', function () {
+      this.getTranslation = function () {};
     });
-    /* Mocks end ===== */
+
     angular
       .module('hs.map', [
         'hs',
         'ng',
         'hs.utils',
         'hs.layout',
-        'gettext',
+        'hs.language',
         'hs.core',
       ])
       .service('HsMapService', HsMapService);

--- a/components/query/feature-popup.component.js
+++ b/components/query/feature-popup.component.js
@@ -7,7 +7,7 @@ export default {
     HsMapService,
     HsQueryVectorService,
     $element,
-    gettext,
+    HsLanguageService,
     $injector,
     HsEventBusService
   ) {
@@ -51,8 +51,8 @@ export default {
       async removeFeature(feature) {
         const dialog = $injector.get('HsConfirmDialog');
         const confirmed = await dialog.show(
-          gettext('Really delete this feature?'),
-          gettext('Confirm delete')
+          HsLanguageService.getTraslation('QUERY.reallyDelete'),
+          HsLanguageService.getTraslation('QUERY.confirmDelete')
         );
         if (confirmed == 'yes') {
           HsQueryVectorService.removeFeature(feature);
@@ -63,11 +63,10 @@ export default {
       async clearLayer(layer) {
         const dialog = $injector.get('HsConfirmDialog');
         const confirmed = await dialog.show(
-          gettext('Really delete all features from layer "{0}"?').replace(
-            '{0}',
-            layer.get('title')
-          ),
-          gettext('Confirm delete')
+          HsLanguageService.getTraslation(
+            'QUERY.reallyDeleteAllFeaturesFrom' + '{0} ?'
+          ).replace('{0}', layer.get('title')),
+          HsLanguageService.getTraslation('QUERY.confirmDelete')
         );
         if (confirmed == 'yes') {
           if (layer.getSource().getSource) {

--- a/components/query/query-base.service.js
+++ b/components/query/query-base.service.js
@@ -13,9 +13,9 @@ import {transform} from 'ol/proj';
  * @param $sce
  * @param HsConfig
  * @param HsLayoutService
+ * @param HsLanguageService
  * @param HsUtilsService
  * @param $timeout
- * @param gettext
  */
 export const HsQueryBaseService = function (
   $rootScope,
@@ -24,9 +24,9 @@ export const HsQueryBaseService = function (
   $sce,
   HsConfig,
   HsLayoutService,
+  HsLanguageService,
   HsUtilsService,
-  $timeout,
-  gettext
+  $timeout
 ) {
   'ngInject';
   const me = this;
@@ -87,7 +87,7 @@ export const HsQueryBaseService = function (
       me.currentQuery = (Math.random() + 1).toString(36).substring(7);
       me.setData(getCoordinate(evt.coordinate), 'coordinates', true);
       me.last_coordinate_clicked = evt.coordinate; //It is used in some examples and apps
-      me.data.selectedProj = me.data.coordinates[0].projections[0]
+      me.data.selectedProj = me.data.coordinates[0].projections[0];
       $rootScope.$broadcast('mapQueryStarted', evt);
     });
 
@@ -315,7 +315,7 @@ export const HsQueryBaseService = function (
       'EPSG:4326'
     );
     const coords = {
-      name: gettext('Coordinates'),
+      name: HsLanguageService.getTranslation('QUERY.coordinates'),
       mapProjCoordinate: coordinate,
       epsg4326Coordinate,
       projections: [
@@ -363,7 +363,7 @@ export const HsQueryBaseService = function (
     'composition_browser',
     'analysis',
     'sensors',
-    'draw'
+    'draw',
   ];
 
   this.currentPanelQueryable = function () {
@@ -411,4 +411,4 @@ export const HsQueryBaseService = function (
     }
   );
   return me;
-}
+};

--- a/components/query/query.module.ts
+++ b/components/query/query.module.ts
@@ -7,12 +7,12 @@ import attributeRowComponent from './attribute-row.component';
 import defaultInfoPanelBody from './default-info-panel-body.directive';
 import featureComponent from './feature.component';
 import featurePopupComponent from './feature-popup.component';
-import {HsQueryBaseService} from './query-base.service';
 import queryController from './query.controller';
 import queryInfoPanelDirective from './query-info-panel.directive';
 import queryInfoPanelMdDirective from './query-info-panel-md.directive';
-import {HsQueryVectorService} from './query-vector.service';
 import queryWmsService from './query-wms.service';
+import {HsQueryBaseService} from './query-base.service';
+import {HsQueryVectorService} from './query-vector.service';
 //import '../../common/confirm';
 import '../layout';
 
@@ -98,7 +98,7 @@ export const HsQueryModule = angular
 
   .component('hs.query.featurePopup', featurePopupComponent)
 
-  .config(function ($compileProvider) {
+  .config(($compileProvider) => {
     'ngInject';
     $compileProvider.aHrefSanitizationWhitelist(
       /^\s*(https?|ftp|mailto|file|blob):/


### PR DESCRIPTION
For now, I can only remove gettext from individual modules not the whole project, because it would cause multiple merge conflicts with modules that are being refactored right now. Will continue to remove all translate tags when new commits arrive.
Also will update Wiki about new why to add translations, when angular-gettext is fully removed.