### PR TITLE
Ability to set Hslayers config through attribute

### DIFF
--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {HsConfig} from './config.service';
 
 @Component({
@@ -6,6 +6,12 @@ import {HsConfig} from './config.service';
   templateUrl: './hslayers.html',
   styles: [],
 })
-export class HslayersComponent {
+export class HslayersComponent implements OnInit {
+  @Input() config: HsConfig;
   constructor(public HsConfig: HsConfig) {}
+  ngOnInit(): void {
+    if (this.config) {
+      this.HsConfig.update(this.config);
+    }
+  }
 }


### PR DESCRIPTION
`<hslayers [config]="mapConfig"></hslayers>`

```
export class AppComponent {
  mapConfig: HsConfig = {
    assetsPath: 'assets/hslayers-ng',
    proxyPrefix: window.location.hostname.includes('localhost')
      ? `${window.location.protocol}//${window.location.hostname}:8085/`
      : '/proxy/',
    popUpDisplay: 'click',
    open_lm_after_comp_loaded: true,
...
```

Examples branch https://github.com/hslayers/examples/tree/issue-1486/config-attribute
examples/full has the implementation