### PR TITLE
ci: Bump NodeJS to 12.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Node 10 goes end-of-life. Node 12 is the oldest maintained version from now on.

https://nodejs.org/en/about/releases/