### PR TITLE
Load composition also from Layman URL

### DIFF
--- a/components/compositions/compositions-parser.service.js
+++ b/components/compositions/compositions-parser.service.js
@@ -104,9 +104,14 @@ export default function (
             .then((res) => {
               if (res.data.file) {
                 // Layman composition wrapper
-                me.loadUrl(res.data.file.url, overwrite, callback, pre_parse);
+                return me.loadUrl(
+                  res.data.file.url,
+                  overwrite,
+                  callback,
+                  pre_parse
+                );
               } else {
-                me.loaded(res);
+                return me.loaded(res);
               }
             })
             .then(() => {
@@ -290,7 +295,11 @@ export default function (
           respError.abstract =
             'Sorry but composition was deleted or incorrectly saved';
           break;
+        default:
+          respError.title = 'Unknown error happened while loading composition';
+          respError.abstract = response.error.toString();
       }
+      console.warn(response.error);
       $rootScope.$broadcast('compositions.composition_loaded', respError);
     },
 

--- a/components/compositions/compositions.service.js
+++ b/components/compositions/compositions.service.js
@@ -259,7 +259,13 @@ export default function (
       if (!id.includes('http') && !id.includes(HsConfig.status_manager_url)) {
         id = HsStatusManagerService.endpointUrl() + '?request=load&id=' + id;
       }
-      HsCompositionsParserService.loadUrl(id);
+      HsCompositionsParserService.loadUrl(id).catch((e) => {
+        console.warn(e);
+        HsCompositionsParserService.createErrorDialog(
+          'Composition not found',
+          e.data
+        );
+      });
     }
   }
 

--- a/components/compositions/compositions.service.js
+++ b/components/compositions/compositions.service.js
@@ -256,10 +256,7 @@ export default function (
   function tryParseCompositionFromUrlParam() {
     if (HsPermalinkUrlService.getParamValue('composition')) {
       let id = HsPermalinkUrlService.getParamValue('composition');
-      if (
-        id.indexOf('http') == -1 &&
-        id.indexOf(HsConfig.status_manager_url) == -1
-      ) {
+      if (!id.includes('http') && !id.includes(HsConfig.status_manager_url)) {
         id = HsStatusManagerService.endpointUrl() + '?request=load&id=' + id;
       }
       HsCompositionsParserService.loadUrl(id);

--- a/components/draw/draw.controller.js
+++ b/components/draw/draw.controller.js
@@ -134,7 +134,7 @@ export default function (
 
     controlLayerListAction() {
       if (!HsDrawService.hasSomeDrawables && HsDrawService.tmpDrawLayer) {
-        HsDrawService.saveDrawingLayer($scope);
+        HsDrawService.saveDrawingLayer();
       } else {
         $scope.layersExpanded = !$scope.layersExpanded;
       }


### PR DESCRIPTION
Improves the loading of compositions from URL param so additionally to this
http://localhost:8080/?composition=https://hub.lesprojekt.cz/rest/vacha/maps/co_ja_vim/file
we now also load from this
http://localhost:8080/?composition=https://hub.lesprojekt.cz/rest/vacha/maps/co_ja_vim
and also if the URL is malformed, a proper error message is displayed to the user (instead of just error raising in the console).

fixes #1178 