### PR TITLE
Dont re-add baselayers

### DIFF
--- a/components/map/map.service.ts
+++ b/components/map/map.service.ts
@@ -557,7 +557,9 @@ export class HsMapService {
     visibilityOverrides?: Array<string>
   ): Layer {
     if (removeIfExists && this.layerAlreadyExists(lyr)) {
-      this.removeDuplicate(lyr);
+      if (lyr.get('base') == true) {
+        return;
+      }
     }
     if (visibilityOverrides) {
       lyr.setVisible(this.layerTitleInArray(lyr, visibilityOverrides));


### PR DESCRIPTION
Prevents layers from getting under the base map on permalink layer load. Should be enough to fix #1390 