### PR TITLE
Parse WMS or WFS layer from the URL parametres

### DIFF
--- a/components/add-layers/add-layers.component.js
+++ b/components/add-layers/add-layers.component.js
@@ -75,12 +75,21 @@ export default {
      * @param type
      */
     function connectServiceFromUrlParam(type) {
-      if (HsPermalinkUrlService.getParamValue(`${type}_to_connect`)) {
-        const url = HsPermalinkUrlService.getParamValue(`${type}_to_connect`);
+      const url = HsPermalinkUrlService.getParamValue(`${type}_to_connect`);
+      console.log(url);
+      if (url) {
+        const layers = HsPermalinkUrlService.getParamValue('visible_layers');
         HsLayoutService.setMainPanel('datasource_selector');
         $scope.type = type.toUpperCase();
+        console.log(layers);
         $timeout(() => {
-          $rootScope.$broadcast(`ows.${type}_connecting`, url);
+          if (layers) {
+            for (const layer of layers.split(';')) {
+              $rootScope.$broadcast(`ows.${type}_connecting`, url, layer);
+            }
+          } else {
+            $rootScope.$broadcast(`ows.${type}_connecting`, url);
+          }
         });
       }
     }

--- a/components/add-layers/add-layers.component.js
+++ b/components/add-layers/add-layers.component.js
@@ -77,7 +77,7 @@ export default {
     function connectServiceFromUrlParam(type) {
       const url = HsPermalinkUrlService.getParamValue(`${type}_to_connect`);
       if (url) {
-        const layers = HsPermalinkUrlService.getParamValue('visible_layers');
+        const layers = HsPermalinkUrlService.getParamValue(`${type}_layers`);
         HsLayoutService.setMainPanel('datasource_selector');
         $scope.type = type.toUpperCase();
         $timeout(() => {

--- a/components/add-layers/add-layers.component.js
+++ b/components/add-layers/add-layers.component.js
@@ -76,12 +76,10 @@ export default {
      */
     function connectServiceFromUrlParam(type) {
       const url = HsPermalinkUrlService.getParamValue(`${type}_to_connect`);
-      console.log(url);
       if (url) {
         const layers = HsPermalinkUrlService.getParamValue('visible_layers');
         HsLayoutService.setMainPanel('datasource_selector');
         $scope.type = type.toUpperCase();
-        console.log(layers);
         $timeout(() => {
           if (layers) {
             for (const layer of layers.split(';')) {

--- a/components/add-layers/wfs/add-layers-wfs-service.js
+++ b/components/add-layers/wfs/add-layers-wfs-service.js
@@ -1,17 +1,14 @@
 /* eslint-disable angular/definedundefined */
-import '../../utils/utils.module';
 import * as xml2Json from 'xml-js';
 import moment from 'moment';
 global.moment = moment;
-import '../../../common/get-capabilities.module';
-import GML3 from 'ol/format/GML3';
-import VectorLayer from 'ol/layer/Vector';
-import {WFS} from 'ol/format';
-import {bbox} from 'ol/loadingstrategy';
-import {get} from 'ol/proj';
-import {transform, transformExtent} from 'ol/proj';
-
+import {GML as GML3, WFS} from 'ol/format';
 import {Vector} from 'ol/source';
+import {bbox} from 'ol/loadingstrategy';
+import {get, transformExtent} from 'ol/proj';
+
+import '../../../common/get-capabilities.module';
+import '../../utils/utils.module';
 
 /**
  * @param HsConfig
@@ -124,9 +121,7 @@ export class HsAddLayersWfsService {
     } else {
       caps = caps['WFS_Capabilities'];
     }
-    console.log('parsed', caps);
     this.parseWFSJson(caps);
-    console.log('double-parsed', caps);
     this.title = caps.ServiceIdentification.Title;
     // this.description = addAnchors(caps.ServiceIdentification.Abstract);
     this.version = caps.ServiceIdentification.ServiceTypeVersion;
@@ -136,7 +131,6 @@ export class HsAddLayersWfsService {
     this.layers = Array.isArray(caps.FeatureTypeList.FeatureType)
       ? caps.FeatureTypeList.FeatureType
       : [caps.FeatureTypeList.FeatureType];
-    console.log(layer);
     this.output_formats = layer.OutputFormats
       ? layer.OutputFormats.Format
       : 'GML3';
@@ -206,7 +200,7 @@ export class HsAddLayersWfsService {
         this.$rootScope.$broadcast('wfs_capabilities_error', e);
       }
     });
-    return;
+    return this.bbox;
   }
 
   getPreferedFormat(formats) {

--- a/components/add-layers/wfs/add-layers-wfs.component.js
+++ b/components/add-layers/wfs/add-layers-wfs.component.js
@@ -182,7 +182,7 @@ export default {
      * @function addLayers
      * @memberOf hs.addLayersWfs
      * @description Seconds step in adding layers to the map, with resampling or without. Lops through the list of layers and calls addLayer.
-     * @param {boolean} checked - Add all available layers or o0lny checked ones. Checked=false=all
+     * @param {boolean} checked - Add all available layers or only checked ones. Checked=false=all
      */
     $scope.addLayers = function (checked) {
       /**

--- a/components/add-layers/wms/add-layers-wms.component.js
+++ b/components/add-layers/wms/add-layers-wms.component.js
@@ -37,35 +37,32 @@ export default {
      */
     $scope.connect = function (layerToSelect) {
       HsHistoryListService.addSourceHistory('Wms', $scope.url);
-      HsWmsGetCapabilitiesService.requestGetCapabilities($scope.url).then(
-        (capabilities) => {
+      HsWmsGetCapabilitiesService.requestGetCapabilities($scope.url)
+        .then((capabilities) => {
           $timeout((_) => {
             HsAddLayersWmsAddLayerService.capabilitiesReceived(
               capabilities,
               layerToSelect
-            )
-              .then((data) => {
-                if (layerToSelect) {
-                  $scope.addLayers(true);
-                  console.log('data', data);
-                  if (data && data.extent) {
-                    const extent = transformExtent(
-                      data.extent,
-                      'EPSG:4326',
-                      HsMapService.map.getView().getProjection()
-                    );
-                    if (extent !== null) {
-                      HsMapService.map
-                        .getView()
-                        .fit(extent, HsMapService.map.getSize());
-                    }
+            ).then((data) => {
+              if (layerToSelect) {
+                $scope.addLayers(true);
+                if (data && data.extent) {
+                  const extent = transformExtent(
+                    data.extent,
+                    'EPSG:4326',
+                    HsMapService.map.getView().getProjection()
+                  );
+                  if (extent !== null) {
+                    HsMapService.map
+                      .getView()
+                      .fit(extent, HsMapService.map.getSize());
                   }
                 }
-              })
-              .catch((e) => console.warn(e));
+              }
+            });
           }, 0);
-        }
-      );
+        })
+        .catch((e) => console.warn(e));
       $scope.showDetails = true;
     };
 

--- a/components/add-layers/wms/add-layers-wms.component.js
+++ b/components/add-layers/wms/add-layers-wms.component.js
@@ -1,3 +1,5 @@
+import {transformExtent} from 'ol/proj';
+
 import '../../../common/get-capabilities.module';
 import '../../utils/utils.module';
 
@@ -13,6 +15,7 @@ export default {
     HsWmsGetCapabilitiesService,
     HsAddLayersWmsAddLayerService,
     HsHistoryListService,
+    HsMapService,
     $timeout
   ) {
     'ngInject';
@@ -41,9 +44,22 @@ export default {
               capabilities,
               layerToSelect
             )
-              .then(() => {
+              .then((data) => {
                 if (layerToSelect) {
                   $scope.addLayers(true);
+                  console.log('data', data);
+                  if (data && data.extent) {
+                    const extent = transformExtent(
+                      data.extent,
+                      'EPSG:4326',
+                      HsMapService.map.getView().getProjection()
+                    );
+                    if (extent !== null) {
+                      HsMapService.map
+                        .getView()
+                        .fit(extent, HsMapService.map.getSize());
+                    }
+                  }
                 }
               })
               .catch((e) => console.warn(e));

--- a/components/add-layers/wms/add-layers-wms.component.js
+++ b/components/add-layers/wms/add-layers-wms.component.js
@@ -29,6 +29,9 @@ export default {
       $scope.showDetails = false;
     };
 
+    /**
+     * @param {string} [layerToSelect]
+     */
     $scope.connect = function (layerToSelect) {
       HsHistoryListService.addSourceHistory('Wms', $scope.url);
       HsWmsGetCapabilitiesService.requestGetCapabilities($scope.url).then(
@@ -37,7 +40,13 @@ export default {
             HsAddLayersWmsAddLayerService.capabilitiesReceived(
               capabilities,
               layerToSelect
-            );
+            )
+              .then(() => {
+                if (layerToSelect) {
+                  $scope.addLayers(true);
+                }
+              })
+              .catch((e) => console.warn(e));
           }, 0);
         }
       );
@@ -85,7 +94,7 @@ export default {
      * @memberof hs.addLayersWms
      * @function setUrlAndConnect
      * @param {string} url Url of requested service
-     * @param {string} layer Optional layer to select, when
+     * @param {string} [layer] Optional layer to select, when
      * getCapabilities arrives
      */
     $scope.setUrlAndConnect = function (url, layer) {

--- a/components/add-layers/wms/add-layers-wms.service.js
+++ b/components/add-layers/wms/add-layers-wms.service.js
@@ -110,6 +110,9 @@ export default function (
       } else if (typeof caps.Capability.Layer == 'object') {
         me.data.services = [caps.Capability.Layer];
       }
+      me.data.extent =
+        me.data.services[0].EX_GeographicBoundingBox ||
+        me.data.services[0].BoundingBox;
 
       selectLayerByName(layerToSelect);
 
@@ -133,6 +136,7 @@ export default function (
       ]);
       //FIXME: unused?
       $rootScope.$broadcast('wmsCapsParsed');
+      return me.data;
     } catch (e) {
       $rootScope.$broadcast('wmsCapsParseError', e);
     }

--- a/components/add-layers/wms/add-layers-wms.service.js
+++ b/components/add-layers/wms/add-layers-wms.service.js
@@ -58,7 +58,11 @@ export default function (
     }
   }
 
-  this.capabilitiesReceived = function (response, layerToSelect) {
+  /**
+   * @param response
+   * @param {string} [layerToSelect]
+   */
+  this.capabilitiesReceived = async function (response, layerToSelect) {
     try {
       const parser = new WMSCapabilities();
       const caps = parser.read(response);
@@ -127,6 +131,7 @@ export default function (
         'text/plain',
         'text/html',
       ]);
+      //FIXME: unused?
       $rootScope.$broadcast('wmsCapsParsed');
     } catch (e) {
       $rootScope.$broadcast('wmsCapsParseError', e);
@@ -161,7 +166,7 @@ export default function (
   }
 
   /**
-   * @param layerToSelect
+   * @param {string} layerToSelect
    */
   function selectLayerByName(layerToSelect) {
     if (layerToSelect) {
@@ -190,10 +195,10 @@ export default function (
       );
     }, 0);
   };
-    /**
+  /**
    * @function checkboxChange
    * @memberOf add-layers-wms.service
-   * @description Determines whether any of checkboxes (layer/sublayer) of add-layer-wms directive is checked. 
+   * @description Determines whether any of checkboxes (layer/sublayer) of add-layer-wms directive is checked.
    * @param {boolean} changed - Layer or sublayer of service to be added to map
    */
   me.checkboxChange = function (changed) {
@@ -206,7 +211,7 @@ export default function (
    * @function addLayers
    * @memberOf add-layers-wms.controller
    * @description Seconds step in adding layers to the map, with resampling or without. Lops through the list of layers and calls addLayer.
-   * @param {boolean} checked - Add all available layersor ony checked ones. Checked=false=all
+   * @param {boolean} checked - Add all available layers or only checked ones. Checked=false=all
    */
   me.addLayers = function (checked) {
     /**

--- a/components/layermanager/layermanager-metadata.service.js
+++ b/components/layermanager/layermanager-metadata.service.js
@@ -186,6 +186,7 @@ export default function (
    * @memberOf HsLayermanagerMetadata.service
    * @param {Ol.layer} layer Selected layer
    * @description Callback function, adds getCapabilities response metadata to layer object
+   * @returns {Promise}
    */
   me.queryMetadata = async function (layer) {
     const url = HsLayerUtilsService.getURL(layer);
@@ -222,7 +223,11 @@ export default function (
             layer.set('MetadataURL', metadata);
             return layer;
           }
-          if (angular.isUndefined(layer.get('Layer')[0].MetadataURL)) {
+          if (
+            layer.get('MetadataURL') === undefined &&
+            layer.get('Layer') &&
+            layer.get('Layer')[0].MetadataURL === undefined
+          ) {
             layer.set('MetadataURL', {
               '0': caps.Service,
             });
@@ -246,7 +251,7 @@ export default function (
           return true;
         })
         .catch((e) => {
-          console.log('GetCapabilities call invalid', e);
+          console.warn('GetCapabilities call invalid', e);
           return e;
         });
       return capabilities;


### PR DESCRIPTION
Can be used like this: <s>http://localhost:8080/?wms_to_connect=https://hub.lesprojekt.cz/client/geoserver/viktorie_sloupova/ows&visible_layers=af_suicide_rate</s>

New implementation is following:
localhost:8080/?wms_to_connect=https://hub.lesprojekt.cz/client/geoserver/viktorie_sloupova/ows&wms_layers=africa_driving_side
or
localhost:8080/?wfs_to_connect=https://hub.lesprojekt.cz/client/geoserver/viktorie_sloupova/wfs&wfs_layers=af_suicide_rate
respectively.
Advantage: It does not override `visible_layers` property, hence it does not disable basemaps if they were turned on by other means.

fixes #1176 