### PR TITLE
Enhance capability of time-editor

### DIFF
--- a/projects/hslayers/src/components/layermanager/layermanager-wmst.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-wmst.service.ts
@@ -300,16 +300,3 @@ export class HsLayerManagerWmstService {
     return timePoints;
   }
 }
-
-declare global {
-  interface Date {
-    monthDiff: (d2) => number;
-  }
-}
-Date.prototype.monthDiff = function (d2) {
-  let months: number;
-  months = (d2.getFullYear() - this.getFullYear()) * 12;
-  months -= this.getMonth() + 1;
-  months += d2.getMonth();
-  return months <= 0 ? 0 : months;
-};


### PR DESCRIPTION
This PR is consecutive to #1597 and re-implements the possibility to use layers with time-points defined with Duration ISO string (like "1999-01-22T19:00:00/2018-01-22T13:00:00/PT8766H") in the new time-editor.

![image](https://user-images.githubusercontent.com/5598693/110480604-f66b6980-80e6-11eb-82b4-4c4056769a51.png)

Layer on the screenshot is "srazky_l_2000_2018_r" from "https://gis.lesprojekt.cz/cgi-bin/mapserv?map=/home/dima/maps/m_liberec.map".