### PR TITLE
Issue 1797

### DIFF
--- a/projects/hslayers/src/components/add-data/catalogue/add-data-list-item.component.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/add-data-list-item.component.ts
@@ -148,11 +148,10 @@ export class HsAddDataListItemComponent {
     const confirmed = await dialog.waitResult();
     if (confirmed == 'yes') {
       this.HsLaymanService.removeLayer(layer.name);
-      this.HsAddDataCatalogueService.catalogEntries = this.HsAddDataCatalogueService.catalogEntries.filter(
-        (item) => {
+      this.HsAddDataCatalogueService.catalogEntries =
+        this.HsAddDataCatalogueService.catalogEntries.filter((item) => {
           return item.id != layer.id;
-        }
-      );
+        });
     }
   }
 }

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
@@ -23,7 +23,7 @@
             </div>
             <p class="px-5">{{'COMMON.or' | translate}}</p>
             <label class="dropzone-label">
-                <input name="file" type="file" class="inputfile" (change)="read($event)" id="shpdbfshx" multiple>
+                <input name="file" type="file"  accept=".shp, .shx, .dbf, .sbn" class="inputfile" (change)="read($event)" id="shpdbfshx" multiple>
                 <label for="shpdbfshx" class="p-2 rounded"> <i class="icon-uploadalt pr-2"></i>{{'ADDLAYERS.Vector.chooseFiles' | translate}}</label>
             </label> 
 

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
@@ -11,7 +11,7 @@
             </div>
             <p class="px-5">{{'COMMON.or' | translate}}</p>
             <label class="dropzone-label">
-                <input #vectorFileInput type="file" id="hs-vector-file" class="inputfile" (change)="handleFileUpload($event.target.files)">
+                <input #vectorFileInput type="file" accept=".kml, .gpx, .geojson" id="hs-vector-file" class="inputfile" (change)="handleFileUpload($event.target.files)">
                 <label for="hs-vector-file" class="p-2 rounded"> <i class="icon-uploadalt pr-2"></i> {{'ADDLAYERS.Vector.chooseFiles' | translate}}</label>
             </label> 
 

--- a/projects/hslayers/src/components/compositions/compositions.html
+++ b/projects/hslayers/src/components/compositions/compositions.html
@@ -10,7 +10,7 @@
             </button>
             <label class="but-title-sm hs-extra-buttons btn-file mb-0" style="font-size: 14px; padding: 1px 6px;"
                 title="{{'COMPOSITIONS.import'|translate}}">
-                <span class="icon-upload"></span><input type="file" (change)="handleFileSelect($event)" accept="json"
+                <span class="icon-upload"></span><input type="file" (change)="handleFileSelect($event)" accept=".json"
                     style="display: none;">
             </label>
             <button class="but-title-sm hs-extra-buttons" title="{{'COMPOSITIONS.addByAddress'|translate}}"


### PR DESCRIPTION
refs #1797
Wanted to make .kml, .gpx and .geojson accept file values to be filtered based on which vector type was selected, but the thing is we treat kml and geojson identically. Either value gives us the same opened panel view, so I can't really do much with that.
If this fix is not good enough, It can be done with some event propagated to trigger some filter function for  these accept file values to be checked and changed.