### PR TITLE
Sync fix

### DIFF
--- a/components/save-map/layer-synchronizer.service.js
+++ b/components/save-map/layer-synchronizer.service.js
@@ -1,4 +1,5 @@
 import {WFS} from 'ol/format';
+
 const debounceInterval = 1000;
 
 /**
@@ -186,6 +187,18 @@ export default function (
         ).then((response) => {
           if (response.data.indexOf('Exception') > -1) {
             me.displaySyncErrorDialog(response.data);
+          }
+          if (inserted[0]) {
+            const id = new DOMParser()
+              .parseFromString(response.data, 'application/xml')
+              .getElementsByTagName('ogc:FeatureId')[0]
+              .getAttribute('fid');
+            inserted[0].setId(id);
+
+            const geometry = inserted[0].getGeometry();
+            inserted[0].setGeometryName('wkb_geometry');
+            inserted[0].setGeometry(geometry);
+            inserted[0].unset('geometry', true);
           }
           layer.set('hs-layman-synchronizing', false);
         });

--- a/components/save-map/layer-synchronizer.service.js
+++ b/components/save-map/layer-synchronizer.service.js
@@ -91,6 +91,9 @@ export default function (
       layerSource.forEachFeature((f) => me.observeFeature(f));
       layerSource.on('addfeature', (e) => {
         me.sync([e.feature], [], [], layer);
+        if (e.feature) {
+          me.observeFeature(e.feature);
+        }
       });
       layerSource.on('removefeature', (e) => {
         me.sync([], [], [e.feature], layer);

--- a/components/save-map/layman.service.js
+++ b/components/save-map/layman.service.js
@@ -246,8 +246,7 @@ export default function (
                   method: 'POST',
                   data: serializedFeature.outerHTML
                     .replaceAll('<geometry>', '<wkb_geometry>')
-                    .replaceAll('</geometry>', '</wkb_geometry>')
-                    .replaceAll('<Name>geometry</Name>', '<Name>wkb_geometry</Name>'),
+                    .replaceAll('</geometry>', '</wkb_geometry>'),
                   headers: {'Content-Type': 'application/xml'},
                 }).then((response) => {
                   resolve(response);

--- a/components/save-map/layman.service.js
+++ b/components/save-map/layman.service.js
@@ -246,7 +246,8 @@ export default function (
                   method: 'POST',
                   data: serializedFeature.outerHTML
                     .replaceAll('<geometry>', '<wkb_geometry>')
-                    .replaceAll('</geometry>', '</wkb_geometry>'),
+                    .replaceAll('</geometry>', '</wkb_geometry>')
+                    .replaceAll('<Name>geometry</Name>', '<Name>wkb_geometry</Name>'),
                   headers: {'Content-Type': 'application/xml'},
                 }).then((response) => {
                   resolve(response);


### PR DESCRIPTION
- add geom change event listener for features added to source after the layer is pulled from layman
- Updating the geometry is not possible without the change of  [gemoetryName](https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html#getGeometryName) and [id](https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html#getId) that needs to match the one in layman

will be also neccessary to port to 2.x 