### PR TITLE
Handle 404 in describeLayer properly

### DIFF
--- a/components/save-map/layman.service.ts
+++ b/components/save-map/layman.service.ts
@@ -355,7 +355,7 @@ export class HsLaymanService implements HsSaverService {
         return response;
       }
     } catch (ex) {
-      if (ex.error.code == 15) {
+      if (ex.error?.code == 15) {
         return null;
       } else {
         this.HsLogService.error(ex);

--- a/components/save-map/layman.service.ts
+++ b/components/save-map/layman.service.ts
@@ -260,6 +260,7 @@ export class HsLaymanService implements HsSaverService {
   /**
    * @function pullVectorSource
    * @memberof HsLaymanService
+   * @param _endpoint
    * @param layer
    * @public
    * @param {object} endpoint Endpoint description
@@ -350,15 +351,16 @@ export class HsLaymanService implements HsSaverService {
           }/layers/${layerName}?${Math.random()}`
         )
         .toPromise();
-      if (response?.code == 15) {
-        return null;
-      }
       if (response.name) {
         return response;
       }
     } catch (ex) {
-      this.HsLogService.error(ex);
-      throw ex;
+      if (ex.error.code == 15) {
+        return null;
+      } else {
+        this.HsLogService.error(ex);
+        throw ex;
+      }
     }
   }
 


### PR DESCRIPTION
 - Not possible to upload new layer to layman.
When layer was not found on Layman, server responded with code 404 which needs to be handled inside catch block. Maybe some change on layman side after the update