### PR TITLE
fix: Set always correct url to the Layman login button

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "prebuild": "node projects/hslayers/prebuild.js",
     "build": "ng build hslayers --prod",
+    "build-app": "ng build hslayers-app --prod",
     "build-sensors": "ng build hslayers-sensors --prod",
     "prebuild-watch": "node projects/hslayers/prebuild.js",
     "build-watch": "ng build hslayers --watch",

--- a/projects/hslayers/src/common/layman/layman-current-user.component.ts
+++ b/projects/hslayers/src/common/layman/layman-current-user.component.ts
@@ -37,6 +37,13 @@ export class HsLaymanCurrentUserComponent {
     return (location.protocol == endpointUrl.protocol && location.host == endpointUrl.host);
   }
 
+  loginButtonUrl() {
+    if (this.sameDomain())
+      return window.location.href + '#';
+    else
+      this.authUrl();
+  }
+
   authUrl() {
     return this.endpoint.url + '/login';
   }

--- a/projects/hslayers/src/common/layman/layman-current-user.html
+++ b/projects/hslayers/src/common/layman/layman-current-user.html
@@ -1,5 +1,5 @@
 <div *ngIf="endpoint" style="margin-left: 1em; float: right; ">
-    <a class="btn btn-block btn-light hs-light-background" style="border-radius: 0.25rem;" (click)="login()" *ngIf="isAuthorized()" href="{{sameDomain() ? '#' : authUrl()}}" target="{{sameDomain() ? '' : '_blank'}}">
+    <a class="btn btn-block btn-light hs-light-background" style="border-radius: 0.25rem;" (click)="login()" *ngIf="isAuthorized()" href="{{loginButtonUrl()}}" target="{{sameDomain() ? '' : '_blank'}}">
         {{'COMPOSITIONS.loginToCatalogue' | translate}}</a>
     <a class="btn btn-block btn-light hs-light-background" style="border-radius: 0.25rem;" (click)="logout()" *ngIf="!isAuthorized()">{{'COMMON.Logout' | translate }}
         {{endpoint.user}}</a>


### PR DESCRIPTION
There happened to be a flawed url (without the query part) on the Login button in some cases which caused the map to reload once the user clicked on Login.