### PR TITLE
Issue 1415/layers sorted to much

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -29,7 +29,7 @@
       "tileMatrix": "Matice dlaždic"
     },
     "addSelected": "Přidat označené vrstvy do mapy",
-    "before": "Přidat před vrstvu",
+    "under": "Přidat pod vrstvu",
     "chooseFormat": "Vyberte formát",
     "chooseType": "Vyberte typ",
     "considerUsingTiles": "Zvažte použití dlaždic. Některé servery mají omezenou maximální velikost obrazu.",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -29,7 +29,7 @@
       "tileMatrix": "Tile matrix"
     },
     "addSelected": "Add selected layers to the map",
-    "before": "Add before layer",
+    "under": "Add under layer",
     "chooseFormat": "Choose format",
     "chooseType": "Choose type",
     "considerUsingTiles": "Consider using tiles. Some servers has restricted max size of picture.",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -29,7 +29,7 @@
       "tileMatrix": "\"Flīžu\" matrica"
     },
     "addSelected": "Pievienot izvēlētos slāņus kartei",
-    "before": "Pievienot pirms slāņa",
+    "under": "Pievienot zem slāņa",
     "chooseFormat": "Izvēlieties formātu",
     "chooseType": "Izvēlieties tipu",
     "considerUsingTiles": "Apsveriet \"flīžu\" izmantošanu. Dažos serveros ir ierobežots maksimālais attēla lielums.",

--- a/projects/hslayers/src/components/add-layers/add-layers.service.ts
+++ b/projects/hslayers/src/components/add-layers/add-layers.service.ts
@@ -20,25 +20,21 @@ export class HsAddLayersService {
       const layers = this.hsMapService.map.getLayers();
       if (this.HsConfig.reverseLayerList) {
         layer.setZIndex(addBefore.getZIndex() + 1);
-        layers.forEach((mapLayer) => {
-          if (layer.get('base') != true) {
-            if (
-              mapLayer.getZIndex() == layer.getZIndex() ||
-              mapLayer.getZIndex() == prevLayerZIndex
-            ) {
-              mapLayer.setZIndex(mapLayer.getZIndex() + 1);
-              prevLayerZIndex = mapLayer.getZIndex();
-            }
-          }
-        });
       } else {
         layer.setZIndex(addBefore.getZIndex());
-        layers.forEach((layer) => {
-          if (layer.get('base') != true) {
-            layer.setZIndex(layer.getZIndex() + 1);
-          }
-        });
       }
+      layers.forEach((mapLayer) => {
+        if (layer.get('base') != true) {
+          if (
+            mapLayer.getZIndex() == layer.getZIndex() ||
+            mapLayer.getZIndex() == prevLayerZIndex
+          ) {
+            mapLayer.setZIndex(mapLayer.getZIndex() + 1);
+            prevLayerZIndex = mapLayer.getZIndex();
+          }
+        }
+      });
+
       const ix = layers.getArray().indexOf(addBefore);
       layers.insertAt(ix, layer);
     } else {

--- a/projects/hslayers/src/components/add-layers/add-layers.service.ts
+++ b/projects/hslayers/src/components/add-layers/add-layers.service.ts
@@ -18,7 +18,7 @@ export class HsAddLayersService {
     if (addBefore) {
       let prevLayerZIndex: number;
       const layers = this.hsMapService.map.getLayers();
-      if (this.HsConfig.layer_order === 'desc') {
+      if (this.HsConfig.reverseLayerList) {
         layer.setZIndex(addBefore.getZIndex() + 1);
         layers.forEach((mapLayer) => {
           if (layer.get('base') != true) {

--- a/projects/hslayers/src/components/add-layers/add-layers.service.ts
+++ b/projects/hslayers/src/components/add-layers/add-layers.service.ts
@@ -14,29 +14,18 @@ export class HsAddLayersService {
     public HsConfig: HsConfig
   ) {}
 
-  addLayer(layer: BaseLayer, addBefore?: BaseLayer) {
-    if (addBefore) {
-      let prevLayerZIndex: number;
-      const layers = this.hsMapService.map.getLayers();
-      if (this.HsConfig.reverseLayerList) {
-        layer.setZIndex(addBefore.getZIndex() + 1);
-      } else {
-        layer.setZIndex(addBefore.getZIndex());
-      }
-      layers.forEach((mapLayer) => {
-        if (layer.get('base') != true) {
-          if (
-            mapLayer.getZIndex() == layer.getZIndex() ||
-            mapLayer.getZIndex() == prevLayerZIndex
-          ) {
-            mapLayer.setZIndex(mapLayer.getZIndex() + 1);
-            prevLayerZIndex = mapLayer.getZIndex();
-          }
+  addLayer(layer: BaseLayer, underLayer?: BaseLayer) {
+    if (underLayer) {
+      const layers = this.hsMapService.getLayersArray();
+      const underZ = underLayer.getZIndex();
+      layer.setZIndex(underZ);
+      for (const iLayer of layers.filter((l) => !l.get('base'))) {
+        if (iLayer.getZIndex() >= underZ) {
+          iLayer.setZIndex(iLayer.getZIndex() + 1);
         }
-      });
-
-      const ix = layers.getArray().indexOf(addBefore);
-      layers.insertAt(ix, layer);
+      }
+      const ix = layers.indexOf(underLayer);
+      this.hsMapService.map.getLayers().insertAt(ix, layer);
     } else {
       this.hsMapService.map.addLayer(layer);
     }

--- a/projects/hslayers/src/components/add-layers/add-layers.service.ts
+++ b/projects/hslayers/src/components/add-layers/add-layers.service.ts
@@ -1,4 +1,5 @@
 import BaseLayer from 'ol/layer/Base';
+import {HsConfig} from './../../config.service';
 import {HsMapService} from '../map/map.service';
 import {HsUtilsService} from '../utils/utils.service';
 import {Injectable} from '@angular/core';
@@ -9,12 +10,35 @@ import {Injectable} from '@angular/core';
 export class HsAddLayersService {
   constructor(
     public hsMapService: HsMapService,
-    public hsUtilsService: HsUtilsService
+    public hsUtilsService: HsUtilsService,
+    public HsConfig: HsConfig
   ) {}
 
   addLayer(layer: BaseLayer, addBefore?: BaseLayer) {
     if (addBefore) {
+      let prevLayerZIndex: number;
       const layers = this.hsMapService.map.getLayers();
+      if (this.HsConfig.layer_order === 'desc') {
+        layer.setZIndex(addBefore.getZIndex() + 1);
+        layers.forEach((mapLayer) => {
+          if (layer.get('base') != true) {
+            if (
+              mapLayer.getZIndex() == layer.getZIndex() ||
+              mapLayer.getZIndex() == prevLayerZIndex
+            ) {
+              mapLayer.setZIndex(mapLayer.getZIndex() + 1);
+              prevLayerZIndex = mapLayer.getZIndex();
+            }
+          }
+        });
+      } else {
+        layer.setZIndex(addBefore.getZIndex());
+        layers.forEach((layer) => {
+          if (layer.get('base') != true) {
+            layer.setZIndex(layer.getZIndex() + 1);
+          }
+        });
+      }
       const ix = layers.getArray().indexOf(addBefore);
       layers.insertAt(ix, layer);
     } else {

--- a/projects/hslayers/src/components/add-layers/common/add-layers-target-position.component.html
+++ b/projects/hslayers/src/components/add-layers/common/add-layers-target-position.component.html
@@ -1,9 +1,9 @@
 <div class="form-group">
     <div class="input-group">
         <div class="input-group-prepend">
-            <span class="input-group-text control-label">{{'ADDLAYERS.before' | translate}}</span>
+            <span class="input-group-text control-label">{{'ADDLAYERS.under' | translate}}</span>
         </div>
-        <select class="form-control" [(ngModel)]="addBefore" (ngModelChange)="updateChanges()" name="addBefore">
+        <select class="form-control" [(ngModel)]="addUnder" (ngModelChange)="updateChanges()" name="addUnder">
             <option [ngValue]="null" selected>{{'ADDLAYERS.none' | translate}}</option>
             <option [ngValue]="layer.layer" *ngFor="let layer of hsLayerManagerService.data.layers">{{hsLayerUtilsService.translateTitle(layer.title)}}</option>
         </select>

--- a/projects/hslayers/src/components/add-layers/common/add-layers-target-position.component.ts
+++ b/projects/hslayers/src/components/add-layers/common/add-layers-target-position.component.ts
@@ -8,8 +8,8 @@ import {HsLayerUtilsService} from '../../utils/layer-utils.service';
   templateUrl: './add-layers-target-position.component.html',
 })
 export class HsAddLayersTargetPositionComponent {
-  @Input() addBefore: BaseLayer | null; // @type'; TODO: comes from another scope
-  @Output() addBeforeChange = new EventEmitter<BaseLayer | null>();
+  @Input() addUnder: BaseLayer | null; // @type'; TODO: comes from another scope
+  @Output() addUnderChange = new EventEmitter<BaseLayer | null>();
 
   constructor(
     public hsLayerUtilsService: HsLayerUtilsService,
@@ -17,6 +17,6 @@ export class HsAddLayersTargetPositionComponent {
   ) {}
 
   updateChanges(): void {
-    this.addBeforeChange.next(this.addBefore);
+    this.addUnderChange.next(this.addUnder);
   }
 }

--- a/projects/hslayers/src/components/add-layers/shp/add-layers-shp.component.ts
+++ b/projects/hslayers/src/components/add-layers/shp/add-layers-shp.component.ts
@@ -31,7 +31,7 @@ export class HsAddLayersShpComponent implements OnInit {
   title = '';
   folder_name = '';
   advancedPanelVisible = false;
-  addBefore: BaseLayer = null;
+  addUnder: BaseLayer = null;
 
   constructor(
     public hsAddLayersShpService: HsAddLayersShpService,

--- a/projects/hslayers/src/components/add-layers/vector/add-layers-vector.component.ts
+++ b/projects/hslayers/src/components/add-layers/vector/add-layers-vector.component.ts
@@ -23,7 +23,7 @@ export class HsAddLayersVectorComponent {
   featureCount = 0;
   type = '';
   errorOccured = false;
-  addBefore: BaseLayer = null;
+  addUnder: BaseLayer = null;
 
   constructor(
     public hsAddLayersVectorService: HsAddLayersVectorService,
@@ -62,7 +62,7 @@ export class HsAddLayersVectorComponent {
         features: this.features,
         path: this.folder_name,
       },
-      this.addBefore
+      this.addUnder
     );
     this.hsAddLayersVectorService.fitExtent(layer);
     this.hsLayoutService.setMainPanel('layermanager');

--- a/projects/hslayers/src/components/add-layers/vector/add-layers-vector.component.ts
+++ b/projects/hslayers/src/components/add-layers/vector/add-layers-vector.component.ts
@@ -60,7 +60,7 @@ export class HsAddLayersVectorComponent {
       {
         extractStyles: this.extract_styles,
         features: this.features,
-        path: this.folder_name,
+        path: this.folder_name.trim() != '' ? this.folder_name : undefined,
       },
       this.addUnder
     );

--- a/projects/hslayers/src/components/add-layers/vector/add-layers-vector.service.ts
+++ b/projects/hslayers/src/components/add-layers/vector/add-layers-vector.service.ts
@@ -58,7 +58,7 @@ export class HsAddLayersVectorService {
    * @param name
    * @param {string} title Title of new layer
    * @param {string} abstract Abstract of new layer
-   * @param addBefore
+   * @param addUnder
    * @param {string} srs EPSG code of selected projection (eg. "EPSG:4326")
    * @param {object} options Other options
    * @returns {Promise} Return Promise which return OpenLayers vector layer
@@ -71,7 +71,7 @@ export class HsAddLayersVectorService {
     abstract: string,
     srs: string,
     options: HsVectorLayerOptions,
-    addBefore?: BaseLayer
+    addUnder?: BaseLayer
   ): Promise<VectorLayer> {
     return new Promise((resolve, reject) => {
       try {
@@ -99,7 +99,7 @@ export class HsAddLayersVectorService {
           });
         }
         if (this.HsMapService.map) {
-          this.hsAddLayersService.addLayer(lyr, addBefore);
+          this.hsAddLayersService.addLayer(lyr, addUnder);
         }
         resolve(lyr);
       } catch (ex) {

--- a/projects/hslayers/src/components/add-layers/vector/add-vector-layer.directive.html
+++ b/projects/hslayers/src/components/add-layers/vector/add-vector-layer.directive.html
@@ -58,7 +58,7 @@
         </div>
 
         <div class="form-group">
-            <hs-add-layers-target-position [(addBefore)]="addBefore" ></hs-add-layers-target-position>
+            <hs-add-layers-target-position [(addUnder)]="addUnder" ></hs-add-layers-target-position>
         </div>
     </div>
 

--- a/projects/hslayers/src/components/add-layers/wms/add-layers-wms.service.ts
+++ b/projects/hslayers/src/components/add-layers/wms/add-layers-wms.service.ts
@@ -39,7 +39,7 @@ export class HsAddLayersWmsService {
       mapProjection: undefined,
       registerMetadata: true,
       tileSize: 512,
-      addBefore: null,
+      addUnder: null,
     };
     //TODO: all dimension related things need to be refactored into seperate module
     this.getDimensionValues = hsDimensionService.getDimensionValues;
@@ -384,14 +384,14 @@ export class HsAddLayersWmsService {
       subLayers: subLayers,
     });
     this.hsMapService.proxifyLayerLoader(new_layer, this.data.useTiles);
-    this.hsAddLayersService.addLayer(new_layer, this.data.addBefore);
+    this.hsAddLayersService.addLayer(new_layer, this.data.addUnder);
   }
 
   /**
    * @description Add service and its layers to project
    * @function addService
    * @param {string} url Service url
-   * @param addBefore {BaseLayer} OL layer before which to add new layer
+   * @param addUnder {BaseLayer} OL layer before which to add new layer
    * @param path {string} Folder name with path to group layers
    * @param {Group} group Group layer to which add layer to
    * @param {string} layerName Name of layer to add. If not specified then all layers are added
@@ -400,7 +400,7 @@ export class HsAddLayersWmsService {
     url: string,
     group: Group,
     layerName: string,
-    addBefore?: BaseLayer,
+    addUnder?: BaseLayer,
     path?: string
   ): void {
     this.hsWmsGetCapabilitiesService
@@ -422,7 +422,7 @@ export class HsAddLayersWmsService {
           if (group !== undefined) {
             group.addLayer(layer);
           } else {
-            this.hsAddLayersService.addLayer(layer, addBefore);
+            this.hsAddLayersService.addLayer(layer, addUnder);
           }
         });
       });

--- a/projects/hslayers/src/components/add-layers/wms/add-wms-layer.directive.html
+++ b/projects/hslayers/src/components/add-layers/wms/add-wms-layer.directive.html
@@ -76,7 +76,7 @@
             </div>
         </div>
 
-        <hs-add-layers-target-position [(addBefore)]="data.addBefore" ></hs-add-layers-target-position>
+        <hs-add-layers-target-position [(addUnder)]="data.addUnder" ></hs-add-layers-target-position>
        
         <hr />
         <table class="table table-sm table-striped table-bordered">

--- a/projects/hslayers/src/components/compositions/compositions.spec.ts
+++ b/projects/hslayers/src/components/compositions/compositions.spec.ts
@@ -33,7 +33,7 @@ import {TranslateModule} from '@ngx-translate/core';
 import {compositionJson} from '../../../test/data/composition';
 import {compositionsJson} from '../../../test/data/compositions';
 class HsConfigMock {
-  layer_order = '-position';
+  reverseLayerList = true;
   constructor() {}
 }
 

--- a/projects/hslayers/src/components/core/event-bus.service.ts
+++ b/projects/hslayers/src/components/core/event-bus.service.ts
@@ -119,10 +119,5 @@ export class HsEventBusService {
   layerSelectedFromUrl: BehaviorSubject<VectorLayer> = new BehaviorSubject(
     null
   );
-  /**
-   * @event layerPositionUpdates
-   * @description Fires when layer is moved up or down in physical layer list
-   */
-  layerPositionUpdates: Subject<void> = new Subject();
   constructor() {}
 }

--- a/projects/hslayers/src/components/layermanager/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor.component.ts
@@ -386,6 +386,7 @@ export class HsLayerEditorComponent {
       layer,
     });
     layer.set('title', newLayerTitle);
+    this.HsEventBusService.layerManagerUpdates.next();
   }
 
   get title(): string {

--- a/projects/hslayers/src/components/layermanager/layer-editor.spec.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor.spec.ts
@@ -35,7 +35,7 @@ import {TranslateModule} from '@ngx-translate/core';
 import {Vector as VectorSource} from 'ol/source';
 
 class HsConfigMock {
-  layer_order = '-position';
+  reverseLayerList = true;
   layersInFeatureTable = [];
   constructor() {}
 }

--- a/projects/hslayers/src/components/layermanager/layer-list.spec.ts
+++ b/projects/hslayers/src/components/layermanager/layer-list.spec.ts
@@ -135,9 +135,12 @@ describe('layermanager-layer-list', () => {
   });
 
   it('should list sublayers', () => {
-    component['HsLayerManagerService'].layerAdded({
-      element: subLayerContainerLayer,
-    });
+    component['HsLayerManagerService'].layerAdded(
+      {
+        element: subLayerContainerLayer,
+      },
+      false
+    );
     expect(component).toBeTruthy();
     expect(window.console.error).not.toHaveBeenCalled();
   });

--- a/projects/hslayers/src/components/layermanager/layer-list.spec.ts
+++ b/projects/hslayers/src/components/layermanager/layer-list.spec.ts
@@ -139,7 +139,7 @@ describe('layermanager-layer-list', () => {
       {
         element: subLayerContainerLayer,
       },
-      false
+      true
     );
     expect(component).toBeTruthy();
     expect(window.console.error).not.toHaveBeenCalled();

--- a/projects/hslayers/src/components/layermanager/layer-list.spec.ts
+++ b/projects/hslayers/src/components/layermanager/layer-list.spec.ts
@@ -33,7 +33,7 @@ import {Vector as VectorSource} from 'ol/source';
 import {wmsGetCapabilitiesResponse} from '../../../test/data/wms-capabilities';
 
 class HsConfigMock {
-  layer_order = '-position';
+  reverseLayerList = true;
   constructor() {}
 }
 

--- a/projects/hslayers/src/components/layermanager/layermanager-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-layerlist.component.ts
@@ -38,10 +38,10 @@ export class HsLayerListComponent {
     public HsLayerUtilsService: HsLayerUtilsService
   ) {
     this.HsEventBusService.layerManagerUpdates.subscribe(() => {
-      this.sortLayersByPosition();
+      this.updateLayers();
     });
     this.HsEventBusService.layerPositionUpdates.subscribe(() => {
-      this.sortLayersByPosition();
+      this.updateLayers();
     });
   }
   /**
@@ -119,7 +119,6 @@ export class HsLayerListComponent {
      * @description List of layers which belong to folder hierarchy level of directive instance
      */
     this.filtered_layers = this.filterLayers();
-    this.sortLayersByPosition();
   }
 
   /**
@@ -157,11 +156,9 @@ export class HsLayerListComponent {
     }
   }
 
-
-
   /**
    * @function isLayerQueryable
-   * @memberOf hs.layermanager.controller
+   * @memberOf hs.layermanager.layerlist
    * @param {object} layer_container Selected layer - wrapped in layer object
    * @description Test if layer is queryable (WMS layer with Info format)
    */
@@ -171,15 +168,12 @@ export class HsLayerListComponent {
 
   /**
    * @ngdoc method
-   * @name hs.layermanager.layerlistDirective#sortLayersByPosition
+   * @name hs.layermanager.layerlist#updateLayers
    * @private
-   * @description Sort layers by computed position
+   * @description Update layers list
    */
-  sortLayersByPosition(): void {
+  updateLayers(): void {
     this.filtered_layers = this.filterLayers();
-    this.filtered_layers = this.HsLayerManagerService.sortLayersByZ(
-      this.filtered_layers
-    );
     this.generateLayerTitlesArray();
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-layerlist.component.ts
@@ -38,9 +38,7 @@ export class HsLayerListComponent {
     public HsLayerUtilsService: HsLayerUtilsService
   ) {
     this.HsEventBusService.layerManagerUpdates.subscribe(() => {
-      this.updateLayers();
-    });
-    this.HsEventBusService.layerPositionUpdates.subscribe(() => {
+      this.HsLayerManagerService.updateLayerListPositions();
       this.updateLayers();
     });
   }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -72,7 +72,6 @@ export class HsLayerPhysicalListComponent {
     const interactedLayerZIndex = layer.getZIndex();
     layer.setZIndex(layerSwitchedWith.getZIndex());
     layerSwitchedWith.setZIndex(interactedLayerZIndex);
-    this.HsLayerManagerService.updateLayerListPositions();
-    this.layersCopy = this.HsLayerManagerService.sortLayersByZ(this.layersCopy);
+    this.HsEventBusService.layerManagerUpdates.next();
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -33,13 +33,6 @@ export class HsLayerPhysicalListComponent {
       this.layersCopy = this.layers.map((l) => {
         return {title: l.title, layer: l.layer};
       });
-      console.log('Before', this.layersCopy);
-      if (this.HsConfig.reverseLayerList) {
-        this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
-          this.layersCopy
-        );
-      }
-      console.log('After', this.layersCopy);
     });
   }
   moveLayer(layer, orient: string): void {

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -22,7 +22,6 @@ export class HsLayerPhysicalListComponent {
     layer: BaseLayer;
     active?: boolean;
   }> = [];
-  previoslySelectedLayer: any;
   constructor(
     public HsLayerManagerService: HsLayerManagerService,
     public HsLayerUtilsService: HsLayerUtilsService,
@@ -30,40 +29,26 @@ export class HsLayerPhysicalListComponent {
     public HsConfig: HsConfig
   ) {
     this.fillLayers();
-    this.HsEventBusService.layerManagerUpdates.subscribe(
-      (suspendListSourceUpdate: boolean) => {
-        this.fillLayers(suspendListSourceUpdate);
+    this.HsEventBusService.layerManagerUpdates.subscribe((layer: any) => {
+      this.fillLayers();
+      if (layer !== undefined) {
+        this.layersCopy.find((wrapper) => wrapper.layer == layer).active = true;
       }
-    );
+    });
   }
 
-  private fillLayers(suspendListSourceUpdate?: boolean) {
+  private fillLayers() {
     if (this.layers == undefined) {
       return;
     }
-    if (
-      suspendListSourceUpdate !== undefined &&
-      typeof suspendListSourceUpdate == 'boolean' &&
-      suspendListSourceUpdate
-    ) {
-      this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
-        this.layersCopy
-      );
-    } else {
-      this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
-        this.layers.map((l) => {
-          return {title: l.title, layer: l.layer};
-        })
-      );
-    }
+    this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
+      this.layers.map((l) => {
+        return {title: l.title, layer: l.layer};
+      })
+    );
   }
 
   moveLayer(layer, orient: string): void {
-    if (this.previoslySelectedLayer !== undefined) {
-      this.previoslySelectedLayer.active = false;
-    }
-    layer.active = true;
-    this.previoslySelectedLayer = layer;
     const currentLayerIndex = this.layersCopy.indexOf(layer);
     switch (orient) {
       case 'up':
@@ -84,7 +69,6 @@ export class HsLayerPhysicalListComponent {
     const interactedLayerZIndex = layer.getZIndex();
     layer.setZIndex(layerSwitchedWith.getZIndex());
     layerSwitchedWith.setZIndex(interactedLayerZIndex);
-    const suspendListSourceUpdate = true;
-    this.HsEventBusService.layerManagerUpdates.next(suspendListSourceUpdate);
+    this.HsEventBusService.layerManagerUpdates.next(layer);
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -33,11 +33,13 @@ export class HsLayerPhysicalListComponent {
       this.layersCopy = this.layers.map((l) => {
         return {title: l.title, layer: l.layer};
       });
+      console.log('Before', this.layersCopy);
       if (this.HsConfig.reverseLayerList) {
         this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
           this.layersCopy
         );
       }
+      console.log('After', this.layersCopy);
     });
   }
   moveLayer(layer, orient: string): void {

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -36,6 +36,9 @@ export class HsLayerPhysicalListComponent {
   }
 
   private fillLayers() {
+    if (this.layers == undefined) {
+      return;
+    }
     this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
       this.layers.map((l) => {
         return {title: l.title, layer: l.layer};
@@ -69,9 +72,6 @@ export class HsLayerPhysicalListComponent {
     const interactedLayerZIndex = layer.getZIndex();
     layer.setZIndex(layerSwitchedWith.getZIndex());
     layerSwitchedWith.setZIndex(interactedLayerZIndex);
-    this.sortLayers();
-  }
-  sortLayers(): void {
     this.HsLayerManagerService.updateLayerListPositions();
     this.layersCopy = this.HsLayerManagerService.sortLayersByZ(this.layersCopy);
   }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -29,12 +29,20 @@ export class HsLayerPhysicalListComponent {
     public HsEventBusService: HsEventBusService,
     public HsConfig: HsConfig
   ) {
+    this.fillLayers();
     this.HsEventBusService.layerManagerUpdates.subscribe(() => {
-      this.layersCopy = this.layers.map((l) => {
-        return {title: l.title, layer: l.layer};
-      });
+      this.fillLayers();
     });
   }
+
+  private fillLayers() {
+    this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
+      this.layers.map((l) => {
+        return {title: l.title, layer: l.layer};
+      })
+    );
+  }
+
   moveLayer(layer, orient: string): void {
     if (this.previoslySelectedLayer !== undefined) {
       this.previoslySelectedLayer.active = false;

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -71,6 +71,5 @@ export class HsLayerPhysicalListComponent {
   sortLayers(): void {
     this.HsLayerManagerService.updateLayerListPositions();
     this.layersCopy = this.HsLayerManagerService.sortLayersByZ(this.layersCopy);
-    this.HsEventBusService.layerPositionUpdates.next();
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -31,7 +31,6 @@ export class HsLayerPhysicalListComponent {
       this.layersCopy = this.layers.map((l) => {
         return {title: l.title, layer: l.layer};
       });
-      this.sortLayers();
     });
   }
   moveLayer(layer, orient: string): void {
@@ -60,10 +59,12 @@ export class HsLayerPhysicalListComponent {
     const interactedLayerZIndex = layer.getZIndex();
     layer.setZIndex(layerSwitchedWith.getZIndex());
     layerSwitchedWith.setZIndex(interactedLayerZIndex);
-    this.HsEventBusService.layerPositionUpdates.next();
     this.sortLayers();
   }
   sortLayers(): void {
-    this.layersCopy = this.HsLayerManagerService.sortLayersByZ(this.layersCopy);
+    this.layersCopy = this.HsLayerManagerService.updateLayerListPositions(
+      this.layersCopy
+    );
+    this.HsEventBusService.layerPositionUpdates.next();
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -30,20 +30,32 @@ export class HsLayerPhysicalListComponent {
     public HsConfig: HsConfig
   ) {
     this.fillLayers();
-    this.HsEventBusService.layerManagerUpdates.subscribe(() => {
-      this.fillLayers();
-    });
+    this.HsEventBusService.layerManagerUpdates.subscribe(
+      (suspendListSourceUpdate: boolean) => {
+        this.fillLayers(suspendListSourceUpdate);
+      }
+    );
   }
 
-  private fillLayers() {
+  private fillLayers(suspendListSourceUpdate?: boolean) {
     if (this.layers == undefined) {
       return;
     }
-    this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
-      this.layers.map((l) => {
-        return {title: l.title, layer: l.layer};
-      })
-    );
+    if (
+      suspendListSourceUpdate !== undefined &&
+      typeof suspendListSourceUpdate == 'boolean' &&
+      suspendListSourceUpdate
+    ) {
+      this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
+        this.layersCopy
+      );
+    } else {
+      this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
+        this.layers.map((l) => {
+          return {title: l.title, layer: l.layer};
+        })
+      );
+    }
   }
 
   moveLayer(layer, orient: string): void {
@@ -72,6 +84,7 @@ export class HsLayerPhysicalListComponent {
     const interactedLayerZIndex = layer.getZIndex();
     layer.setZIndex(layerSwitchedWith.getZIndex());
     layerSwitchedWith.setZIndex(interactedLayerZIndex);
-    this.HsEventBusService.layerManagerUpdates.next();
+    const suspendListSourceUpdate = true;
+    this.HsEventBusService.layerManagerUpdates.next(suspendListSourceUpdate);
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-physical-layerlist.component.ts
@@ -1,5 +1,6 @@
 import BaseLayer from 'ol/layer/Base';
 import {Component, Input} from '@angular/core';
+import {HsConfig} from './../../config.service';
 import {HsEventBusService} from '../core/event-bus.service';
 import {HsLayerManagerService} from './layermanager.service';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
@@ -25,12 +26,18 @@ export class HsLayerPhysicalListComponent {
   constructor(
     public HsLayerManagerService: HsLayerManagerService,
     public HsLayerUtilsService: HsLayerUtilsService,
-    public HsEventBusService: HsEventBusService
+    public HsEventBusService: HsEventBusService,
+    public HsConfig: HsConfig
   ) {
     this.HsEventBusService.layerManagerUpdates.subscribe(() => {
       this.layersCopy = this.layers.map((l) => {
         return {title: l.title, layer: l.layer};
       });
+      if (this.HsConfig.reverseLayerList) {
+        this.layersCopy = this.HsLayerManagerService.sortLayersByZ(
+          this.layersCopy
+        );
+      }
     });
   }
   moveLayer(layer, orient: string): void {
@@ -62,9 +69,8 @@ export class HsLayerPhysicalListComponent {
     this.sortLayers();
   }
   sortLayers(): void {
-    this.layersCopy = this.HsLayerManagerService.updateLayerListPositions(
-      this.layersCopy
-    );
+    this.HsLayerManagerService.updateLayerListPositions();
+    this.layersCopy = this.HsLayerManagerService.sortLayersByZ(this.layersCopy);
     this.HsEventBusService.layerPositionUpdates.next();
   }
 }

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -200,7 +200,6 @@ export class HsLayerManagerService {
       this.data.layers.push(new_layer);
       if (sorting) {
         this.updateLayerListPositions();
-        this.HsEventBusService.layerPositionUpdates.next();
       }
       if (layer.get('queryCapabilities') != false) {
         this.HsLayerManagerMetadata.fillMetadata(layer).then(() => {
@@ -274,8 +273,13 @@ export class HsLayerManagerService {
       }
     }
   }
+  /**
+   * @description Sort layers which are added to map and registered
+   * in layermanager by Z and notify components that layer positions have changed.
+   */
   updateLayerListPositions(): void {
     this.data.layers = this.sortLayersByZ(this.data.layers);
+    this.HsEventBusService.layerPositionUpdates.next();
   }
   sortLayersByZ(arr: any[]): any[] {
     const minus = this.HsConfig.reverseLayerList || false;
@@ -877,7 +881,6 @@ export class HsLayerManagerService {
       );
     });
     this.updateLayerListPositions();
-    this.HsEventBusService.layerPositionUpdates.next();
     if (this.HsShareUrlService.getParamValue('layerSelected')) {
       const layerTitle = this.HsShareUrlService.getParamValue('layerSelected');
       const layerFound = await this.checkLayerFromUrl(layerTitle);

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -277,24 +277,15 @@ export class HsLayerManagerService {
       }
     }
   }
-  updateLayerListPositions(arr?: any[]): any[] {
+  updateLayerListPositions(): void {
     this.data.layers = this.sortLayersByZ(this.data.layers);
-    if (arr?.length > 0) {
-      const sortedArray = this.sortLayersByZ(arr);
-      return sortedArray;
-    } else {
-      return [];
-    }
-  }
-  layerOrderOrientation(): string {
-    return this.HsConfig.layer_order || 'desc';
   }
   sortLayersByZ(arr: any[]): any[] {
-    const desc = this.layerOrderOrientation().startsWith('desc');
+    const minus = this.HsConfig.reverseLayerList || false;
     return arr.sort((a, b) => {
       a = a.layer.getZIndex();
       b = b.layer.getZIndex();
-      const tmp = (a < b ? -1 : a > b ? 1 : 0) * (desc ? -1 : 1);
+      const tmp = (a < b ? -1 : a > b ? 1 : 0) * (minus ? -1 : 1);
       return tmp;
     });
   }

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -880,7 +880,6 @@ export class HsLayerManagerService {
         true
       );
     });
-    this.updateLayerListPositions();
     this.HsEventBusService.layerManagerUpdates.next();
     if (this.HsShareUrlService.getParamValue('layerSelected')) {
       const layerTitle = this.HsShareUrlService.getParamValue('layerSelected');
@@ -915,7 +914,6 @@ export class HsLayerManagerService {
         return;
       }
       this.layerAdded(e);
-      this.updateLayerListPositions();
     });
     this.map.getLayers().on('remove', (e) => this.layerRemoved(e));
   }

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -158,13 +158,10 @@ export class HsLayerManagerService {
         this.HsConfig.clusteringDistance
       );
     }
-    if (typeof layer.getZIndex() == 'undefined') {
-      layer.setZIndex(this.zIndexValue);
-      this.zIndexValue = ++this.zIndexValue;
-    } else {
-      if (layer.getZIndex() == this.zIndexValue) {
-        this.zIndexValue = ++this.zIndexValue;
-      }
+    if (layer.getZIndex() == undefined) {
+      layer.setZIndex(this.zIndexValue++);
+    } else if (layer.getZIndex() > this.zIndexValue) {
+      this.zIndexValue = layer.getZIndex() + 1;
     }
 
     /**

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -279,7 +279,6 @@ export class HsLayerManagerService {
   updateLayerListPositions(): void {
     //TODO: We could also sort by title or other property. Not supported right now though, just zIndex
     this.data.layers = this.sortLayersByZ(this.data.layers);
-    this.HsEventBusService.layerPositionUpdates.next();
   }
   sortLayersByZ(arr: any[]): any[] {
     const minus = this.HsConfig.reverseLayerList || false;

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -200,6 +200,7 @@ export class HsLayerManagerService {
         new_layer.legends = layer.get('legends');
       }
       this.data.layers.push(new_layer);
+      this.updateLayerListPositions();
       if (layer.get('queryCapabilities') != false) {
         this.HsLayerManagerMetadata.fillMetadata(layer).then(() => {
           setTimeout(() => {
@@ -272,18 +273,26 @@ export class HsLayerManagerService {
       }
     }
   }
+  updateLayerListPositions(arr?: any[]): any[] {
+    this.data.layers = this.sortLayersByZ(this.data.layers);
+    if (arr?.length > 0) {
+      const sortedArray = this.sortLayersByZ(arr);
+      return sortedArray;
+    } else {
+      return [];
+    }
+  }
+  layerOrderOrientation(): string {
+    return this.HsConfig.layer_order || '+position';
+  }
   sortLayersByZ(arr: any[]): any[] {
-    const minus = this.order().indexOf('-') == 0;
-    arr.sort((a, b) => {
+    const minus = this.layerOrderOrientation().indexOf('-') == 0;
+    return arr.sort((a, b) => {
       a = a.layer.getZIndex();
       b = b.layer.getZIndex();
       const tmp = (a < b ? -1 : a > b ? 1 : 0) * (minus ? -1 : 1);
       return tmp;
     });
-    return arr;
-  }
-  order(): string {
-    return this.HsConfig.layer_order || '-position';
   }
   /**
    * (PRIVATE) Get layer by its title
@@ -591,7 +600,6 @@ export class HsLayerManagerService {
     }
     this.HsEventBusService.LayerManagerBaseLayerVisibilityChanges.next(layer);
   }
-
   /**
    * (PRIVATE)
    *

--- a/projects/hslayers/src/components/layermanager/partials/physical-layerlist.html
+++ b/projects/hslayers/src/components/layermanager/partials/physical-layerlist.html
@@ -3,7 +3,7 @@
         <li *ngFor="let layer of layersCopy;" class="list-group-item hs-lm-item" [ngClass]="{'activeLayer': layer.active}">
             <div class="d-flex"> 
                 <div class="align-items-center p-0 hs-lm-item-title flex-grow-1">
-                    {{HsLayerUtilsService.translateTitle(layer.title)}}{{layer.layer.getZIndex()}}
+                    {{HsLayerUtilsService.translateTitle(layer.title)}}
                 </div>
                 <div class="p-0 info_btn text-right">
                     <span class="icon-arrow-up" [title]="'LAYERMANAGER.layerList.moveLayerUp' | translate"

--- a/projects/hslayers/src/components/layermanager/partials/physical-layerlist.html
+++ b/projects/hslayers/src/components/layermanager/partials/physical-layerlist.html
@@ -3,7 +3,7 @@
         <li *ngFor="let layer of layersCopy;" class="list-group-item hs-lm-item" [ngClass]="{'activeLayer': layer.active}">
             <div class="d-flex"> 
                 <div class="align-items-center p-0 hs-lm-item-title flex-grow-1">
-                    {{HsLayerUtilsService.translateTitle(layer.title)}}
+                    {{HsLayerUtilsService.translateTitle(layer.title)}}{{layer.layer.getZIndex()}}
                 </div>
                 <div class="p-0 info_btn text-right">
                     <span class="icon-arrow-up" [title]="'LAYERMANAGER.layerList.moveLayerUp' | translate"

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -9,7 +9,6 @@ export class HsConfig {
   allowAddExternalDatasets?: boolean;
   sidebarClosed?: boolean;
   sidebarPosition?: string;
-  layer_order?: string;
   box_layers?: Array<any>;
   senslog?: {
     url: string;
@@ -94,6 +93,7 @@ export class HsConfig {
   assetsPath?: string;
 
   configChanges?: Subject<HsConfig> = new Subject();
+  reverseLayerList?: boolean;
   constructor() {}
 
   update?(newConfig: HsConfig): void {

--- a/projects/hslayers/src/hslayers.component.spec.ts
+++ b/projects/hslayers/src/hslayers.component.spec.ts
@@ -1,10 +1,10 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { HsConfig } from './config.service';
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {HsConfig} from './config.service';
 
-import { HslayersComponent } from './hslayers.component';
+import {HslayersComponent} from './hslayers.component';
 
 class HsConfigMock {
-  layer_order = '-position';
+  reverseLayerList = true;
   constructor() {}
 }
 
@@ -14,10 +14,9 @@ describe('HslayersComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HslayersComponent ],
-      providers: [{provide: HsConfig, useValue: new HsConfigMock()},]
-    })
-    .compileComponents();
+      declarations: [HslayersComponent],
+      providers: [{provide: HsConfig, useValue: new HsConfigMock()}],
+    }).compileComponents();
   }));
 
   beforeEach(() => {


### PR DESCRIPTION
![bug](https://user-images.githubusercontent.com/46564459/103010445-0db3a580-4541-11eb-9a6f-961667dddc40.png)
Optimized layer sorting, but found out a new bug! Adding layer from external data without providing folder, creates two lists of the same layers array.
P.s. ignore the numbers in the titles.