### PR TITLE
Fixes 1.25

### DIFF
--- a/common/arcgis/get-capabilities.service.js
+++ b/common/arcgis/get-capabilities.service.js
@@ -77,7 +77,7 @@ export default function (
    * @returns {Promise} Promise object - Response to GetCapabalities request
    */
   this.requestGetCapabilities = function (service_url) {
-    service_url = service_url.replace('&amp;', '&');
+    service_url = service_url.replace(/&amp;/g, '&');
     const params = HsUtilsService.getParamsFromUrl(service_url);
     const path = this.getPathFromUrl(service_url);
     params.f = 'json';

--- a/common/layman/layman-current-user.component.js
+++ b/common/layman/layman-current-user.component.js
@@ -23,11 +23,8 @@ export default {
         return vm.endpoint.user == 'anonymous' || vm.endpoint.user == 'browser';
       },
       logout() {
-        const url = `${vm.endpoint.url}/authn/logout`;
         vm.monitorUser();
-        $http.get(url).then((res) => {
-          vm.endpoint.user = 'anonymous';
-        });
+        HsCommonLaymanService.logout(vm.endpoint);
       },
       protocolsMatch() {
         return $location.protocol() == vm.endpoint.liferayProtocol;

--- a/common/layman/layman-login.component.js
+++ b/common/layman/layman-login.component.js
@@ -6,7 +6,7 @@ export default {
   controller: function ($scope) {
     'ngInject';
     this.modalVisible = true;
-    $scope.$on('datasource-selector.layman_auth', () => {
+    $scope.$on('authChange', () => {
       this.modalVisible = false;
     });
   },

--- a/common/layman/layman.service.js
+++ b/common/layman/layman.service.js
@@ -16,10 +16,7 @@ export default function ($http, $rootScope) {
               if (endpoint.user != res.data.username) {
                 endpoint.user = res.data.username;
                 somethingChanged = true;
-                $rootScope.$broadcast(
-                  'datasource-selector.layman_auth',
-                  endpoint
-                );
+                $rootScope.$broadcast('authChange', endpoint);
               }
             } else {
               if (endpoint.user != endpoint.originalConfiguredUser) {
@@ -42,6 +39,18 @@ export default function ($http, $rootScope) {
         ['anonymous', 'browser'].indexOf(endpoint.user) > -1
       ) {
         await me.getCurrentUser(endpoint);
+      }
+    },
+
+    async logout(endpoint) {
+      const url = `${endpoint.url}/authn/logout`;
+      try {
+        $http.get(url).then((response) => {
+          endpoint.user = 'anonymous';
+          $rootScope.$broadcast('authChange', endpoint);
+        });
+      } catch (ex) {
+        console.warn(ex);
       }
     },
   });

--- a/common/wfs/get-capabilities.service.js
+++ b/common/wfs/get-capabilities.service.js
@@ -64,7 +64,7 @@ export default function ($http, HsMapService, HsUtilsService, $rootScope) {
    * @returns {Promise} Promise object -  Response to GetCapabalities request
    */
   this.requestGetCapabilities = function (service_url) {
-    service_url = service_url.replace('&amp;', '&');
+    service_url = service_url.replace(/&amp;/g, '&');
     me.service_url = service_url;
     const params = HsUtilsService.getParamsFromUrl(service_url);
     const path = this.getPathFromUrl(service_url);

--- a/common/wms/get-capabilities.service.js
+++ b/common/wms/get-capabilities.service.js
@@ -71,7 +71,7 @@ export default function ($http, HsMapService, HsUtilsService, $rootScope) {
    * @returns {Promise} Promise object - Response to GetCapabalities request
    */
   this.requestGetCapabilities = function (service_url) {
-    service_url = service_url.replace('&amp;', '&');
+    service_url = service_url.replace(/&amp;/g, '&');
     const params = HsUtilsService.getParamsFromUrl(service_url);
     const path = this.getPathFromUrl(service_url);
     if (

--- a/common/wmts/get-capabilities.service.js
+++ b/common/wmts/get-capabilities.service.js
@@ -71,7 +71,7 @@ export default function ($http, HsMapService, HsUtilsService, $rootScope) {
    * @returns {Promise} Promise object -  Response to GetCapabalities request
    */
   this.requestGetCapabilities = function (service_url) {
-    service_url = service_url.replace('&amp;', '&');
+    service_url = service_url.replace(/&amp;/g, '&');
     const params = HsUtilsService.getParamsFromUrl(service_url);
     const path = this.getPathFromUrl(service_url);
     if (

--- a/components/add-layers/vector/VectorLayerDescriptor.js
+++ b/components/add-layers/vector/VectorLayerDescriptor.js
@@ -68,7 +68,8 @@ export default class {
         break;
       case 'wfs':
         Object.assign(this.layerParams, {
-          synchronize: options.dsType == 'layman' ? true : false,
+          synchronize:
+            options.dsType == 'layman' ? true : options.synchronize || false,
           editor: {
             editable: true,
             defaultAttributes: {

--- a/components/add-layers/vector/VectorLayerDescriptor.js
+++ b/components/add-layers/vector/VectorLayerDescriptor.js
@@ -68,8 +68,6 @@ export default class {
         break;
       case 'wfs':
         Object.assign(this.layerParams, {
-          synchronize:
-            options.dsType == 'layman' ? true : options.synchronize || false,
           editor: {
             editable: true,
             defaultAttributes: {

--- a/components/add-layers/vector/add-layers-vector.service.js
+++ b/components/add-layers/vector/add-layers-vector.service.js
@@ -34,6 +34,10 @@ export default function (HsMapService, HsUtilsService) {
           srs,
           options
         );
+        lyr.set('definition', {
+          format: 'hs.format.WFS',
+          url: url.replace('ows', 'wfs'),
+        });
         if (HsMapService.map) {
           HsMapService.addLayer(lyr, true);
         }

--- a/components/add-layers/wfs/add-layers-wfs.component.js
+++ b/components/add-layers/wfs/add-layers-wfs.component.js
@@ -192,7 +192,6 @@ export default {
         source: HsAddLayersWfsService.createWfsSource(options),
         path: $scope.path,
         renderOrder: null,
-        synchronize: false,
       });
       HsMapService.map.addLayer(new_layer);
       HsLayoutService.setMainPanel('layermanager');

--- a/components/compositions/compositions-parser.service.js
+++ b/components/compositions/compositions-parser.service.js
@@ -85,7 +85,7 @@ export default function (
     loadUrl: function (url, overwrite, callback, pre_parse) {
       return new Promise((resolve, reject) => {
         me.current_composition_url = url;
-        url = url.replace('&amp;', '&');
+        url = url.replace(/&amp;/g, '&');
         url = HsUtilsService.proxify(url);
 
         if (url.includes('.wmc')) {

--- a/components/compositions/endpoints/compositions-layman.service.js
+++ b/components/compositions/endpoints/compositions-layman.service.js
@@ -46,6 +46,7 @@ export default function (
           }
           angular.forEach(endpoint.compositions, (record) => {
             record.editable = true;
+            record.url = `${endpoint.url}/rest/${endpoint.user}/maps/${record.name}`;
             record.endpoint = endpoint;
           });
           $rootScope.$broadcast('CompositionsLoaded');

--- a/components/compositions/layer-parser.service.js
+++ b/components/compositions/layer-parser.service.js
@@ -377,6 +377,9 @@ export default function (HsMapService, HsAddLayersVectorService) {
       let format = '';
       if (angular.isDefined(lyr_def.protocol)) {
         format = lyr_def.protocol.format;
+        if (lyr_def.protocol.url !== undefined) {
+          lyr_def.protocol.url = decodeURIComponent(lyr_def.protocol.url);
+        }
       }
       const options = {};
       options.opacity = lyr_def.opacity || 1;
@@ -392,7 +395,7 @@ export default function (HsMapService, HsAddLayersVectorService) {
         case 'ol.format.KML':
           layer = HsAddLayersVectorService.createVectorLayer(
             'kml',
-            decodeURIComponent(lyr_def.protocol.url),
+            lyr_def.protocol.url,
             lyr_def.title || 'Layer',
             lyr_def.abstract,
             lyr_def.projection.toUpperCase(),
@@ -402,38 +405,23 @@ export default function (HsMapService, HsAddLayersVectorService) {
         case 'ol.format.GeoJSON':
           layer = HsAddLayersVectorService.createVectorLayer(
             'geojson',
-            decodeURIComponent(lyr_def.protocol.url),
+            lyr_def.protocol.url,
             lyr_def.title || 'Layer',
             lyr_def.abstract,
             lyr_def.projection.toUpperCase(),
             options
           );
-          break;
+          break;  
         case 'hs.format.WFS':
           options.defOptions = lyr_def.defOptions;
-          options.synchronize = lyr_def.synchronize;
           layer = HsAddLayersVectorService.createVectorLayer(
             'wfs',
-            decodeURIComponent(lyr_def.protocol.url),
+            lyr_def.protocol.url,
             lyr_def.title || 'Layer',
             lyr_def.abstract,
             lyr_def.projection.toUpperCase(),
             options
           );
-          break;
-        case 'hs.format.LaymanWfs':
-          layer = new VectorLayer({
-            title: lyr_def.title,
-            name: lyr_def.title,
-            visibility: lyr_def.visibility,
-            synchronize: true,
-            editor: {
-              editable: true,
-              defaultAttributes: {},
-            },
-            saveState: true,
-            source: new VectorSource({}),
-          });
           break;
         case 'hs.format.Sparql':
           layer = me.createSparqlLayer(lyr_def);
@@ -450,6 +438,7 @@ export default function (HsMapService, HsAddLayersVectorService) {
             );
           }
       }
+      layer.set('definition', lyr_def.protocol);
       return layer;
     },
   };

--- a/components/compositions/layer-parser.service.js
+++ b/components/compositions/layer-parser.service.js
@@ -411,6 +411,7 @@ export default function (HsMapService, HsAddLayersVectorService) {
           break;
         case 'hs.format.WFS':
           options.defOptions = lyr_def.defOptions;
+          options.synchronize = lyr_def.synchronize;
           layer = HsAddLayersVectorService.createVectorLayer(
             'wfs',
             decodeURIComponent(lyr_def.protocol.url),

--- a/components/draw/draw-layer-metadata.component.js
+++ b/components/draw/draw-layer-metadata.component.js
@@ -74,7 +74,6 @@ export default {
         HsDrawService.addDrawLayer(vm.layer);
         HsDrawService.fillDrawableLayers();
 
-        vm.layer.set('synchronize', true);
         vm.awaitLayerSync(vm.layer).then(() => {
           vm.layer.getSource().dispatchEvent('addfeature');
         });

--- a/components/draw/draw-layer-metadata.component.js
+++ b/components/draw/draw-layer-metadata.component.js
@@ -14,7 +14,7 @@ export default {
     'ngInject';
     this.modalVisible = true;
     const vm = this;
-    $scope.$on('datasource-selector.layman_auth', (endpoint) => {
+    $scope.$on('authChange', (endpoint) => {
       vm.endpoint = endpoint;
     });
     $timeout(() => {

--- a/components/draw/draw.controller.js
+++ b/components/draw/draw.controller.js
@@ -54,7 +54,6 @@ export default function (
             visible: true,
             removable: true,
             editable: true,
-            synchronize: false,
             path: HsConfig.defaultDrawLayerPath || gettext('User generated'),
           });
           HsDrawService.tmpDrawLayer = true;

--- a/components/draw/draw.service.js
+++ b/components/draw/draw.service.js
@@ -34,7 +34,7 @@ export default function (
   $timeout,
   HsQueryVectorService,
   HsLaymanService,
-  HsConfirmDialogService,
+  HsConfirmDialogService
 ) {
   'ngInject';
   const me = this;
@@ -108,7 +108,6 @@ export default function (
         visible: true,
         removable: true,
         editable: true,
-        synchronize: HsLaymanService.laymanEndpointExists() ? true : false,
         path: HsConfig.defaultDrawLayerPath || gettext('User generated'),
       });
       me.selectedLayer = drawLayer;
@@ -341,7 +340,7 @@ export default function (
       );
       if (confirmed == 'yes') {
         HsMapService.map.removeLayer(me.selectedLayer);
-        if (me.selectedLayer.get('synchronize') == true) {
+        if (HsLaymanService.isLayerSynchronizable(me.selectedLayer)) {
           HsLaymanService.removeLayer(this.selectedLayer);
         }
         if (me.selectedLayer.get('title') == 'tmpDrawLayer') {

--- a/components/draw/draw.service.js
+++ b/components/draw/draw.service.js
@@ -34,7 +34,7 @@ export default function (
   $timeout,
   HsQueryVectorService,
   HsLaymanService,
-  HsConfirmDialogService
+  HsConfirmDialogService,
 ) {
   'ngInject';
   const me = this;
@@ -109,6 +109,10 @@ export default function (
         removable: true,
         editable: true,
         path: HsConfig.defaultDrawLayerPath || gettext('User generated'),
+        definition: {
+          format: 'hs.format.WFS',
+          url: HsLaymanService.getLaymanEndpoint() + '/wfs',
+        },
       });
       me.selectedLayer = drawLayer;
       const el = angular.element(

--- a/components/hscesium/cesium-layers.service.js
+++ b/components/hscesium/cesium-layers.service.js
@@ -78,7 +78,7 @@ export class HsCesiumLayersService {
           }
         }
       }
-      resource = resource.replaceAll('fromcrs', 'FROMCRS');
+      resource = resource.replace(/fromcrs/gm, 'FROMCRS');
       if (resource.indexOf('proxy4ows') > -1) {
         return resource;
       }

--- a/components/hscesium/cesium.service.js
+++ b/components/hscesium/cesium.service.js
@@ -209,7 +209,7 @@ export default function (
                 : iframe.contentWindow.document;
               innerDoc.querySelector(
                 '.cesium-infoBox-description'
-              ).innerHTML = s.replaceAll('\n', '<br/>');
+              ).innerHTML = s.replace(/\n/gm, '<br/>');
               iframe.style.height = 200 + 'px';
             }, 1000);
           }

--- a/components/layermanager/layermanager-layerlist.directive.js
+++ b/components/layermanager/layermanager-layerlist.directive.js
@@ -166,7 +166,7 @@ export default function (
         function sortLayersByPosition() {
           scope.filtered_layers = filterLayers();
           const minus = scope.order().indexOf('-') == 0;
-          const attribute = scope.order().replaceAll('-', '');
+          const attribute = scope.order().split('-').join('');
           scope.filtered_layers.sort((a, b) => {
             var a = a.layer.get(attribute);
             var b = b.layer.get(attribute);

--- a/components/layermanager/layermanager.service.js
+++ b/components/layermanager/layermanager.service.js
@@ -733,7 +733,6 @@ export default function (
       cur_res = HsMapService.map.getView().getResolution();
     }
     me.currentResolution = cur_res;
-    console.log(cur_res, lyr.getMaxResolution());
     return (
       lyr.getMinResolution() <= cur_res && cur_res <= lyr.getMaxResolution()
     );

--- a/components/layermanager/layermanager.service.js
+++ b/components/layermanager/layermanager.service.js
@@ -118,16 +118,13 @@ export default function (
       return;
     }
     //WMST.layerIsWmsT(layer);
+    const isVector = HsLayerUtilsService.isLayerVectorLayer(layer);
     loadingEvents(layer);
     layer.on('change:visible', layerVisibilityChanged);
-    if (
-      HsLayerUtilsService.isLayerVectorLayer(layer) &&
-      layer.get('cluster') &&
-      layer.get('declutter')
-    ) {
+    if (isVector && layer.get('cluster') && layer.get('declutter')) {
       layer.set('declutter', false);
     }
-    if (HsLayerUtilsService.isLayerVectorLayer(layer) && layer.get('cluster')) {
+    if (isVector && layer.get('cluster')) {
       HsLayerEditorVectorLayerService.cluster(true, layer, '40');
     }
     if (typeof layer.get('position') == 'undefined') {
@@ -151,7 +148,6 @@ export default function (
         return 'layer' + (this.coded_path || '') + (this.uid || '');
       },
     };
-
     layer.on('propertychange', (event) => {
       new_layer.title = HsLayerUtilsService.getLayerTitle(layer);
     });
@@ -168,7 +164,7 @@ export default function (
         HsLayermanagerMetadata.fillMetadata(layer).then(() => {
           setTimeout(() => {
             new_layer.grayed = !me.isLayerInResolutionInterval(layer);
-          },50);
+          }, 50);
         });
       }
     } else {

--- a/components/save-map/layer-synchronizer.service.js
+++ b/components/save-map/layer-synchronizer.service.js
@@ -131,7 +131,7 @@ export default function (
         );
         let featureString;
         if (response) {
-          featureString = response;
+          featureString = response.data;
         }
         layer.set('hs-layman-synchronizing', false);
         if (featureString) {
@@ -180,8 +180,8 @@ export default function (
             HsLaymanService.getLayerName(layer),
             layer
           ).then((response) => {
-            if (response.indexOf('Exception') > -1) {
-              me.displaySyncErrorDialog(response);
+            if (response.data.indexOf('Exception') > -1) {
+              me.displaySyncErrorDialog(response.data);
             }
             layer.set('hs-layman-synchronizing', false);
           });

--- a/components/save-map/layman.service.js
+++ b/components/save-map/layman.service.js
@@ -418,12 +418,8 @@ export default function (
      * @public
      * @description Checks whether the layman endpoint exists or not
      */
-    laymanEndpointExists() {
-      return (
-        HsCommonEndpointsService.endpoints.findIndex(
-          (endpoint) => endpoint.type === 'layman'
-        ) >= 0
-      );
+    getLaymanEndpoint() {
+      return HsCommonEndpointsService.endpoints.filter((e)=> e.type == 'layman').pop().url;
     },
     /**
      * @function removeLayer
@@ -443,9 +439,11 @@ export default function (
 
     isLayerSynchronizable(layer) {
       const definition = layer.get('definition');
+      if (!definition) {
+        return false;
+      }
       return (
         HsUtilsService.instOf(layer.getSource(), VectorSource) &&
-        angular.isDefined(definition) &&
         definition.format.toLowerCase().includes('wfs')
       );
     },

--- a/components/save-map/layman.service.js
+++ b/components/save-map/layman.service.js
@@ -240,7 +240,7 @@ export default function (
                 );
 
                 $http({
-                  url: layerDesc.wfs.url,
+                  url: layerDesc.wfs.url + '?request=Transaction',
                   method: 'POST',
                   data: serializedFeature.outerHTML
                     .replaceAll('<geometry>', '<wkb_geometry>')

--- a/components/save-map/layman.service.js
+++ b/components/save-map/layman.service.js
@@ -1,5 +1,7 @@
 import * as unidecode from 'unidecode';
 import {GeoJSON, WFS} from 'ol/format';
+import {Vector as VectorSource} from 'ol/source';
+
 /**
  * @param HsUtilsService
  * @param $http
@@ -437,6 +439,15 @@ export default function (
             `${ds.url}/rest/${ds.user}/layers/${me.getLayerName(layer)}`
           );
         });
+    },
+
+    isLayerSynchronizable(layer) {
+      const definition = layer.get('definition');
+      return (
+        HsUtilsService.instOf(layer.getSource(), VectorSource) &&
+        angular.isDefined(definition) &&
+        definition.format.toLowerCase().includes('wfs')
+      );
     },
   });
   return me;

--- a/components/save-map/save-map.service.js
+++ b/components/save-map/save-map.service.js
@@ -393,6 +393,7 @@ export default function (
         }
         if (layer.get('synchronize')) {
           json.protocol = {format: 'hs.format.WFS'};
+          json.synchronize = layer.get('synchronize');
           delete json.features;
         }
         if (angular.isDefined(src.defOptions)) {

--- a/components/save-map/save-map.service.js
+++ b/components/save-map/save-map.service.js
@@ -384,16 +384,13 @@ export default function (
             url: encodeURIComponent(definition.url),
             format: definition.format,
           };
+          delete json.features;
         } else {
           try {
             json.features = me.serializeFeatures(src.getFeatures());
           } catch (ex) {
             //Do nothing
           }
-        }
-        if (layer.get('synchronize')) {
-          json.protocol = {format: 'hs.format.WFS'};
-          delete json.features;
         }
         if (angular.isDefined(src.defOptions)) {
           json.defOptions = src.defOptions;
@@ -503,9 +500,6 @@ export default function (
     angular.forEach(HsMapService.map.getLayers(), (layer) => {
       if (layer.get('saveState')) {
         const lyr = me.layer2json(layer);
-        if (layer.get('synchronize')) {
-          lyr.synchronize = layer.get('synchronize');
-        }
         layers.push(lyr);
       }
     });

--- a/components/save-map/save-map.service.js
+++ b/components/save-map/save-map.service.js
@@ -393,7 +393,6 @@ export default function (
         }
         if (layer.get('synchronize')) {
           json.protocol = {format: 'hs.format.WFS'};
-          json.synchronize = layer.get('synchronize');
           delete json.features;
         }
         if (angular.isDefined(src.defOptions)) {
@@ -503,7 +502,11 @@ export default function (
     const layers = [];
     angular.forEach(HsMapService.map.getLayers(), (layer) => {
       if (layer.get('saveState')) {
-        layers.push(me.layer2json(layer));
+        const lyr = me.layer2json(layer);
+        if (layer.get('synchronize')) {
+          lyr.synchronize = layer.get('synchronize');
+        }
+        layers.push(lyr);
       }
     });
     data.layers = layers;


### PR DESCRIPTION
- backport layman sync fixes
- Update wfsTrasnsaction url according to new layman WFS proxy
- store synchronize parameter to cookies so after a reload layer is synced with layman once again automaticaly