### PR TITLE
feature: Locales in languages panel can be configured

### DIFF
--- a/projects/hslayers/src/components/core/core.service.ts
+++ b/projects/hslayers/src/components/core/core.service.ts
@@ -43,8 +43,10 @@ export class HsCoreService {
     } else {
       this.HsLayoutService.sidebarExpanded = true;
     }
-
-    this.translate.addLangs(['en', 'cs', 'lv', 'sk']);
+    const languages = this.HsConfig.enabledLanguages
+      ? this.HsConfig.enabledLanguages.split(',').map((lang) => lang.trim())
+      : ['cs', 'lv'];
+    this.translate.addLangs(languages);
     this.translate.setDefaultLang('en');
     if (this.HsConfig.language) {
       this.translate.use(this.HsConfig.language);
@@ -99,7 +101,8 @@ export class HsCoreService {
         function () {
           this.updateVH();
           this.updateMapSize();
-          this.HsEventBusService.layoutResizes.next();        },
+          this.HsEventBusService.layoutResizes.next();
+        },
         300,
         false,
         this

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -89,6 +89,7 @@ export class HsConfig {
   geonamesUser?: any;
   searchProvider?: any;
   language?: string;
+  enabledLanguages?: string;
   query?: any;
   queryPoint?: string;
   popUpDisplay?: string;


### PR DESCRIPTION
HsConfig enabledLanguages can be set as string from any container app. User must input required languages code name, such as, LV for latvian. Each code must be sepperated using comma.
 Example:
enabledLanguages: 'lv, cs, sk',