### PR TITLE
Enhance usability of SPARQL sources

### DIFF
--- a/projects/hslayers/src/common/layers/hs.source.SPOI.ts
+++ b/projects/hslayers/src/common/layers/hs.source.SPOI.ts
@@ -1,16 +1,33 @@
-import {SparqlJson, SparqlOptions} from './hs.source.SparqlJson';
+import {SparqlJson} from './hs.source.SparqlJson';
+
+export type SPOIOptions = {
+  category: string;
+  projection: string;
+};
 
 /**
  * Handy shorthand for SparqlJson source with some params pre-filled for SPOI dataset
  */
 export class SPOI extends SparqlJson {
-  constructor({projection}: SparqlOptions) {
+  constructor({category, projection}: SPOIOptions) {
     const options = {
       endpointUrl: 'https://www.foodie-cloud.org/sparql',
       endpointOptions: {},
+      geom_attribute: '?geom',
       optimizeForVirtuoso: true,
       projection: projection,
-      query: '',
+      query: `
+        PREFIX poi: <http://www.openvoc.eu/poi#>
+        PREFIX spoi: <http://gis.zcu.cz/SPOI/Ontology#>
+        SELECT ?o ?p ?s
+        FROM <http://www.sdi4apps.eu/poi.rdf>
+        WHERE {
+          ?o <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> spoi:${category} .
+          ?o <http://www.opengis.net/ont/geosparql#asWKT> ?geom.
+          FILTER(isBlank(?geom) = false).
+          <extent>
+          ?o ?p ?s .
+        } ORDER BY ?o`,
     };
     super(options);
   }

--- a/projects/hslayers/src/common/layers/hs.source.SPOI.ts
+++ b/projects/hslayers/src/common/layers/hs.source.SPOI.ts
@@ -1,0 +1,17 @@
+import {SparqlJson, SparqlOptions} from './hs.source.SparqlJson';
+
+/**
+ * Handy shorthand for SparqlJson source with some params pre-filled for SPOI dataset
+ */
+export class SPOI extends SparqlJson {
+  constructor({projection}: SparqlOptions) {
+    const options = {
+      endpointUrl: 'https://www.foodie-cloud.org/sparql',
+      endpointOptions: {},
+      optimizeForVirtuoso: true,
+      projection: projection,
+      query: '',
+    };
+    super(options);
+  }
+}

--- a/projects/hslayers/src/public-api.ts
+++ b/projects/hslayers/src/public-api.ts
@@ -48,6 +48,7 @@ export * from './common/endpoints/endpoint.interface';
 export * from './common/feature-extensions';
 export * from './common/layer-extensions';
 export * from './common/layers/hs.source.SparqlJson';
+export * from './common/layers/hs.source.SPOI';
 export * from './common/log/log.module';
 export * from './common/log/log.service';
 export * from './common/wms/wms-get-capabilities-response.interface';


### PR DESCRIPTION
As this PR contains a port of a previously fixed performance issue (#1648) I would welcome if we can incorporate it into the 4.0 release.

Changes:
- in SparqlJson it is mainly refactoring
- new class hs.source.SPOI which simplifies the usage of SPOI data drastically. Similar source classes can be created in the future for other endpoints as well (not necessarily only SPARQL ones, we can pre-define Layman or Micka sources for example).
