### PR TITLE
Remove /po and bootstrap-isolate from NPM files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "/dist",
     "/img",
     "/lib",
-    "/po",
-    "/scripts/bootstrap-isolate.js",
     "ajs-app.ts",
     "ajs-upgraded-providers.ts",
     "app.module.ts",


### PR DESCRIPTION
One tiny change to make the release in NPM a bit smaller.

/po directory was superseded by /assets/locales
bootstrap-isolate.js was superseded by SASS