### PR TITLE
Issue-1664-layman-workspace

### DIFF
--- a/projects/hslayers-server/src/oauth2/util.js
+++ b/projects/hslayers-server/src/oauth2/util.js
@@ -62,7 +62,7 @@ exports.handleProxyRes = (proxyRes, req, res) => {
       body = Buffer.concat(body).toString().replace(repl, replWith);
 
       /* 
-        /rest/layers
+        /rest/layers || rest/workspaces/layers
         X-Total-Count header includes total number of layers available from the request
       */
       if(this.headers['x-total-count']){

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -1,7 +1,9 @@
 import Feature from 'ol/Feature';
 import {Group, Layer} from 'ol/layer';
-import {HsLaymanLayerDescriptor} from '../components/save-map/layman-layer-descriptor.interface';
 import {Style} from 'ol/style';
+
+import {HsLaymanLayerDescriptor} from '../components/save-map/layman-layer-descriptor.interface';
+import {accessRightsInterface} from '../components/add-data/common/access-rights.interface';
 
 const TITLE = 'title';
 const NAME = 'name';
@@ -44,6 +46,7 @@ const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
 const LEGENDS = 'legends';
 const SUB_LAYERS = 'sublayers';
 const WORKSPACE = 'workspace';
+const ACCESS_RIGHTS = 'access_rights';
 
 export type Attribution = {
   onlineResource?: string;
@@ -78,6 +81,15 @@ export type popUpAttribute = {
 export type popUp = {
   attributes?: Array<popUpAttribute | string>;
 };
+
+export function getAccessRights(layer: Layer): accessRightsInterface {
+  return layer.get(ACCESS_RIGHTS);
+}
+
+export function setAccessRights(layer: Layer, access_rights:accessRightsInterface ){
+  layer.set(ACCESS_RIGHTS, access_rights);
+}
+
 export function setTitle(layer: Layer, title: string): void {
   layer.set(TITLE, title);
 }
@@ -546,6 +558,8 @@ export function setWorkspace(layer: Layer, workspace: string): void {
 }
 
 export const HsLayerExt = {
+  getAccessRights,
+  setAccessRights,
   setTitle,
   getTitle,
   setName,
@@ -622,4 +636,6 @@ export const HsLayerExt = {
   getThumbnail,
   setVirtualAttributes,
   getVirtualAttributes,
+  setWorkspace,
+  getWorkspace,
 };

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -43,6 +43,7 @@ const THUMBNAIL = 'thumbnail';
 const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
 const LEGENDS = 'legends';
 const SUB_LAYERS = 'sublayers';
+const WORKSPACE = 'workspace';
 
 export type Attribution = {
   onlineResource?: string;
@@ -535,6 +536,15 @@ export function setVirtualAttributes(
 export function getVirtualAttributes(layer: Layer): any {
   return layer.get(VIRTUAL_ATTRIBUTES);
 }
+
+export function getWorkspace(layer: Layer): string {
+  return layer.get(WORKSPACE);
+}
+
+export function setWorkspace(layer: Layer, workspace: string): void {
+  layer.set(WORKSPACE, workspace);
+}
+
 export const HsLayerExt = {
   setTitle,
   getTitle,

--- a/projects/hslayers/src/components/add-data/catalogue/add-data-layer-descriptor.interface.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/add-data-layer-descriptor.interface.ts
@@ -13,4 +13,6 @@ export interface HsAddDataLayerDescriptor {
   };
   endpoint?;
   id?;
+  workspace?: string;
+  editable?: boolean;
 }

--- a/projects/hslayers/src/components/add-data/catalogue/add-data-list-item.html
+++ b/projects/hslayers/src/components/add-data/catalogue/add-data-list-item.html
@@ -31,7 +31,7 @@
                 <i class="icon-info-sign icon-primary"></i><span class="ml-1">{{'COMMON.metadata' |
                     translate}}</span>
             </a>
-            <a class="btn btn-sm" *ngIf="layer.endpoint.type == 'layman'"
+            <a class="btn btn-sm" *ngIf="layer.editable"
                 (click)="$event.stopPropagation();removeLayer(layer)">
                 <i class="icon-trash text-danger"></i><span class="ml-1">{{'COMMON.removeLayer' | translate}}</span>
             </a>

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -39,7 +39,9 @@ export class HsLaymanBrowserService {
   queryCatalog(endpoint: HsEndpoint, data?: any): Observable<any> {
     endpoint.getCurrentUserIfNeeded(endpoint);
     const withPermisionOrMine = data?.onlyMine
-      ? `workspaces/${endpoint.user}/`
+      ? endpoint.user !== 'anonymous' && endpoint.user !== 'browser'
+        ? `workspaces/${endpoint.user}/`
+        : ''
       : '';
     const url = `${endpoint.url}/rest/${withPermisionOrMine}layers`;
     endpoint.datasourcePaging.loaded = false;

--- a/projects/hslayers/src/components/add-data/common/access-rights.interface.ts
+++ b/projects/hslayers/src/components/add-data/common/access-rights.interface.ts
@@ -1,0 +1,4 @@
+export interface accessRightsInterface {
+  write: string;
+  read: string;
+}

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
@@ -60,6 +60,41 @@
                 [placeholder]="'COMMON.fillInDescriptive'| translate" [(ngModel)]="abstract">
             </textarea>
         </div>
+
+        <div class="form-group d-flex justify-content-between" *ngIf="isAuthorized">
+            <label class="pt-2" style="margin-bottom: 0;">
+                {{'SAVECOMPOSITION.readAccessRights' | translate}}
+            </label>
+            <div class="btn-group">
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.read = 'EVERYONE'"
+                    [ngClass]="{'active':access_rights.read == 'EVERYONE'}">
+                    {{'SAVECOMPOSITION.public' | translate}}
+                </button>
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.read = 'private'"
+                    [ngClass]="{'active':access_rights.read == 'private'}">
+                    {{'SAVECOMPOSITION.private' | translate}}
+                </button>
+            </div>
+        </div>
+        <div class="form-group d-flex justify-content-between"  *ngIf="isAuthorized">
+            <label class="pt-2" style="margin-bottom: 0;">
+                {{'SAVECOMPOSITION.writeAccessRights' | translate}}
+            </label>
+            <div class="btn-group">
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.write = 'EVERYONE'"
+                    [ngClass]="{'active':access_rights.write == 'EVERYONE'}">
+                    {{'SAVECOMPOSITION.public' | translate}}
+                </button>
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.write = 'private'"
+                    [ngClass]="{'active':access_rights.write == 'private'}">
+                    {{'SAVECOMPOSITION.private' | translate}}
+                </button>
+            </div>
+        </div>
     
         <div class="form-group">
             <label class="capabilities_label control-label">{{'ADDLAYERS.SHP.SLDStyleFile' | translate}} </label>

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
@@ -91,7 +91,8 @@ export class HsAddDataFileShpComponent implements OnInit {
     try {
       const descriptor = await this.hsLaymanService.describeLayer(
         endpoint,
-        layerName
+        layerName,
+        endpoint.user
       );
       if (['STARTED', 'PENDING', 'SUCCESS'].includes(descriptor.wms.status)) {
         return new Promise((resolve) => {

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.service.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.service.ts
@@ -51,7 +51,9 @@ export class HsAddDataFileShpService {
       formdata.append('crs', srs);
       this.httpClient
         .post(
-          `${endpoint.url}/rest/${endpoint.user}/layers?${Math.random()}`,
+          `${endpoint.url}/rest/workspaces/${
+            endpoint.user
+          }/layers?${Math.random()}`,
           formdata,
           {withCredentials: true}
         )

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.service.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.service.ts
@@ -27,7 +27,8 @@ export class HsAddDataFileShpService {
     title: string,
     abstract: string,
     srs: string,
-    sld: FileDescriptor
+    sld: FileDescriptor,
+    access_rights: any
   ): Promise<any> {
     return new Promise((resolve, reject) => {
       const formdata = new FormData();
@@ -49,6 +50,8 @@ export class HsAddDataFileShpService {
       formdata.append('title', title);
       formdata.append('abstract', abstract);
       formdata.append('crs', srs);
+      formdata.append('write', access_rights.write);
+      formdata.append('read', access_rights.read);
       this.httpClient
         .post(
           `${endpoint.url}/rest/workspaces/${

--- a/projects/hslayers/src/components/add-data/url/wfs/add-data-url-wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/add-data-url-wfs.service.ts
@@ -77,7 +77,8 @@ export class HsAddDataWfsService {
                 //TODO: If Layman allows layers with different casing,
                 // then remove the case lowering
                 if (
-                  layer.Title.toLowerCase() === this.layerToAdd.toLowerCase()
+                  layer.Title.toLowerCase() === this.layerToAdd.toLowerCase() ||
+                  layer.Name.toLowerCase() === this.layerToAdd.toLowerCase()
                 ) {
                   layer.checked = true;
                 }
@@ -432,6 +433,13 @@ export class HsAddDataWfsService {
         bbox.UpperCorner.split(' ')[0],
         bbox.UpperCorner.split(' ')[1],
       ];
+    }
+    if (!this.mapProjection) {
+      this.mapProjection = this.HsMapService.map
+        .getView()
+        .getProjection()
+        .getCode()
+        .toUpperCase();
     }
     const extent = transformExtent(bbox, 'EPSG:4326', this.mapProjection);
     if (extent) {

--- a/projects/hslayers/src/components/add-data/vector/VectorLayerDescriptor.ts
+++ b/projects/hslayers/src/components/add-data/vector/VectorLayerDescriptor.ts
@@ -1,5 +1,6 @@
 import VectorSource from 'ol/source/Vector';
 import {HsVectorLayerOptions} from './vector-layer-options.type';
+import {accessRightsInterface} from '../common/access-rights.interface';
 
 export class VectorLayerDescriptor {
   mapProjection;
@@ -16,6 +17,7 @@ export class VectorLayerDescriptor {
     path: string;
     visible: boolean;
     workspace: string;
+    access_rights: accessRightsInterface;
   };
 
   constructor(
@@ -47,6 +49,7 @@ export class VectorLayerDescriptor {
       path: options.path,
       visible: options.visible,
       workspace: options.workspace,
+      access_rights: options.access_rights,
     };
 
     switch (type ? type.toLowerCase() : '') {

--- a/projects/hslayers/src/components/add-data/vector/VectorLayerDescriptor.ts
+++ b/projects/hslayers/src/components/add-data/vector/VectorLayerDescriptor.ts
@@ -15,6 +15,7 @@ export class VectorLayerDescriptor {
     removable?: boolean;
     path: string;
     visible: boolean;
+    workspace: string;
   };
 
   constructor(
@@ -45,6 +46,7 @@ export class VectorLayerDescriptor {
       removable: true,
       path: options.path,
       visible: options.visible,
+      workspace: options.workspace,
     };
 
     switch (type ? type.toLowerCase() : '') {

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
@@ -11,6 +11,7 @@ import {HsLayoutService} from '../../layout/layout.service';
 import {HsToastService} from '../../layout/toast/toast.service';
 import {HsUtilsService} from '../../utils/utils.service';
 
+import {accessRightsInterface} from '../common/access-rights.interface';
 import {getHsLaymanSynchronizing} from '../../../common/layer-extensions';
 
 @Component({
@@ -40,6 +41,10 @@ export class HsAddDataVectorComponent {
   isAuthorized = false;
   // Not possible to save KML to layman yet
   saveAvailable: boolean;
+  access_rights: accessRightsInterface = {
+    'write': 'EVERYONE',
+    'read': 'EVERYONE',
+  };
   constructor(
     public HsAddDataVectorService: HsAddDataVectorService,
     public hsHistoryListService: HsHistoryListService,
@@ -93,6 +98,7 @@ export class HsAddDataVectorComponent {
         extractStyles: this.extract_styles,
         features: this.features,
         path: this.hsUtilsService.undefineEmptyString(this.folder_name),
+        access_rights: this.access_rights,
       },
       this.addUnder
     );

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
@@ -55,6 +55,40 @@
                 </button>
             </div>
         </div>
+        <div class="form-group d-flex justify-content-between" *ngIf="saveToLayman">
+            <label class="pt-2" style="margin-bottom: 0;">
+                {{'SAVECOMPOSITION.readAccessRights' | translate}}
+            </label>
+            <div class="btn-group">
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.read = 'EVERYONE'"
+                    [ngClass]="{'active':access_rights.read == 'EVERYONE'}">
+                    {{'SAVECOMPOSITION.public' | translate}}
+                </button>
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.read = 'private'"
+                    [ngClass]="{'active':access_rights.read == 'private'}">
+                    {{'SAVECOMPOSITION.private' | translate}}
+                </button>
+            </div>
+        </div>
+        <div class="form-group d-flex justify-content-between" *ngIf="saveToLayman">
+            <label class="pt-2" style="margin-bottom: 0;">
+                {{'SAVECOMPOSITION.writeAccessRights' | translate}}
+            </label>
+            <div class="btn-group">
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.write = 'EVERYONE'"
+                    [ngClass]="{'active':access_rights.write == 'EVERYONE'}">
+                    {{'SAVECOMPOSITION.public' | translate}}
+                </button>
+                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                    (click)="access_rights.write = 'private'"
+                    [ngClass]="{'active':access_rights.write == 'private'}">
+                    {{'SAVECOMPOSITION.private' | translate}}
+                </button>
+            </div>
+        </div>
 
         <button type="button" class="btn btn-block btn-outline-secondary dropdown-toggle dropdown-toggle-split"
             (click)="advancedPanelVisible = !advancedPanelVisible">

--- a/projects/hslayers/src/components/add-data/vector/vector-layer-options.type.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-layer-options.type.ts
@@ -8,4 +8,5 @@ export type HsVectorLayerOptions = {
   style?: any;
   extractStyles?: boolean;
   features?: Feature[];
+  workspace?: string;
 };

--- a/projects/hslayers/src/components/add-data/vector/vector-layer-options.type.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-layer-options.type.ts
@@ -1,4 +1,5 @@
 import Feature from 'ol/Feature';
+import {accessRightsInterface} from '../common/access-rights.interface';
 
 export type HsVectorLayerOptions = {
   opacity?: number;
@@ -9,4 +10,5 @@ export type HsVectorLayerOptions = {
   extractStyles?: boolean;
   features?: Feature[];
   workspace?: string;
+  access_rights?: accessRightsInterface;
 };

--- a/projects/hslayers/src/components/compositions/compositions-catalogue.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-catalogue.service.ts
@@ -214,6 +214,7 @@ export class HsCompositionsCatalogueService {
       type: this.data.type,
       start: ep.compositionsPaging.start,
       limit: ep.compositionsPaging.limit,
+      filterByOnlyMine: this.filterByOnlyMine,
     });
   }
   /**

--- a/projects/hslayers/src/components/compositions/endpoints/compositions-layman.service.ts
+++ b/projects/hslayers/src/components/compositions/endpoints/compositions-layman.service.ts
@@ -52,7 +52,9 @@ export class HsCompositionsLaymanService {
     const bbox = params.filterByExtent ? b.join(',') : '';
 
     const withPermisionOrMine = params.filterByOnlyMine
-      ? `workspaces/${endpoint.user}/`
+      ? endpoint.user !== 'anonymous' && endpoint.user !== 'browser'
+        ? `workspaces/${endpoint.user}/`
+        : ''
       : '';
     const url = `${endpoint.url}/rest/${withPermisionOrMine}maps`;
 

--- a/projects/hslayers/src/components/draw/draw-layer-metadata.component.ts
+++ b/projects/hslayers/src/components/draw/draw-layer-metadata.component.ts
@@ -2,11 +2,13 @@ import {Component, Input, OnInit, ViewRef} from '@angular/core';
 import {HsDialogComponent} from '../layout/dialogs/dialog-component.interface';
 import {HsDialogContainerService} from '../../components/layout/dialogs/dialog-container.service';
 import {HsMapService} from '../map/map.service';
+import {accessRightsInterface} from '../add-data/common/access-rights.interface';
 import {
   getEditor,
   getHsLaymanSynchronizing,
   getPath,
   getTitle,
+  setAccessRights,
   setEditor,
   setName,
   setPath,
@@ -30,6 +32,10 @@ export class HsDrawLayerMetadataDialogComponent
   folderVisible = false;
   type: string;
   endpoint: any;
+  access_rights: accessRightsInterface = {
+    'write': 'EVERYONE',
+    'read': 'EVERYONE',
+  };
 
   constructor(
     public HsMapService: HsMapService,
@@ -75,6 +81,7 @@ export class HsDrawLayerMetadataDialogComponent
       f.setProperties(dic);
     });
 
+    setAccessRights(this.layer, this.access_rights);
     this.data.changeDrawSource();
 
     this.data.addDrawLayer(this.layer);

--- a/projects/hslayers/src/components/draw/draw.service.ts
+++ b/projects/hslayers/src/components/draw/draw.service.ts
@@ -210,6 +210,7 @@ export class HsDrawService {
         format: layman ? 'hs.format.WFS' : null,
         url: layman ? layman.url + '/wfs' : null,
       },
+      workspace: this.HsLaymanService.getLaymanEndpoint().user,
     });
     this.selectedLayer = drawLayer;
     this.HsDialogContainerService.create(
@@ -270,7 +271,7 @@ export class HsDrawService {
         layer.title,
         undefined,
         'EPSG:4326',
-        undefined
+        {workspace: layer.workspace}
       );
       lyr = this.HsMapService.findLayerByTitle(layer.title);
     }
@@ -481,7 +482,9 @@ export class HsDrawService {
       if (this.laymanEndpoint.layers) {
         this.drawableLaymanLayers = this.laymanEndpoint.layers.filter(
           (layer) => {
-            return !this.HsMapService.findLayerByTitle(layer.title);
+            return (
+              !this.HsMapService.findLayerByTitle(layer.title) && layer.editable
+            );
           }
         );
       }
@@ -511,7 +514,7 @@ export class HsDrawService {
     const confirmed = await dialog.waitResult();
     if (confirmed == 'yes') {
       this.HsMapService.map.removeLayer(this.selectedLayer);
-      if (getDefinition(this.selectedLayer)?.format == 'hs.format.WFS') {
+      if (getDefinition(this.selectedLayer)?.url) {
         this.HsLaymanService.removeLayer(this.selectedLayer);
       }
       if (getTitle(this.selectedLayer) == TMP_LAYER_TITLE) {

--- a/projects/hslayers/src/components/draw/partials/draw-layer-metadata.html
+++ b/projects/hslayers/src/components/draw/partials/draw-layer-metadata.html
@@ -40,6 +40,40 @@
                                 name="title" />
                         </div>
                     </div>
+                    <div class="form-group d-flex justify-content-between" *ngIf="data.isAuthorized">
+                        <label class="pt-2" style="margin-bottom: 0;">
+                            {{'SAVECOMPOSITION.readAccessRights' | translate}}
+                        </label>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                                (click)="access_rights.read = 'EVERYONE'"
+                                [ngClass]="{'active':access_rights.read == 'EVERYONE'}">
+                                {{'SAVECOMPOSITION.public' | translate}}
+                            </button>
+                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                                (click)="access_rights.read = 'private'"
+                                [ngClass]="{'active':access_rights.read == 'private'}">
+                                {{'SAVECOMPOSITION.private' | translate}}
+                            </button>
+                        </div>
+                    </div>
+                    <div class="form-group d-flex justify-content-between"  *ngIf="data.isAuthorized">
+                        <label class="pt-2" style="margin-bottom: 0;">
+                            {{'SAVECOMPOSITION.writeAccessRights' | translate}}
+                        </label>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                                (click)="access_rights.write = 'EVERYONE'"
+                                [ngClass]="{'active':access_rights.write == 'EVERYONE'}">
+                                {{'SAVECOMPOSITION.public' | translate}}
+                            </button>
+                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                                (click)="access_rights.write = 'private'"
+                                [ngClass]="{'active':access_rights.write == 'private'}">
+                                {{'SAVECOMPOSITION.private' | translate}}
+                            </button>
+                        </div>
+                    </div>
                     <div class="flex-row w-75 align-items-center" style="display: flex;">
                         <a class="p-1 mb-1"
                             (click)="folderVisible = !folderVisible">{{'COMMON.advancedOptions' | translate}}</a>

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -14,17 +14,18 @@ import {HsToastService} from '../layout/toast/toast.service';
 import {HsUtilsService} from '../utils/utils.service';
 
 import {
-  getLayerName,
-  getLaymanFriendlyLayerName,
-  wfsNotAvailable,
-} from './layman-utils';
-import {
+  getAccessRights,
   getLaymanLayerDescriptor,
   getTitle,
   getWorkspace,
   setHsLaymanSynchronizing,
   setLaymanLayerDescriptor,
 } from '../../common/layer-extensions';
+import {
+  getLayerName,
+  getLaymanFriendlyLayerName,
+  wfsNotAvailable,
+} from './layman-utils';
 
 export type WfsSyncParams = {
   /** Endpoint description */
@@ -113,7 +114,7 @@ export class HsLaymanService implements HsSaverService {
    * Send layer definition and features to Layman
    * @param endpoint Endpoint description
    * @param geojson Geojson object with features to send to server
-   * @param description Object containing {name, title, crs} of
+   * @param description Object containing {name, title, crs, workspace, acces_rights} of
    * layer to retrieve
    * @param layerDesc Previously fetched layer descriptor
    * @return Promise result of POST/PATCH
@@ -138,6 +139,9 @@ export class HsLaymanService implements HsSaverService {
     formdata.append('name', description.name);
     formdata.append('title', description.title);
     formdata.append('crs', description.crs);
+    formdata.append('write', description.acces_rights.write ?? 'EVERYONE');
+    formdata.append('read', description.acces_rights.read ?? 'EVERYONE');
+
     const headers = new HttpHeaders();
     headers.append('Content-Type', null);
     headers.append('Accept', 'application/json');
@@ -200,6 +204,7 @@ export class HsLaymanService implements HsSaverService {
         ? this.crs
         : 'EPSG:3857',
       workspace: getWorkspace(layer),
+      acces_rights: getAccessRights(layer),
     });
     setTimeout(async () => {
       await this.makeGetLayerRequest(ep, layer);


### PR DESCRIPTION
Adapt HSLayers to the new layman API structure.

Few thing I preceive as not settled:
- Which layman layers  should be considered drawables and should be listed in 'Server layers' list in draw panel. Up until now it was just layers that belong to logged in user. Atm using general request 'rest/layers' returns layers with permision (both read and write). For hub.lesprojekt its more than 200. 

- Layers added thorugh add-data panel as vectors (WFS) were created as empty (no feaetures) and synced with layman right after. This however is not possible anymore (atleast not right out of the box) as we are now able to add layers with 'read-only' access that  should not  be 'sync-ed' (I suppose) . Solved by adding layer as URL WFS (same as with Micka's WFS services). Another approach would be to somehow modify sync logic to allow initial pull of features.

- Possibility to make vector layers snychronizable after its added to map
- When composition with write access is being saved its not currently possible to modify source cmpositon but only to save as a new under the current user. 

Even though I tested everything that came to my mind I still feel like there will be something I missed or some unexpected behavior in the communication.
