### PR TITLE
Port 1.26changes

### DIFF
--- a/components/add-layers/drag-drop-layer.service.ts
+++ b/components/add-layers/drag-drop-layer.service.ts
@@ -68,6 +68,7 @@ export class HsDragDropLayerService {
           const layer = await this.hsAddLayersVectorService.addVectorLayer(
             'geojson',
             decodeURIComponent(data.url),
+            data.title || 'Layer', //name
             data.title || 'Layer',
             '',
             data.projection,
@@ -83,6 +84,7 @@ export class HsDragDropLayerService {
           const layer = await this.hsAddLayersVectorService.addVectorLayer(
             '',
             undefined,
+            data.title || 'Layer', //name
             data.title || 'Layer',
             '',
             data.projection,

--- a/components/add-layers/shp/add-layers-shp.component.ts
+++ b/components/add-layers/shp/add-layers-shp.component.ts
@@ -6,6 +6,7 @@ import {HsCommonEndpointsService} from '../../../common/endpoints/endpoints.serv
 import {HsEndpoint} from '../../../common/endpoints/endpoint.interface';
 import {HsLaymanService} from '../../save-map/layman.service';
 import {HsLayoutService} from '../../layout/layout.service';
+import {FileDescriptor} from './file-descriptor';
 
 @Component({
   selector: 'hs-add-layers-shp',
@@ -147,9 +148,3 @@ export class HsAddLayersShpComponent {
     console.log(this.sld);
   }
 }
-
-export type FileDescriptor = {
-  name: string;
-  type: string;
-  content: ArrayBuffer;
-};

--- a/components/add-layers/shp/add-layers-shp.service.ts
+++ b/components/add-layers/shp/add-layers-shp.service.ts
@@ -1,7 +1,7 @@
 import {HsEndpoint} from '../../../common/endpoints/endpoint.interface';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import type {FileDescriptor} from './add-layers-shp.component';
+import {FileDescriptor} from './file-descriptor';
 
 @Injectable({providedIn: 'root'})
 export class HsAddLayersShpService {

--- a/components/add-layers/shp/file-descriptor.ts
+++ b/components/add-layers/shp/file-descriptor.ts
@@ -1,0 +1,5 @@
+export type FileDescriptor = {
+  name: string;
+  type: string;
+  content: ArrayBuffer;
+};

--- a/components/add-layers/vector/VectorLayerDescriptor.ts
+++ b/components/add-layers/vector/VectorLayerDescriptor.ts
@@ -1,9 +1,4 @@
-import Feature from 'ol/Feature';
-import SparqlJson from '../../layers/hs.source.SparqlJson';
 import VectorSource from 'ol/source/Vector';
-import {GPX, GeoJSON, KML} from 'ol/format';
-import {VectorSourceFromFeatures} from './VectorSourceFromFeatures';
-import {VectorSourceFromUrl} from './VectorSourceFromUrl';
 
 export class VectorLayerDescriptor {
   mapProjection;
@@ -18,25 +13,6 @@ export class VectorLayerDescriptor {
     style: any;
     source?: VectorSource;
   };
-  sourceParams: {
-    extractStyles?: any;
-    from_composition?: boolean;
-    srs?: any;
-    url?: string;
-    format?: any;
-    geom_attribute?: string;
-    options?: any;
-    category_field?: string;
-    projection?: any;
-    minResolution?: number;
-    maxResolution?: number;
-    features?: Feature[];
-  };
-  sourceClass:
-    | typeof VectorSourceFromUrl
-    | typeof VectorSourceFromFeatures
-    | typeof SparqlJson
-    | typeof VectorSource;
 
   constructor(
     type: string,
@@ -44,7 +20,6 @@ export class VectorLayerDescriptor {
     title,
     abstract,
     url: string,
-    srs,
     options,
     mapProjection
   ) {
@@ -60,54 +35,28 @@ export class VectorLayerDescriptor {
       abstract,
       definition,
       saveState: true,
-      title,
       name,
+      title,
       opacity: options.opacity || 1,
       from_composition: options.from_composition || false,
       style: options.style,
-    };
-
-    this.sourceParams = {
-      from_composition: options.from_composition || false,
-      srs,
     };
 
     switch (type ? type.toLowerCase() : '') {
       case 'kml':
         definition.format = 'ol.format.KML';
         definition.url = url;
-        this.sourceParams.url = url;
-        this.sourceParams.format = new KML({
-          extractStyles: options.extractStyles,
-        });
-        this.sourceClass = VectorSourceFromUrl;
         break;
       case 'geojson':
         definition.format = 'ol.format.GeoJSON';
         definition.url = url;
-        this.sourceParams.url = url;
-        this.sourceParams.format = new GeoJSON();
-        this.sourceClass = VectorSourceFromUrl;
         break;
       case 'gpx':
         definition.format = 'ol.format.GPX';
         definition.url = url;
-        this.sourceParams.url = url;
-        this.sourceParams.format = new GPX();
-        this.sourceClass = VectorSourceFromUrl;
         break;
       case 'sparql':
         definition.format = 'hs.format.Sparql';
-        this.sourceParams = {
-          geom_attribute: '?geom',
-          url: url,
-          category_field: 'http://www.openvoc.eu/poi#categoryWaze',
-          projection: 'EPSG:3857',
-          minResolution: 1,
-          maxResolution: 38,
-          //#####feature_loaded: function(feature){feature.set('hstemplate', 'hs.geosparql_directive')}
-        };
-        this.sourceClass = SparqlJson;
         break;
       case 'wfs':
         Object.assign(this.layerParams, {
@@ -118,23 +67,8 @@ export class VectorLayerDescriptor {
             },
           },
         });
-        this.sourceClass = VectorSource;
         break;
       default:
-        this.sourceClass = VectorSourceFromFeatures;
-        const format = new GeoJSON();
-        let features = options.features || [];
-        if (typeof features === 'string') {
-          features = format.readFeatures(options.features, {
-            dataProjection: srs,
-            featureProjection: this.mapProjection,
-          });
-        }
-        this.sourceParams = {
-          srs,
-          options,
-          features,
-        };
     }
   }
 }

--- a/components/add-layers/vector/VectorLayerDescriptor.ts
+++ b/components/add-layers/vector/VectorLayerDescriptor.ts
@@ -11,6 +11,7 @@ export class VectorLayerDescriptor {
     abstract: any;
     definition: any;
     saveState: boolean;
+    name: any;
     title: any;
     opacity: any;
     from_composition: boolean;
@@ -39,6 +40,7 @@ export class VectorLayerDescriptor {
 
   constructor(
     type: string,
+    name,
     title,
     abstract,
     url: string,
@@ -59,6 +61,7 @@ export class VectorLayerDescriptor {
       definition,
       saveState: true,
       title,
+      name,
       opacity: options.opacity || 1,
       from_composition: options.from_composition || false,
       style: options.style,

--- a/components/add-layers/vector/VectorSourceFromUrl.ts
+++ b/components/add-layers/vector/VectorSourceFromUrl.ts
@@ -2,8 +2,6 @@ import * as loadingStrategy from 'ol/loadingstrategy';
 import VectorSource from 'ol/source/Vector';
 import {get as getProj} from 'ol/proj';
 
-import {VectorLayerDescriptor} from './VectorLayerDescriptor';
-
 export class VectorSourceFromUrl extends VectorSource {
   featureProjection: any;
   mapProjection: any;
@@ -13,7 +11,7 @@ export class VectorSourceFromUrl extends VectorSource {
   styleAble: boolean;
   error: boolean;
   errorMessage: any;
-  constructor(descriptor: VectorLayerDescriptor) {
+  constructor(descriptor: any) {
     super({
       format: descriptor.sourceParams.format,
       url: descriptor.sourceParams.url,

--- a/components/add-layers/vector/add-layers-vector-url-parser.service.ts
+++ b/components/add-layers/vector/add-layers-vector-url-parser.service.ts
@@ -39,6 +39,7 @@ export class HsVectorUrlParserService {
         type,
         url,
         title,
+        title,
         abstract,
         'EPSG:4326'
       );
@@ -50,6 +51,7 @@ export class HsVectorUrlParserService {
       const lyr = await this.HsAddLayersVectorService.addVectorLayer(
         'kml',
         url,
+        title,
         title,
         abstract,
         'EPSG:4326',

--- a/components/add-layers/vector/add-layers-vector.component.ts
+++ b/components/add-layers/vector/add-layers-vector.component.ts
@@ -14,6 +14,7 @@ export class HsAddLayersVectorComponent {
   extract_styles = false;
   abstract: string;
   url: string;
+  name = '';
 
   constructor(
     private hsAddLayersVectorService: HsAddLayersVectorService,
@@ -35,6 +36,7 @@ export class HsAddLayersVectorComponent {
     const layer = await this.hsAddLayersVectorService.addVectorLayer(
       '',
       this.url,
+      this.name,
       this.title,
       this.abstract,
       this.srs,

--- a/components/add-layers/vector/add-layers-vector.service.ts
+++ b/components/add-layers/vector/add-layers-vector.service.ts
@@ -6,6 +6,7 @@ import VectorLayerDescriptor from './VectorLayerDescriptor';
 import {HsMapService} from '../../map/map.service';
 import {HsStylerService} from '../../styles/styler.service';
 import {HsUtilsService} from '../../utils/utils.service';
+import {VectorSourceDescriptor} from './vector-source-descriptor';
 
 @Injectable({
   providedIn: 'root',
@@ -22,6 +23,7 @@ export class HsAddLayersVectorService {
    * @description Load nonwms OWS data and create layer
    * @param {string} type Type of data to load (supports Kml, Geojson, Wfs and Sparql)
    * @param {string} url Url of data/service localization
+   * @param name
    * @param {string} title Title of new layer
    * @param {string} abstract Abstract of new layer
    * @param {string} srs EPSG code of selected projection (eg. "EPSG:4326")
@@ -67,6 +69,7 @@ export class HsAddLayersVectorService {
    * @description Load nonwms OWS data and create layer
    * @param {string} type Type of data to load (supports Kml, Geojson, Wfs and Sparql)
    * @param {string} url Url of data/service localization
+   * @param name
    * @param {string} title Title of new layer
    * @param {string} abstract Abstract of new layer
    * @param {string} srs EPSG code of selected projection (eg. "EPSG:4326")
@@ -105,12 +108,19 @@ export class HsAddLayersVectorService {
       title,
       abstract,
       url,
+      options,
+      mapProjection
+    );
+
+    const sourceDescriptor = new VectorSourceDescriptor(
+      type,
+      url,
       srs,
       options,
       mapProjection
     );
 
-    const src = new descriptor.sourceClass(descriptor);
+    const src = new sourceDescriptor.sourceClass(sourceDescriptor);
     descriptor.layerParams.source = src;
     if (descriptor.layerParams.style) {
       descriptor.layerParams.style = this.HsStylerService.parseStyle(

--- a/components/add-layers/vector/add-layers-vector.service.ts
+++ b/components/add-layers/vector/add-layers-vector.service.ts
@@ -31,6 +31,7 @@ export class HsAddLayersVectorService {
   addVectorLayer(
     type: string,
     url: string,
+    name: string,
     title: string,
     abstract: string,
     srs: string,
@@ -41,6 +42,7 @@ export class HsAddLayersVectorService {
         const lyr = this.createVectorLayer(
           type,
           url,
+          name,
           title,
           abstract,
           srs,
@@ -74,6 +76,7 @@ export class HsAddLayersVectorService {
   createVectorLayer(
     type: string,
     url: string,
+    name: string,
     title: string,
     abstract: string,
     srs: string,
@@ -98,6 +101,7 @@ export class HsAddLayersVectorService {
 
     const descriptor = new VectorLayerDescriptor(
       type,
+      name,
       title,
       abstract,
       url,

--- a/components/add-layers/vector/add-layers-vector.service.ts
+++ b/components/add-layers/vector/add-layers-vector.service.ts
@@ -54,6 +54,10 @@ export class HsAddLayersVectorService {
         TODO: Should have set definition property with protocol inside 
         so layer synchronizer would know if to sync 
         */
+        lyr.set('definition', {
+          format: 'hs.format.WFS',
+          url: url.replace('ows', 'wfs'),
+        });
         if (this.HsMapService.map) {
           this.HsMapService.addLayer(lyr, true);
         }

--- a/components/add-layers/vector/add-layers-vector.service.ts
+++ b/components/add-layers/vector/add-layers-vector.service.ts
@@ -134,25 +134,30 @@ export class HsAddLayersVectorService {
   fitExtent(lyr: Layer): void {
     const src = lyr.getSource();
     if (src.getFeatures().length > 0) {
-      this.tryFit(src.getExtent());
+      this.tryFit(src.getExtent(), src);
     } else {
-      src.on('change', (e) => {
-        if (src.getState() == 'ready') {
-          if (src.getFeatures().length == 0) {
-            return;
-          }
-          const extent = src.getExtent();
-          this.tryFit(extent);
-        }
-      });
+      src.on('change', this.changeListener(src));
     }
   }
 
+  changeListener = function (src) {
+    if (src.getState() == 'ready') {
+      setTimeout(() => {
+        if (src.getFeatures().length == 0) {
+          return;
+        }
+        const extent = src.getExtent();
+        this.tryFit(extent, src);
+      }, 1000);
+    }
+  };
+
   /**
    * @param extent
+   * @param src
    * @private
    */
-  tryFit(extent): void {
+  tryFit(extent, src): void {
     if (
       !isNaN(extent[0]) &&
       !isNaN(extent[1]) &&
@@ -163,6 +168,7 @@ export class HsAddLayersVectorService {
       this.HsMapService.map
         .getView()
         .fit(extent, this.HsMapService.map.getSize());
+      src.un('change', this.changeListener);
     }
   }
 

--- a/components/add-layers/vector/add-vector-layer.directive.html
+++ b/components/add-layers/vector/add-vector-layer.directive.html
@@ -8,6 +8,11 @@
     </div>
 
     <div class="form-group">
+        <label class="capabilities_label control-label">{{'COMMON.name' | translate}}</label>
+        <input class="form-control" name="name" [(ngModel)]="name" />
+    </div>
+
+    <div class="form-group">
         <label class="capabilities_label control-label">{{'COMMON.abstract' | translate}}</label>
         <textarea class="form-control" id='hs-ows-abstract' [placeholder]="'COMMON.fillInDescriptive' | translate"
             name="abstract" [(ngModel)]="abstract">

--- a/components/add-layers/vector/vector-source-descriptor.ts
+++ b/components/add-layers/vector/vector-source-descriptor.ts
@@ -1,0 +1,87 @@
+import Feature from 'ol/Feature';
+import SparqlJson from '../../layers/hs.source.SparqlJson';
+import VectorSource from 'ol/source/Vector';
+import {GPX, GeoJSON, KML} from 'ol/format';
+import {VectorSourceFromFeatures} from './VectorSourceFromFeatures';
+import {VectorSourceFromUrl} from './VectorSourceFromUrl';
+export class VectorSourceDescriptor {
+  mapProjection;
+  sourceParams: {
+    extractStyles?: any;
+    from_composition?: boolean;
+    srs?: any;
+    url?: string;
+    format?: any;
+    geom_attribute?: string;
+    options?: any;
+    category_field?: string;
+    projection?: any;
+    minResolution?: number;
+    maxResolution?: number;
+    features?: Feature[];
+  };
+  sourceClass:
+    | typeof VectorSourceFromUrl
+    | typeof VectorSourceFromFeatures
+    | typeof SparqlJson
+    | typeof VectorSource;
+
+  constructor(type: string, url: string, srs, options, mapProjection) {
+    this.mapProjection = mapProjection;
+
+    this.sourceParams = {
+      from_composition: options.from_composition || false,
+      srs,
+    };
+
+    switch (type ? type.toLowerCase() : '') {
+      case 'kml':
+        this.sourceParams.url = url;
+        this.sourceParams.format = new KML({
+          extractStyles: options.extractStyles,
+        });
+        this.sourceClass = VectorSourceFromUrl;
+        break;
+      case 'geojson':
+        this.sourceParams.url = url;
+        this.sourceParams.format = new GeoJSON();
+        this.sourceClass = VectorSourceFromUrl;
+        break;
+      case 'gpx':
+        this.sourceParams.url = url;
+        this.sourceParams.format = new GPX();
+        this.sourceClass = VectorSourceFromUrl;
+        break;
+      case 'sparql':
+        this.sourceParams = {
+          geom_attribute: '?geom',
+          url: url,
+          category_field: 'http://www.openvoc.eu/poi#categoryWaze',
+          projection: 'EPSG:3857',
+          minResolution: 1,
+          maxResolution: 38,
+          //#####feature_loaded: function(feature){feature.set('hstemplate', 'hs.geosparql_directive')}
+        };
+        this.sourceClass = SparqlJson;
+        break;
+      case 'wfs':
+        this.sourceClass = VectorSource;
+        break;
+      default:
+        this.sourceClass = VectorSourceFromFeatures;
+        const format = new GeoJSON();
+        let features = options.features || [];
+        if (typeof features === 'string') {
+          features = format.readFeatures(options.features, {
+            dataProjection: srs,
+            featureProjection: this.mapProjection,
+          });
+        }
+        this.sourceParams = {
+          srs,
+          options,
+          features,
+        };
+    }
+  }
+}

--- a/components/compositions/compositions-parser.service.ts
+++ b/components/compositions/compositions-parser.service.ts
@@ -342,6 +342,7 @@ export class HsCompositionsParserService {
    * @description Select correct layer parser for input data based on layer "className" property (HSLayers.Layer.WMS/OpenLayers.Layer.Vector)
    */
   jsonToLayer(lyr_def) {
+    console.log(lyr_def)
     let resultLayer;
     switch (lyr_def.className) {
       case 'HSLayers.Layer.WMS':

--- a/components/compositions/compositions.service.ts
+++ b/components/compositions/compositions.service.ts
@@ -153,13 +153,18 @@ export class HsCompositionsService {
   }
 
   getRecordLink(record) {
-    let url;
-    if (record.link !== undefined) {
-      url = record.link;
-    } else if (record.links !== undefined) {
-      url = record.links.filter((l) => l.url.indexOf('/file') > -1)[0].url;
+    try {
+      let url;
+      if (record.link !== undefined) {
+        url = record.link;
+      } else if (record.links !== undefined) {
+        url = record.links.filter((l) => l.url.includes('/file') || l.url.includes('.wmc'))[0].url;
+      }
+      return url;
     }
-    return url;
+    catch (e) {
+      this.$log.warn(e);
+    }
   }
 
   loadCompositionParser(record) {
@@ -180,13 +185,15 @@ export class HsCompositionsService {
           reject();
           return;
       }
-      if (this.HsCompositionsParserService.composition_edited == true) {
-        this.notSavedCompositionLoading.next(url);
-        reject();
-      } else {
-        this.loadComposition(url, true).then(() => {
-          resolve();
-        });
+      if (url) {
+        if (this.HsCompositionsParserService.composition_edited == true) {
+          this.notSavedCompositionLoading.next(url);
+          reject();
+        } else {
+          this.loadComposition(url, true).then(() => {
+            resolve();
+          });
+        }
       }
     });
   }

--- a/components/compositions/endpoints/compositions-layman.service.ts
+++ b/components/compositions/endpoints/compositions-layman.service.ts
@@ -10,7 +10,6 @@ import {Subscription} from 'rxjs';
 })
 export class HsCompositionsLaymanService {
   data: any = {};
-  listLoading: Subscription;
   constructor(
     private $http: HttpClient,
     private HsUtilsService: HsUtilsService,
@@ -26,11 +25,11 @@ export class HsCompositionsLaymanService {
         params.sortBy = '';
       }
       try {
-        if (this.listLoading) {
-          this.listLoading.unsubscribe();
-          delete this.listLoading;
+        if (endpoint.listLoading) {
+          endpoint.listLoading.unsubscribe();
+          delete endpoint.listLoading;
         }
-        this.listLoading = this.$http
+        endpoint.listLoading = this.$http
           .get(`${endpoint.url}/rest/${endpoint.user}/maps`)
           .subscribe((response: any) => {
             endpoint.compositionsPaging.loaded = true;

--- a/components/compositions/endpoints/compositions-micka.service.ts
+++ b/components/compositions/endpoints/compositions-micka.service.ts
@@ -12,7 +12,6 @@ import {Subscription} from 'rxjs';
   providedIn: 'root',
 })
 export class HsCompositionsMickaService {
-  listLoading: Subscription;
   constructor(
     private HsCompositionsParserService: HsCompositionsParserService,
     private $http: HttpClient,
@@ -74,8 +73,8 @@ export class HsCompositionsMickaService {
 
   getCompositions(endpoint, params, bbox) {
     return new Promise((resolve, reject) => {
-      this.listLoading = this.$http
-        .get(this.getCompositionsQueryUrl(endpoint, params, bbox),{responseType: 'json'})
+      endpoint.listLoading = this.$http
+        .get(this.getCompositionsQueryUrl(endpoint, params, bbox))
         .subscribe((response: any) => {
           resolve(response);
         });
@@ -94,9 +93,9 @@ export class HsCompositionsMickaService {
       if (params.limit == undefined || isNaN(params.limit)) {
         params.limit = endpoint.compositionsPaging.limit;
       }
-      if (this.listLoading) {
-        this.listLoading.unsubscribe();
-        delete this.listLoading;
+      if (endpoint.listLoading) {
+        endpoint.listLoading.unsubscribe();
+        delete endpoint.listLoading;
       }
       this.getCompositions(endpoint, params, bbox).then(
         (response: any) => {

--- a/components/compositions/endpoints/compositions-micka.service.ts
+++ b/components/compositions/endpoints/compositions-micka.service.ts
@@ -75,7 +75,7 @@ export class HsCompositionsMickaService {
   getCompositions(endpoint, params, bbox) {
     return new Promise((resolve, reject) => {
       this.listLoading = this.$http
-        .get(this.getCompositionsQueryUrl(endpoint, params, bbox))
+        .get(this.getCompositionsQueryUrl(endpoint, params, bbox),{responseType: 'json'})
         .subscribe((response: any) => {
           resolve(response);
         });

--- a/components/compositions/endpoints/compositions-status-manager.service.ts
+++ b/components/compositions/endpoints/compositions-status-manager.service.ts
@@ -10,7 +10,6 @@ import {Subscription} from 'rxjs';
   providedIn: 'root',
 })
 export class HsCompositionsStatusManagerService {
-  listLoading: Subscription;
   constructor(
     private HsStatusManagerService: HsStatusManagerService,
     private HsConfig: HsConfig,
@@ -48,11 +47,11 @@ export class HsCompositionsStatusManagerService {
       '&start=0&limit=1000&sort=' +
       getStatusSortAttr(params.sortBy);
     url = this.HsUtilsService.proxify(url);
-    if (this.listLoading) {
-      this.listLoading.unsubscribe();
-      delete this.listLoading;
+    if (ds.listLoading) {
+      ds.listLoading.unsubscribe();
+      delete ds.listLoading;
     }
-    this.listLoading = this.$http.get(url).subscribe(
+    ds.listLoading = this.$http.get(url).subscribe(
       (response: any) => {
         if (ds.compositions == undefined) {
           ds.compositions = [];

--- a/components/compositions/layer-parser/layer-parser.service.ts
+++ b/components/compositions/layer-parser/layer-parser.service.ts
@@ -322,13 +322,15 @@ export class HsCompositionsLayerParserService {
       options.style = this.HsStylerService.parseStyle(lyr_def.style);
       extractStyles = false;
     }
+    const title = lyr_def.title || 'Layer';
     let layer;
     switch (format) {
       case 'ol.format.KML':
         layer = this.HsAddLayersVectorService.createVectorLayer(
           'kml',
           lyr_def.protocol.url,
-          lyr_def.title || 'Layer',
+          title,
+          lyr_def.name || title,
           lyr_def.abstract,
           lyr_def.projection.toUpperCase(),
           Object.assign(options, {extractStyles})
@@ -338,7 +340,8 @@ export class HsCompositionsLayerParserService {
         layer = this.HsAddLayersVectorService.createVectorLayer(
           'geojson',
           lyr_def.protocol.url,
-          lyr_def.title || 'Layer',
+          title,
+          lyr_def.name || title,
           lyr_def.abstract,
           lyr_def.projection.toUpperCase(),
           options
@@ -350,7 +353,8 @@ export class HsCompositionsLayerParserService {
         layer = this.HsAddLayersVectorService.createVectorLayer(
           'wfs',
           lyr_def.protocol.url,
-          lyr_def.title || 'Layer',
+          title,
+          lyr_def.name || title,
           lyr_def.abstract,
           lyr_def.projection.toUpperCase(),
           options
@@ -363,7 +367,8 @@ export class HsCompositionsLayerParserService {
         layer = this.HsAddLayersVectorService.createVectorLayer(
           '',
           undefined,
-          lyr_def.title || 'Layer',
+          title,
+          lyr_def.name || title,
           lyr_def.abstract,
           lyr_def.projection?.toUpperCase(),
           lyr_def

--- a/components/datasource-selector/datasource-selector.service.ts
+++ b/components/datasource-selector/datasource-selector.service.ts
@@ -22,6 +22,7 @@ type WhatToAddDescriptor = {
   dsType?: string;
   layer?;
   link?;
+  name?;
   title?: string;
   abstract?: string;
   projection?;
@@ -224,6 +225,7 @@ export class HsDatasourcesService {
         const layer = await this.hsAddLayersVectorService.addVectorLayer(
           'wfs',
           whatToAdd.link,
+          whatToAdd.name,
           whatToAdd.title,
           whatToAdd.abstract,
           whatToAdd.projection,
@@ -235,6 +237,7 @@ export class HsDatasourcesService {
       const layer = await this.hsAddLayersVectorService.addVectorLayer(
         whatToAdd.type.toLowerCase(),
         whatToAdd.link,
+        whatToAdd.name,
         whatToAdd.title,
         whatToAdd.abstract,
         whatToAdd.projection,

--- a/components/datasource-selector/datasource-selector.service.ts
+++ b/components/datasource-selector/datasource-selector.service.ts
@@ -233,6 +233,7 @@ export class HsDatasourcesService {
         );
         this.hsAddLayersVectorService.fitExtent(layer);
       }
+      this.hsLayoutService.setMainPanel('layermanager');
     } else if (['KML', 'GEOJSON'].includes(whatToAdd.type)) {
       const layer = await this.hsAddLayersVectorService.addVectorLayer(
         whatToAdd.type.toLowerCase(),

--- a/components/datasource-selector/layman/layman.service.ts
+++ b/components/datasource-selector/layman/layman.service.ts
@@ -139,7 +139,8 @@ export class HsLaymanBrowserService {
       type: lyr.type,
       link: lyr.wms.url,
       layer: lyr.name,
-      title: lyr.name,
+      name: lyr.name,
+      title: lyr.title,
       dsType: ds.type,
     };
   }

--- a/components/datasource-selector/micka/micka.service.ts
+++ b/components/datasource-selector/micka/micka.service.ts
@@ -333,6 +333,7 @@ export class HsMickaBrowserService {
       return false;
     }
     whatToAdd.title = layer.title || 'Layer';
+    whatToAdd.name = layer.title || 'Layer';
     whatToAdd.abstract = layer.abstract || 'Layer';
     return whatToAdd;
   }

--- a/components/datasource-selector/select-type-to-add-layer-dialog.component.ts
+++ b/components/datasource-selector/select-type-to-add-layer-dialog.component.ts
@@ -1,11 +1,7 @@
-/**
- * DEPRECATED
- *
- * @deprecated
- */
 import {Component, Input} from '@angular/core';
 
 import {HsDatasourcesService} from './datasource-selector.service';
+import {HsLayoutService} from '../layout/layout.service';
 
 @Component({
   selector: 'hs-select-type-to-add-layer',
@@ -20,7 +16,10 @@ export class HsSelectTypeToAddLayerDialogComponent {
   alertChoose;
   layerType; //do not rename to 'type', would clash in the template
 
-  constructor(private hsDatasourcesService: HsDatasourcesService) {
+  constructor(
+    private hsDatasourcesService: HsDatasourcesService,
+    private HsLayoutService: HsLayoutService
+  ) {
     this.modalVisible = true;
   }
 
@@ -34,6 +33,7 @@ export class HsSelectTypeToAddLayerDialogComponent {
         this.layer,
         this.layerType
       );
+      this.HsLayoutService.setMainPanel('layermanager');
     }
   }
 }

--- a/components/datasource-selector/select-type-to-add-layer-dialog.component.ts
+++ b/components/datasource-selector/select-type-to-add-layer-dialog.component.ts
@@ -1,7 +1,6 @@
 import {Component, Input} from '@angular/core';
 
 import {HsDatasourcesService} from './datasource-selector.service';
-import {HsLayoutService} from '../layout/layout.service';
 
 @Component({
   selector: 'hs-select-type-to-add-layer',
@@ -16,10 +15,7 @@ export class HsSelectTypeToAddLayerDialogComponent {
   alertChoose;
   layerType; //do not rename to 'type', would clash in the template
 
-  constructor(
-    private hsDatasourcesService: HsDatasourcesService,
-    private HsLayoutService: HsLayoutService
-  ) {
+  constructor(private hsDatasourcesService: HsDatasourcesService) {
     this.modalVisible = true;
   }
 
@@ -33,7 +29,6 @@ export class HsSelectTypeToAddLayerDialogComponent {
         this.layer,
         this.layerType
       );
-      this.HsLayoutService.setMainPanel('layermanager');
     }
   }
 }

--- a/components/layermanager/layer-editor.sub-layer-checkboxes.component.ts
+++ b/components/layermanager/layer-editor.sub-layer-checkboxes.component.ts
@@ -1,5 +1,7 @@
 import {Component, Input} from '@angular/core';
 import {HsLayerEditorSublayerService} from './layer-editor.sub-layer.service';
+import {HsLayerManagerService} from './layermanager.service';
+
 @Component({
   selector: 'hs-layer-editor-sub-layer-checkbox',
   template: require('./partials/sub-layer-checkboxes.html'),
@@ -11,7 +13,8 @@ export class HsLayerEditorSubLayerCheckboxesComponent {
   withChildren: any;
 
   constructor(
-    private HsLayerEditorSublayerService: HsLayerEditorSublayerService
+    private HsLayerEditorSublayerService: HsLayerEditorSublayerService,
+    private HsLayerManagerService: HsLayerManagerService
   ) {
     this.checkedSubLayers = this.HsLayerEditorSublayerService.checkedSubLayers;
     this.withChildren = this.HsLayerEditorSublayerService.withChildren;

--- a/components/layermanager/layermanager-metadata.service.ts
+++ b/components/layermanager/layermanager-metadata.service.ts
@@ -66,6 +66,137 @@ export class HsLayerManagerMetadataService {
     return Object.entries(obj).map((e) => e[1]);
   }
 
+  private roundToHundreds(num: number): number {
+    return Math.ceil(num / 100) * 100;
+  }
+
+  /**
+   * @param properties
+   * @function queryMetadata
+   * @memberOf HsLayermanagerMetadata.service
+   * @description Looks for maxScaleDenominator in property object
+   */
+  searchForScaleDenominator(properties: any) {
+    let maxScale = properties.MaxScaleDenominator
+      ? properties.MaxScaleDenominator
+      : null;
+
+    const layers = properties.Layer;
+    if (layers) {
+      for (const sublayer of layers) {
+        if (sublayer.Layer) {
+          const subScale = this.searchForScaleDenominator(sublayer);
+          maxScale = subScale > maxScale ? subScale : maxScale;
+        } else {
+          if (sublayer.MaxScaleDenominator) {
+            sublayer.maxResolution = sublayer.MaxScaleDenominator;
+            if (maxScale < sublayer.MaxScaleDenominator) {
+              maxScale = sublayer.MaxScaleDenominator;
+            }
+          } else if (!sublayer.maxResolution) {
+            sublayer.maxResolution = maxScale;
+          }
+        }
+      }
+    }
+    if (maxScale) {
+      properties.maxResolution = maxScale;
+    }
+    return maxScale;
+  }
+  /**
+   * @param properties
+   * @function queryMetadata
+   * @memberOf HsLayermanagerMetadata.service
+   * @description Sets or updates values in layer object
+   */
+
+  //TODO TYPES
+  setOrUpdate(layer, key, values) {
+    const previousValue = layer.get(key);
+    if (previousValue) {
+      for (const value of values) {
+        layer.set(previousValue.push(value));
+      }
+    } else {
+      layer.set(key, values);
+    }
+  }
+
+  parseInfoForLayer(
+    layer, //TODOTYPE
+    layer_name: any,
+    caps: any,
+    fromSublayerParam: boolean
+  ) {
+    const layerObject = []; //array of layer objects representing added layer
+
+    if (layer_name.includes(',')) {
+      const layers = [];
+      const legends = [];
+
+      layer_name = layer_name.split(',');
+      //loop over layers from layer.LAYERS
+      for (let i = 0; i < layer_name.length; i++) {
+        layerObject[i] = this.identifyLayerObject(
+          layer_name[i],
+          caps.Capability.Layer
+        );
+        if (layerObject[i].Style) {
+          legends.push(layerObject[i].Style[0].LegendURL[0].OnlineResource);
+        }
+        if (layerObject[i].Layer !== undefined) {
+          if (fromSublayerParam) {
+            delete layerObject[i].Layer;
+            layers.push(layerObject[i]);
+          } else {
+            //loop over sublayers of layer from layer.LAYERS
+            for (let j = 0; j < layerObject[i].Layer.length; j++) {
+              layers.push(layerObject[i].Layer[j]); //merge sublayers
+            }
+          }
+        }
+        layerObject[i].maxResolution = this.searchForScaleDenominator(
+          layerObject[i]
+        );
+      }
+      if (!layer.paramsSet) {
+        layer.setProperties(layerObject[0]);
+        layer.paramsSet = true;
+      }
+      this.setOrUpdate(layer, 'Layer', layers);
+      this.setOrUpdate(layer, 'Legends', legends);
+      this.setOrUpdate(layer, 'MetadataURL', {
+        //use service metadata for layers with multiple layer.LAYERS inputs
+        '0': caps.Service,
+      });
+    } else {
+      layerObject[0] = this.identifyLayerObject(
+        layer_name,
+        caps.Capability.Layer
+      );
+
+      if (!layer.paramsSet) {
+        layer.setProperties(layerObject[0]);
+        layer.paramsSet = true;
+      }
+      if (layerObject[0].Style) {
+        layer.set(
+          'Legends',
+          layerObject[0].Style[0].LegendURL[0].OnlineResource
+        );
+      }
+
+      if (layerObject[0].Layer && fromSublayerParam) {
+        layerObject[0].maxResolution = this.searchForScaleDenominator(
+          layerObject[0]
+        );
+        delete layerObject[0].Layer;
+        this.setOrUpdate(layer, 'Layer', layerObject);
+      }
+    }
+  }
+
   /**
    * @function queryMetadata
    * @memberOf HsLayermanagerMetadata.service
@@ -85,51 +216,17 @@ export class HsLayerManagerMetadataService {
         .then((capabilities_xml) => {
           const parser = new WMSCapabilities();
           const caps = parser.read(capabilities_xml);
-          let layer_name = layer.getSource().getParams().LAYERS;
-          const layerObject = []; //array of layer objects representing added layer
+          const layer_name = layer.getSource().getParams().LAYERS;
+          const layer_name_params = layer.getSource().getParams().LAYERS;
 
-          if (layer_name.includes(',')) {
-            const layers = [];
-            const legends = [];
+          this.parseInfoForLayer(layer, layer_name_params, caps, false);
+          if (layer.get('sublayers')) {
+            this.parseInfoForLayer(layer, layer.get('sublayers'), caps, true);
 
-            layer_name = layer_name.split(',');
-            //loop over layers from layer.LAYERS
-            for (let i = 0; i < layer_name.length; i++) {
-              layerObject[i] = this.identifyLayerObject(
-                layer_name[i],
-                caps.Capability.Layer
-              );
-              if (layerObject[i].Style) {
-                legends.push(
-                  layerObject[i].Style[0].LegendURL[0].OnlineResource
-                );
-              }
-              if (layerObject[i].Layer != undefined) {
-                //loop over sublayers of layer from layer.LAYERS
-                for (let j = 0; j < layerObject[i].Layer.length; j++) {
-                  layers.push(layerObject[i].Layer[j]); //merge sublayers
-                }
-              }
-            }
-            layer.setProperties(layerObject[0]);
-            layer.set('Layer', layers);
-            layer.set('Legends', legends);
-            layer.set('MetadataURL', {
-              //use service metadata for layers with multiple layer.LAYERS inputs
-              '0': caps.Service,
-            });
-          } else {
-            layerObject[0] = this.identifyLayerObject(
-              layer_name,
-              caps.Capability.Layer
-            );
-            layer.setProperties(layerObject[0]);
-            if (layerObject[0].Style) {
-              layer.set(
-                'Legends',
-                layerObject[0].Style[0].LegendURL[0].OnlineResource
-              );
-            }
+            const src = layer.getSource();
+            const params = src.getParams();
+            params.LAYERS = params.LAYERS.concat(',', layer.get('sublayers'));
+            src.updateParams(params);
           }
 
           //prioritize config values
@@ -142,12 +239,27 @@ export class HsLayerManagerMetadataService {
             layer.set('MetadataURL', metadata);
             return layer;
           }
-          if (layerObject[0].MetadataURL == undefined) {
+          if (layer.get('Layer')[0].MetadataURL == undefined){
             layer.set('MetadataURL', {
               '0': caps.Service,
             });
           }
-
+          //Identify max resolution of layer. If layer has sublayers the heighest value is selected
+          setTimeout(() => {
+            if (layer.get('MaxScaleDenominator')) {
+              layer.set(
+                'maxResolution',
+                this.roundToHundreds(layer.get('MaxScaleDenominator'))
+              );
+              return;
+            }
+            const maxScale = this.searchForScaleDenominator(
+              layer.getProperties()
+            );
+            if (maxScale) {
+              layer.set('maxResolution', this.roundToHundreds(maxScale));
+            }
+          });
           return true;
         })
         .catch((e) => {

--- a/components/layermanager/layermanager-metadata.service.ts
+++ b/components/layermanager/layermanager-metadata.service.ts
@@ -239,7 +239,7 @@ export class HsLayerManagerMetadataService {
             layer.set('MetadataURL', metadata);
             return layer;
           }
-          if (layer.get('Layer')[0].MetadataURL == undefined){
+          if (!layer.get('MetadataURL')){
             layer.set('MetadataURL', {
               '0': caps.Service,
             });

--- a/components/layermanager/layermanager.service.ts
+++ b/components/layermanager/layermanager.service.ts
@@ -759,7 +759,7 @@ export class HsLayerManagerService {
       cur_res = this.HsMapService.map.getView().getResolution();
     }
     this.currentResolution = cur_res;
-    console.log(this.currentResolution)
+    console.log(this.currentResolution);
     return (
       lyr.getMinResolution() <= cur_res && cur_res <= lyr.getMaxResolution()
     );
@@ -884,27 +884,27 @@ export class HsLayerManagerService {
 
     this.boxLayersInit();
 
-    this.map.getView().on('change:resolution', (e) => {
-      if (this.timer !== null) {
-        clearTimeout(this.timer);
-      }
-      this.timer = setTimeout(() => {
-        let somethingChanged = false;
-        for (let i = 0; i < this.data.layers.length; i++) {
-          const tmp = !this.isLayerInResolutionInterval(
-            this.data.layers[i].layer
-          );
-          if (this.data.layers[i].grayed != tmp) {
-            this.data.layers[i].grayed = tmp;
-            somethingChanged = true;
-          }
-          if (somethingChanged) {
-            //  $timeout(() => { }, 0);
-          }
-        }
-        this.timer = null;
-      }, 500);
-    });
+    this.map.getView().on(
+      'change:resolution',
+      this.HsUtilsService.debounce(
+        () => {
+          setTimeout(() => {
+            for (let i = 0; i < this.data.layers.length; i++) {
+              const tmp = !this.isLayerInResolutionInterval(
+                this.data.layers[i].layer
+              );
+              if (this.data.layers[i].grayed != tmp) {
+                this.data.layers[i].grayed = tmp;
+              }
+            }
+            this.timer = null;
+          }, 250);
+        },
+        750,
+        false,
+        this
+      )
+    );
 
     this.map.getLayers().on('add', (e) => this.layerAdded(e));
     this.map.getLayers().on('remove', (e) => this.layerRemoved(e));

--- a/components/layermanager/partials/sub-layer-checkboxes.html
+++ b/components/layermanager/partials/sub-layer-checkboxes.html
@@ -20,7 +20,7 @@
                     <label class="form-check-label m-0"
                         [ngClass]="{'hs-checkmark':withChildren[subLayer.Name],'hs-uncheckmark':!withChildren[subLayer.Name]}"
                         [attr.for]="'hs-sublayers-'+subLayer.Name"></label>
-                    <div (click)="toggleExpanded()" [ngStyle]="{'cursor':'pointer'}">
+                    <div (click)="toggleExpanded()" [ngStyle]="{'cursor':'pointer'}" [ngClass]="{'grayed': !withChildren[subLayer.Name] || HsLayerManagerService.currentResolution >= subLayer.maxResolution}">
                         {{subLayer.Title || subLayer.Name}}
                         <button type="button" class="btn btn-sm p-0" [ngStyle]="{'font-size':'x-small'}">
                             <i [ngClass]="{'icon-chevron-down': expanded, 'icon-chevron-right': !expanded}"></i>
@@ -29,7 +29,7 @@
                 </div>
                 <div *ngIf="!subLayer.Layer">
                     <label class="form-check-label m-0"
-                        [ngClass]="{'hs-checkmark':checkedSubLayers[subLayer.Name],'hs-uncheckmark':!checkedSubLayers[subLayer.Name]}"
+                        [ngClass]="{'hs-checkmark':checkedSubLayers[subLayer.Name],'hs-uncheckmark':!checkedSubLayers[subLayer.Name], 'grayed': (!checkedSubLayers[subLayer.Name] || HsLayerManagerService.currentResolution > subLayer.maxResolution) }"
                         [attr.for]="'hs-sublayers-'+subLayer.Name">{{subLayer.Title || subLayer.Name}}</label>
                 </div>
             </div>

--- a/components/save-map/layman.service.ts
+++ b/components/save-map/layman.service.ts
@@ -148,7 +148,7 @@ export class HsLaymanService implements HsSaverService {
       .filter((ds) => ds.type == 'layman')
       .forEach((ds) => {
         if (
-          ds.version === undefined ||
+          ds.version !== undefined &&
           ((ds.version.split('.').join() as unknown) as number) < 171
         ) {
           layerTitle = this.getLaymanFriendlyLayerName(layerTitle);

--- a/components/save-map/partials/panel.html
+++ b/components/save-map/partials/panel.html
@@ -14,7 +14,7 @@
             </div>
         </div>
         <hs-layman-current-user *ngIf="endpoint?.type == 'layman'" [endpoint]="endpoint"></hs-layman-current-user>
-        <hs-save-map-advanced-form *ngIf="HsConfig.advanced_form"></hs-save-map-advanced-form>
-        <div hs.save-map.directive_simpleform="" *ngIf="!HsConfig.advanced_form"></div>
+        <hs-save-map-advanced-form *ngIf="HsConfig.advancedForm"></hs-save-map-advanced-form>
+        <hs-save-map-simple-form *ngIf="!HsConfig.advancedForm"></hs-save-map-simple-form>
     </div>
 </div>

--- a/components/save-map/save-map-simple-form.component.ts
+++ b/components/save-map/save-map-simple-form.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
 @Component({
-  selector: 'hs.save-map-simple-form',
+  selector: 'hs-save-map-simple-form',
   template: require('./partials/simpleform.html'),
 })
 export class HsSaveMapSimpleFormComponent {

--- a/css/app.scss
+++ b/css/app.scss
@@ -63,7 +63,9 @@ $sidebar-item-active: #007bff !default;
 .hs-grayscale {
 	filter: grayscale(100%);
 }
-
+.hs-lm-deactivated-layer, .grayed {
+	color: #cccccc;
+}
 .hs-main-panel {
 	border: none;
 	margin-bottom: 0;


### PR DESCRIPTION
- Implement support for .wmc compositions
- Use both name and title correctly when loading layers from layman
- Fix saving title to layman incorrectly
- Unsubscribe from src changes after view fitted after layer is laoded from layman 
- Parse maxScaleDenominator into maxResoluion param 
- Display grayed layer name if layer out of the scale or switched off
- Create sublayers WMS layer config param. Adding layer name to this parameter makes it sublayer of the layer and parses avalaible information form getCapabilities. In constrast with the params.LAYERS it doesnt create additional sublayer structure even if its available. Currently no additional nested sublayers are possible with this param