### PR TITLE
Fix layman sync problems

### DIFF
--- a/components/layermanager/layer-editor-vector-layer.service.ts
+++ b/components/layermanager/layer-editor-vector-layer.service.ts
@@ -99,7 +99,7 @@ export class HsLayerEditorVectorLayerService {
     });
   }
   updateFeatureTableLayers(layer: Layer): void {
-    const currentLayerIndex = this.HsConfig.layersInFeatureTable.findIndex(
+    const currentLayerIndex = this.HsConfig.layersInFeatureTable?.findIndex(
       (l) => l == layer
     );
     if (layer && currentLayerIndex > -1) {

--- a/components/save-map/layer-synchronizer.service.ts
+++ b/components/save-map/layer-synchronizer.service.ts
@@ -64,13 +64,13 @@ export class HsLayerSynchronizerService {
    * @param {object} layer Layer to add
    */
   addLayer(layer: Layer): void {
-    if (this.isLayerSinhronizable(layer)) {
+    if (this.isLayerSynchronizable(layer)) {
       this.syncedLayers.push(layer);
       this.startMonitoringIfNeeded(layer);
     }
   }
 
-  isLayerSinhronizable(layer: Layer): boolean {
+  isLayerSynchronizable(layer: Layer): boolean {
     return (
       this.HsUtilsService.instOf(layer.getSource(), VectorSource) &&
       layer.get('synchronize') === true


### PR DESCRIPTION
Multiple problems are fixed here:
* Layer description (wfs, wms endpoint urls) were first retrieved for anonymous (browser) user, cached and on subsequent requests wrongly used even after user authorizes resulting in:
"https://groundwater.smartagro.lv/layman/client/geoserver/browser/wfs"
where it should have been 
"https://groundwater.smartagro.lv/layman/client/geoserver/test/wfs"
* Too many current-user requests to layman get issued for each synchronized layer
* 'events-suspended' attribute could be set in uick succession multiple in async function, hich could result in addfeature/changefeature events executed when they are actually pulled from layman, not drawn by user.