### PR TITLE
fix: Encode features as Json object instead of string

### DIFF
--- a/projects/hslayers/src/components/compositions/compositions.spec.ts
+++ b/projects/hslayers/src/components/compositions/compositions.spec.ts
@@ -177,10 +177,16 @@ describe('compositions', () => {
 
   it('should load composition from json', function () {
     loadComposition(component);
-    expect(mockedMapService.map.getLayers().getLength()).toBe(4);
+    expect(mockedMapService.map.getLayers().getLength()).toBe(6);
     expect(getTitle(mockedMapService.map.getLayers().item(0))).toBe(
       'Measurement sketches'
     );
+    expect(
+      mockedMapService.map.getLayers().item(3).getSource().getFeatures().length
+    ).toBe(1);
+    expect(
+      mockedMapService.map.getLayers().item(4).getSource().getFeatures().length
+    ).toBe(1);
   });
 
   it('if should parse composition layer style', function () {

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -2,6 +2,7 @@ import SparqlJson from '../../../common/layers/hs.source.SparqlJson';
 import WMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
 import WMTSCapabilities from 'ol/format/WMTSCapabilities';
 import {Attribution} from 'ol/control';
+import {GeoJSON} from 'ol/format';
 import {
   ImageArcGISRest,
   ImageStatic,
@@ -418,6 +419,9 @@ export class HsCompositionsLayerParserService {
         layer = this.createSparqlLayer(lyr_def);
         break;
       default:
+        const features = lyr_def.features
+          ? new GeoJSON().readFeatures(lyr_def.features)
+          : undefined;
         layer = this.HsAddDataVectorService.createVectorLayer(
           '',
           undefined,
@@ -431,7 +435,7 @@ export class HsCompositionsLayerParserService {
             path: lyr_def.path,
             fromComposition: lyr_def.fromComposition,
             style: lyr_def.style,
-            features: lyr_def.features,
+            features,
           }
         );
     }

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 
 import {Circle, Icon, Style} from 'ol/style';
+import {Feature} from 'ol';
 import {GeoJSON} from 'ol/format';
 import {
   ImageArcGISRest,
@@ -418,7 +419,7 @@ export class HsSaveMapService {
         delete json.features;
       } else {
         try {
-          json.features = this.serializeFeatures(src.getFeatures());
+          json.features = this.getFeaturesJson(src.getFeatures());
         } catch (ex) {
           //Do nothing
         }
@@ -436,19 +437,15 @@ export class HsSaveMapService {
   /**
    * Convert feature array to GeoJSON string
    *
-   * @memberof HsSaveMapService
-   * @function serializeFeatures
-   * @param {Array} features Array of features
-   * @return {string} GeoJSON string
+   * @param features - Array of features
+   * @returns GeoJSON
    */
-  serializeFeatures(features) {
+  getFeaturesJson(features: Feature[]): any {
     const f = new GeoJSON();
-    return f.writeFeatures(features, {
+    const featureProjection = this.HsMapService.getCurrentProj().getCode();
+    return f.writeFeatureObject(features, {
       dataProjection: 'EPSG:4326',
-      featureProjection: this.HsMapService.map
-        .getView()
-        .getProjection()
-        .getCode(),
+      featureProjection,
     });
   }
 

--- a/projects/hslayers/test/data/composition.js
+++ b/projects/hslayers/test/data/composition.js
@@ -55,7 +55,7 @@ export const compositionJson = {
       'metadata': {},
       'visibility': true,
       'opacity': 1,
-      'title': 'Point clicked',
+      'title': 'Point clicked - features as string',
       'className': 'Vector',
       'features':
         '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[25.486272576058198,57.21506027419332]},"properties":null}]}',
@@ -63,6 +63,28 @@ export const compositionJson = {
       'minResolution': 0,
       'projection': 'epsg:4326',
     },
+    {
+      'metadata': {},
+      'visibility': true,
+      'opacity': 1,
+      'title': 'Json features',
+      'className': 'Vector',
+      'features':
+        {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[25.486272576058198,57.21506027419332]},"properties":null}]},
+      'maxResolution': null,
+      'minResolution': 0,
+      'projection': 'epsg:4326',
+    },
+    {
+      'metadata': {},
+      'visibility': true,
+      'opacity': 1,
+      'title': 'Vector layer without features',
+      'className': 'Vector',
+      'maxResolution': null,
+      'minResolution': 0,
+      'projection': 'epsg:4326',
+    }
   ],
   'current_base_layer': {'title': 'Open street map'},
 };


### PR DESCRIPTION
This is needed when saving/loading compositions because storing as string is inneficient, needs
parsing, adds escape characters and makes harder to read.

fix #1398