### PR TITLE
Error for whiteboard composition with layer style loading 

### DIFF
--- a/components/add-layers/vector/add-layers-vector.module.ts
+++ b/components/add-layers/vector/add-layers-vector.module.ts
@@ -15,7 +15,7 @@ angular
     'hs.utils',
     'hs.language',
     'hs.layout',
-    'hs.map',
+    'hs.map'
   ])
   /**
    * @memberof hs.ows

--- a/components/add-layers/vector/add-layers-vector.service.js
+++ b/components/add-layers/vector/add-layers-vector.service.js
@@ -7,10 +7,11 @@ import VectorLayerDescriptor from './VectorLayerDescriptor';
  * @param HsUtilsService
  */
 export class HsAddLayersVectorService {
-  constructor(HsMapService, HsUtilsService) {
+  constructor(HsMapService, HsUtilsService, HsStylerService) {
     'ngInject';
     this.HsMapService = HsMapService;
     this.HsUtilsService = HsUtilsService;
+    this.HsStylerService = HsStylerService;
   }
 
   /**
@@ -93,6 +94,11 @@ export class HsAddLayersVectorService {
 
     const src = new descriptor.sourceClass(descriptor);
     descriptor.layerParams.source = src;
+    if (descriptor.layerParams.style) {
+      descriptor.layerParams.style = this.HsStylerService.parseStyle(
+        descriptor.layerParams.style
+      );
+    }
     const lyr = new VectorLayer(descriptor.layerParams);
     return lyr;
   }

--- a/components/add-layers/vector/add-layers-vector.spec.ts
+++ b/components/add-layers/vector/add-layers-vector.spec.ts
@@ -8,9 +8,7 @@ import Map from 'ol/Map';
 import * as angular from 'angular';
 import {HsLayerUtilsService} from '../../utils/layer-utils.service';
 import {HsLayoutService} from '../../layout/layout.service';
-import {HsMapService} from '../../map/map.service';
-import {HsUtilsService} from '../../utils/utils.service';
-import { HsStylerService } from '../../styles/styler.service';
+import {HsStylerService} from '../../styles/styler.service';
 describe('add-layers-vector', () => {
   let el, scope, vm;
 
@@ -26,18 +24,18 @@ describe('add-layers-vector', () => {
       })
       .factory('HsLayerUtilsService', HsLayerUtilsService);
 
-      angular.module('hs.map', []).service('HsMapService', function () {
-        this.map = new Map({
-          target: 'div',
-        });
-        this.addLayer = function(lyr){
-          this.map.addLayer(lyr);
-        }
+    angular.module('hs.map', []).service('HsMapService', function () {
+      this.map = new Map({
+        target: 'div',
       });
+      this.addLayer = function (lyr) {
+        this.map.addLayer(lyr);
+      };
+    });
 
-      angular.module('hs.styles', []).service('HsStylerService', function () {
-        this.parseStyle = (new HsStylerService(null)).parseStyle;
-      });
+    angular.module('hs.styles', []).service('HsStylerService', function () {
+      this.parseStyle = new HsStylerService(null).parseStyle;
+    });
 
     angular
       .module('hs.layout', ['hs.core'])

--- a/components/add-layers/vector/add-layers-vector.spec.ts
+++ b/components/add-layers/vector/add-layers-vector.spec.ts
@@ -10,6 +10,7 @@ import {HsLayerUtilsService} from '../../utils/layer-utils.service';
 import {HsLayoutService} from '../../layout/layout.service';
 import {HsMapService} from '../../map/map.service';
 import {HsUtilsService} from '../../utils/utils.service';
+import { HsStylerService } from '../../styles/styler.service';
 describe('add-layers-vector', () => {
   let el, scope, vm;
 
@@ -32,6 +33,10 @@ describe('add-layers-vector', () => {
         this.addLayer = function(lyr){
           this.map.addLayer(lyr);
         }
+      });
+
+      angular.module('hs.styles', []).service('HsStylerService', function () {
+        this.parseStyle = (new HsStylerService(null)).parseStyle;
       });
 
     angular

--- a/components/compositions/compositions.component.js
+++ b/components/compositions/compositions.component.js
@@ -34,6 +34,8 @@ export default {
     $scope.config = HsConfig;
     $scope.mickaEndpointService = HsCompositionsMickaService;
     $scope.endpointsService = HsCommonEndpointsService;
+    $scope.HsCompositionsParserService = HsCompositionsParserService;
+
     HsCommonEndpointsService.endpoints.forEach((ep) => (ep.next = ep.limit));
     /**
      * @ngdoc property

--- a/components/compositions/compositions.module.ts
+++ b/components/compositions/compositions.module.ts
@@ -2,6 +2,7 @@ import '../../common/endpoints/endpoints.module';
 import '../layout/layout.module';
 import '../permalink/share.module';
 import '../save-map/save-map.module';
+import '../styles';
 import '../utils';
 import './endpoints/compositions-endpoints.module';
 import './layer-parser.module';
@@ -32,6 +33,7 @@ angular
     'hs.layout',
     'hs.permalink',
     'hs.save-map',
+    'hs.styles',
     'hs',
   ])
   /**

--- a/components/compositions/compositions.spec.ts
+++ b/components/compositions/compositions.spec.ts
@@ -4,8 +4,7 @@ import './compositions.module';
 import 'angular-mocks';
 import * as angular from 'angular';
 import Map from 'ol/Map';
-import {Circle, Fill, Icon, Stroke, Style, Text} from 'ol/style';
-import { HsStylerService } from '../styles/styler.service';
+import {HsStylerService} from '../styles/styler.service';
 
 /* eslint-disable angular/no-service-method */
 /* eslint-disable angular/di */
@@ -57,7 +56,7 @@ describe('compositions', function () {
       });
 
     angular.module('hs.styles', []).service('HsStylerService', function () {
-      this.parseStyle = (new HsStylerService(null)).parseStyle;
+      this.parseStyle = new HsStylerService(null).parseStyle;
     });
 
     angular.module('hs.map', []).service('HsMapService', function () {
@@ -72,7 +71,7 @@ describe('compositions', function () {
       };
       this.addLayer = (lyr) => {
         addedLayers.push(lyr);
-      }
+      };
       this.getMapExtentInEpsg4326 = function () {};
     });
     angular.mock.module('hs.compositions');
@@ -314,7 +313,10 @@ describe('compositions', function () {
     expect(scope.query.editable).toBeUndefined();
   });
 
-  function loadComposition(scope){
+  /**
+   * @param scope
+   */
+  function loadComposition(scope) {
     addedLayers = [];
     scope.HsCompositionsParserService.loadCompositionObject(
       {
@@ -392,7 +394,7 @@ describe('compositions', function () {
   it('if should load composition from json', function () {
     $componentController('hs.compositions', {$scope: scope}, {});
     loadComposition(scope);
-    expect(addedLayers.length).toBe(4); 
+    expect(addedLayers.length).toBe(4);
     expect(addedLayers[0].get('title')).toBe('Measurement sketches');
   });
 

--- a/components/compositions/compositions.spec.ts
+++ b/components/compositions/compositions.spec.ts
@@ -26,7 +26,9 @@ describe('compositions', function () {
       .module('hs.utils', [])
       .service('HsUtilsService', function () {
         this.debounce = function () {};
-        this.proxify = function(url){return url}
+        this.proxify = function (url) {
+          return url;
+        };
       })
       .service('HsLayerUtilsService', function () {});
 
@@ -300,5 +302,80 @@ describe('compositions', function () {
     scope.query = {editable: false};
     scope.mineFilterChanged();
     expect(scope.query.editable).toBeUndefined();
+  });
+
+  it('if should load composition style', function () {
+    $componentController('hs.compositions', {$scope: scope}, {});
+    scope.HsCompositionsParserService.loadCompositionObject(
+      {
+        endpoint: {type: 'layman'},
+        'abstract': '',
+        'title': 'Housing availability',
+        'user': {'email': 'none@none'},
+        'groups': {'guest': 'r'},
+        'scale': 1,
+        'projection': 'epsg:3857',
+        'center': [2831309.671235698, 7822190.932631157],
+        'units': 'm',
+        'layers': [
+          {
+            'metadata': {},
+            'visibility': true,
+            'opacity': 1,
+            'title': 'Measurement sketches',
+            'className': 'Vector',
+            'features': '{"type":"FeatureCollection","features":[]}',
+            'maxResolution': null,
+            'minResolution': 0,
+            'projection': 'epsg:4326',
+            'style': {
+              'fill': 'rgba(255, 255, 255, 0.2)',
+              'stroke': {'color': '#ffcc33', 'width': 2},
+            },
+          },
+          {
+            'metadata': {},
+            'visibility': true,
+            'opacity': 1,
+            'title': 'Position',
+            'className': 'Vector',
+            'features':
+              '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[14.265108804908085,50.03457546855486]},"properties":{"known":false}},{"type":"Feature","geometry":{"type":"GeometryCollection","geometries":[]},"properties":{"known":false}}]}',
+            'maxResolution': null,
+            'minResolution': 0,
+            'projection': 'epsg:4326',
+          },
+          {
+            'metadata': {},
+            'visibility': true,
+            'opacity': 1,
+            'title': 'Measurement sketches',
+            'className': 'Vector',
+            'features': '{"type":"FeatureCollection","features":[]}',
+            'maxResolution': null,
+            'minResolution': 0,
+            'projection': 'epsg:4326',
+            'style': {
+              'fill': 'rgba(255, 255, 255, 0.2)',
+              'stroke': {'color': '#ffcc33', 'width': 2},
+            },
+          },
+          {
+            'metadata': {},
+            'visibility': true,
+            'opacity': 1,
+            'title': 'Point clicked',
+            'className': 'Vector',
+            'features':
+              '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[25.486272576058198,57.21506027419332]},"properties":null}]}',
+            'maxResolution': null,
+            'minResolution': 0,
+            'projection': 'epsg:4326',
+          },
+        ],
+        'current_base_layer': {'title': 'Open street map'},
+      },
+      true
+    );
   });
 });

--- a/components/compositions/layer-parser.service.js
+++ b/components/compositions/layer-parser.service.js
@@ -3,7 +3,6 @@ import ImageLayer from 'ol/layer/Image';
 import SparqlJson from '../layers/hs.source.SparqlJson';
 import VectorLayer from 'ol/layer/Vector';
 import {Attribution} from 'ol/control';
-import {Circle, Fill, Icon, Stroke, Style} from 'ol/style';
 import {ImageArcGISRest, ImageStatic, TileArcGISRest, TileWMS} from 'ol/source';
 import {ImageWMS, XYZ} from 'ol/source';
 import {Tile} from 'ol/layer';
@@ -12,8 +11,13 @@ import {Vector as VectorSource} from 'ol/source';
 /**
  * @param HsMapService
  * @param HsAddLayersVectorService
+ * @param HsStylerService
  */
-export default function (HsMapService, HsAddLayersVectorService, HsStylerService) {
+export default function (
+  HsMapService,
+  HsAddLayersVectorService,
+  HsStylerService
+) {
   'ngInject';
   const me = {
     /**

--- a/components/compositions/layer-parser.service.js
+++ b/components/compositions/layer-parser.service.js
@@ -13,7 +13,7 @@ import {Vector as VectorSource} from 'ol/source';
  * @param HsMapService
  * @param HsAddLayersVectorService
  */
-export default function (HsMapService, HsAddLayersVectorService) {
+export default function (HsMapService, HsAddLayersVectorService, HsStylerService) {
   'ngInject';
   const me = {
     /**
@@ -283,7 +283,7 @@ export default function (HsMapService, HsAddLayersVectorService) {
 
       let style = null;
       if (angular.isDefined(lyr_def.style)) {
-        style = me.parseStyle(lyr_def.style);
+        style = HsStylerService.parseStyle(lyr_def.style);
       }
 
       const src = new SparqlJson({
@@ -305,67 +305,6 @@ export default function (HsMapService, HsAddLayersVectorService) {
     },
     /**
      * @ngdoc method
-     * @name hs.compositions.config_parsers.service#parseStyle
-     * @public
-     * @param {object} j Style definition object
-     * @returns {ol.style.Style} Valid Ol style object
-     * @description Parse style definition object to create valid Style
-     */
-    parseStyle: function (j) {
-      const style_json = {};
-      if (angular.isDefined(j.fill)) {
-        style_json.fill = new Fill({
-          color: j.fill,
-        });
-      }
-      if (angular.isDefined(j.stroke)) {
-        style_json.stroke = new Stroke({
-          color: j.stroke.color,
-          width: j.stroke.width,
-        });
-      }
-      if (angular.isDefined(j.image)) {
-        if (j.image.type == 'circle') {
-          const circle_json = {};
-
-          if (angular.isDefined(j.image.radius)) {
-            circle_json.radius = j.image.radius;
-          }
-
-          if (angular.isDefined(j.image.fill)) {
-            circle_json.fill = new Fill({
-              color: j.image.fill,
-            });
-          }
-          if (angular.isDefined(j.image.stroke)) {
-            circle_json.stroke = new Stroke({
-              color: j.image.stroke.color,
-              width: j.image.stroke.width,
-            });
-          }
-          style_json.image = new Circle(circle_json);
-        }
-        if (j.image.type == 'icon') {
-          const img = new Image();
-          img.src = j.image.src;
-          if (img.width == 0) {
-            img.width = 43;
-          }
-          if (img.height == 0) {
-            img.height = 41;
-          }
-          const icon_json = {
-            img: img,
-            imgSize: [img.width, img.height],
-            crossOrigin: 'anonymous',
-          };
-          style_json.image = new Icon(icon_json);
-        }
-      }
-      return new Style(style_json);
-    },
-    /**
-     * @ngdoc method
      * @name hs.compositions.config_parsers.service#createVectorLayer
      * @public
      * @param {object} lyr_def Layer definition object
@@ -383,7 +322,7 @@ export default function (HsMapService, HsAddLayersVectorService) {
 
       let extractStyles = true;
       if (angular.isDefined(lyr_def.style)) {
-        options.style = me.parseStyle(lyr_def.style);
+        options.style = HsStylerService.parseStyle(lyr_def.style);
         extractStyles = false;
       }
       let layer;

--- a/components/styles/styler.service.ts
+++ b/components/styles/styler.service.ts
@@ -211,4 +211,65 @@ export class HsStylerService {
       return newStyle;
     }
   }
+
+  /**
+   * @ngdoc method
+   * @public
+   * @param {object} j Style definition object
+   * @returns {ol.style.Style} Valid Ol style object
+   * @description Parse style definition object to create valid Style
+   */
+  parseStyle(j) {
+    const style_json: any = {};
+    if (j.fill) {
+      style_json.fill = new Fill({
+        color: j.fill,
+      });
+    }
+    if (j.stroke) {
+      style_json.stroke = new Stroke({
+        color: j.stroke.color,
+        width: j.stroke.width,
+      });
+    }
+    if (j.image) {
+      if (j.image.type == 'circle') {
+        const circle_json: any = {};
+
+        if (j.image.radius) {
+          circle_json.radius = j.image.radius;
+        }
+
+        if (j.image.fill) {
+          circle_json.fill = new Fill({
+            color: j.image.fill,
+          });
+        }
+        if (j.image.stroke) {
+          circle_json.stroke = new Stroke({
+            color: j.image.stroke.color,
+            width: j.image.stroke.width,
+          });
+        }
+        style_json.image = new Circle(circle_json);
+      }
+      if (j.image.type == 'icon') {
+        const img = new Image();
+        img.src = j.image.src;
+        if (img.width == 0) {
+          img.width = 43;
+        }
+        if (img.height == 0) {
+          img.height = 41;
+        }
+        const icon_json = {
+          img: img,
+          imgSize: [img.width, img.height],
+          crossOrigin: 'anonymous',
+        };
+        style_json.image = new Icon(icon_json);
+      }
+    }
+    return new Style(style_json);
+  }
 }


### PR DESCRIPTION
The problem with map integration was that we have in composition
```
'layers': [
          {
            'metadata': {},
            'visibility': true,
            'opacity': 1,
            'title': 'Measurement sketches',
            'className': 'Vector',
            'features': '{"type":"FeatureCollection","features":[]}',
            'maxResolution': null,
            'minResolution': 0,
            'projection': 'epsg:4326',
            'style': {
              'fill': 'rgba(255, 255, 255, 0.2)',
              'stroke': {'color': '#ffcc33', 'width': 2},
            },
          },
```
and the style property is being passed to OL layer constructor as is instead of being parsed and converted to openlayers Style object resulting in 
```
ERROR Error: Uncaught (in promise): AssertionError: Assertion failed. See https://openlayers.org/en/v6.4.3/doc/errors/#41 for details.
AssertionError: Assertion failed. See https://openlayers.org/en/v6.4.3/doc/errors/#41 for details.
```
and stop composition loading in its tracks.
This PR aims to fix that.