### PR TITLE
Don't filter endpoints by datasourcePaging.loaded

### DIFF
--- a/components/datasource-selector/datasource-selector.service.js
+++ b/components/datasource-selector/datasource-selector.service.js
@@ -223,10 +223,9 @@ export default function (
    */
   function dataSourceExistsAndEmpty() {
     return (
-      forDatasourceBrowserFilter(
-        HsCommonEndpointsService.endpoints
-      ).filter((ep) => angular.isUndefined(ep.datasourcePaging.loaded)).length >
-      0
+      forDatasourceBrowserFilter(HsCommonEndpointsService.endpoints).filter(
+        (ep) => !ep.datasourcePaging.loaded
+      ).length > 0
     );
   }
 


### PR DESCRIPTION
datasourcePaging.loaded is always defined -> filter by its value instead

Well, that was a huge code change 😄 

Disclaimer: I do not fully understand the behaviour behind it and why this filter was set the way it was. Hence, this change may introduce some other bugs elsewhere...

fixes #1089