### PR TITLE
fix: Send correct access rights parameters to layman

### DIFF
--- a/projects/hslayers/src/common/layman/access-rights/layman-access-rights.component.ts
+++ b/projects/hslayers/src/common/layman/access-rights/layman-access-rights.component.ts
@@ -1,0 +1,26 @@
+import {Component, Input, ViewRef} from '@angular/core';
+import {accessRightsInterface} from '../../../components/add-data/common/access-rights.interface';
+
+@Component({
+  selector: 'hs-layman-access-rights',
+  templateUrl: './layman-access-rights.html',
+})
+export class HsCommonLaymanAccessRightsComponent {
+  @Input() access_rights: accessRightsInterface;
+  constructor() {}
+
+  accessRightChanged(
+    access_rights: accessRightsInterface,
+    type: string,
+    value: string
+  ): accessRightsInterface {
+    access_rights[type] = value;
+    if (
+      access_rights['access_rights.read'] == 'private' &&
+      access_rights['access_rights.write'] != 'private'
+    ) {
+      access_rights['access_rights.write'] = 'private';
+    }
+    return access_rights;
+  }
+}

--- a/projects/hslayers/src/common/layman/access-rights/layman-access-rights.html
+++ b/projects/hslayers/src/common/layman/access-rights/layman-access-rights.html
@@ -1,0 +1,35 @@
+<div class="form-group d-flex justify-content-between">
+    <label class="pt-2" style="margin-bottom: 0;">
+        {{'SAVECOMPOSITION.readAccessRights' | translate}}
+    </label>
+    <div class="btn-group">
+        <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+        (click)="accessRightChanged(access_rights,'access_rights.read','EVERYONE')"
+        [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
+        {{'SAVECOMPOSITION.public' | translate}}
+    </button>
+    <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+        (click)="accessRightChanged(access_rights,'access_rights.read','private')"
+        [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
+        {{'SAVECOMPOSITION.private' | translate}}
+    </button>
+    </div>
+</div>
+<div class="form-group d-flex justify-content-between" >
+    <label class="pt-2" style="margin-bottom: 0;">
+        {{'SAVECOMPOSITION.writeAccessRights' | translate}}
+    </label>
+    <div class="btn-group">
+        <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+        [disabled]="access_rights['access_rights.read'] == 'private'"
+        (click)="accessRightChanged(access_rights,'access_rights.write','EVERYONE')"
+            [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
+            {{'SAVECOMPOSITION.public' | translate}}
+        </button>
+        <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+        (click)="accessRightChanged(access_rights,'access_rights.write','private')"
+            [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
+            {{'SAVECOMPOSITION.private' | translate}}
+        </button>
+    </div>
+</div>

--- a/projects/hslayers/src/common/layman/layman.module.ts
+++ b/projects/hslayers/src/common/layman/layman.module.ts
@@ -1,15 +1,29 @@
 import {CUSTOM_ELEMENTS_SCHEMA, NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {HsCommonLaymanAccessRightsComponent} from './access-rights/layman-access-rights.component';
 import {HsCommonLaymanService} from './layman.service';
 import {HsLaymanCurrentUserComponent} from './layman-current-user.component';
 import {HsLaymanLoginComponent} from './layman-login.component';
 import {TranslateModule} from '@ngx-translate/core';
+
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  declarations: [HsLaymanLoginComponent, HsLaymanCurrentUserComponent],
+  declarations: [
+    HsLaymanLoginComponent,
+    HsLaymanCurrentUserComponent,
+    HsCommonLaymanAccessRightsComponent,
+  ],
   imports: [CommonModule, TranslateModule],
-  exports: [HsLaymanLoginComponent, HsLaymanCurrentUserComponent],
+  exports: [
+    HsLaymanLoginComponent,
+    HsLaymanCurrentUserComponent,
+    HsCommonLaymanAccessRightsComponent,
+  ],
   providers: [HsCommonLaymanService],
-  entryComponents: [HsLaymanLoginComponent, HsLaymanCurrentUserComponent],
+  entryComponents: [
+    HsLaymanLoginComponent,
+    HsLaymanCurrentUserComponent,
+    HsCommonLaymanAccessRightsComponent,
+  ],
 })
 export class HsLaymanModule {}

--- a/projects/hslayers/src/components/add-data/common/access-rights.interface.ts
+++ b/projects/hslayers/src/components/add-data/common/access-rights.interface.ts
@@ -1,4 +1,4 @@
 export interface accessRightsInterface {
-  write: string;
-  read: string;
+  'access_rights.write': string;
+  'access_rights.read': string;
 }

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
@@ -61,42 +61,8 @@
             </textarea>
         </div>
 
-        <div class="form-group d-flex justify-content-between" *ngIf="isAuthorized">
-            <label class="pt-2" style="margin-bottom: 0;">
-                {{'SAVECOMPOSITION.readAccessRights' | translate}}
-            </label>
-            <div class="btn-group">
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                (click)="accessRightChanged('access_rights.read','EVERYONE')"
-                [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
-                {{'SAVECOMPOSITION.public' | translate}}
-            </button>
-            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                (click)="accessRightChanged('access_rights.read','private')"
-                [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
-                {{'SAVECOMPOSITION.private' | translate}}
-            </button>
-            </div>
-        </div>
-        <div class="form-group d-flex justify-content-between"  *ngIf="isAuthorized">
-            <label class="pt-2" style="margin-bottom: 0;">
-                {{'SAVECOMPOSITION.writeAccessRights' | translate}}
-            </label>
-            <div class="btn-group">
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                [disabled]="access_rights['access_rights.read'] == 'private'"
-                (click)="accessRightChanged('access_rights.write','EVERYONE')"
-                    [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
-                    {{'SAVECOMPOSITION.public' | translate}}
-                </button>
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                (click)="accessRightChanged('access_rights.write','private')"
-                    [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
-                    {{'SAVECOMPOSITION.private' | translate}}
-                </button>
-            </div>
-        </div>
-    
+        <hs-layman-access-rights *ngIf="isAuthorized" [(access_rights)]="access_rights"></hs-layman-access-rights>    
+        
         <div class="form-group">
             <label class="capabilities_label control-label">{{'ADDLAYERS.SHP.SLDStyleFile' | translate}} </label>
             <input name="file" type="file" (change)="read($event)" id="sld">

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
@@ -67,15 +67,15 @@
             </label>
             <div class="btn-group">
                 <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.read = 'EVERYONE'"
-                    [ngClass]="{'active':access_rights.read == 'EVERYONE'}">
-                    {{'SAVECOMPOSITION.public' | translate}}
-                </button>
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.read = 'private'"
-                    [ngClass]="{'active':access_rights.read == 'private'}">
-                    {{'SAVECOMPOSITION.private' | translate}}
-                </button>
+                (click)="accessRightChanged('access_rights.read','EVERYONE')"
+                [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
+                {{'SAVECOMPOSITION.public' | translate}}
+            </button>
+            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                (click)="accessRightChanged('access_rights.read','private')"
+                [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
+                {{'SAVECOMPOSITION.private' | translate}}
+            </button>
             </div>
         </div>
         <div class="form-group d-flex justify-content-between"  *ngIf="isAuthorized">
@@ -84,13 +84,14 @@
             </label>
             <div class="btn-group">
                 <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.write = 'EVERYONE'"
-                    [ngClass]="{'active':access_rights.write == 'EVERYONE'}">
+                [disabled]="access_rights['access_rights.read'] == 'private'"
+                (click)="accessRightChanged('access_rights.write','EVERYONE')"
+                    [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
                     {{'SAVECOMPOSITION.public' | translate}}
                 </button>
                 <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.write = 'private'"
-                    [ngClass]="{'active':access_rights.write == 'private'}">
+                (click)="accessRightChanged('access_rights.write','private')"
+                    [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
                     {{'SAVECOMPOSITION.private' | translate}}
                 </button>
             </div>

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
@@ -226,14 +226,4 @@ export class HsAddDataFileShpComponent implements OnInit {
     console.log(this.files);
     console.log(this.sld);
   }
-
-  accessRightChanged(type: string, value: string) {
-    this.access_rights[type] = value;
-    if (
-      this.access_rights['access_rights.read'] == 'private' &&
-      this.access_rights['access_rights.write'] != 'private'
-    ) {
-      this.access_rights['access_rights.write'] = 'private';
-    }
-  }
 }

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
@@ -42,8 +42,8 @@ export class HsAddDataFileShpComponent implements OnInit {
   showDetails = false;
   isAuthorized: boolean;
   access_rights: accessRightsInterface = {
-    'write': 'EVERYONE',
-    'read': 'EVERYONE',
+    'access_rights.write': 'EVERYONE',
+    'access_rights.read': 'EVERYONE',
   };
 
   constructor(
@@ -225,5 +225,15 @@ export class HsAddDataFileShpComponent implements OnInit {
     }
     console.log(this.files);
     console.log(this.sld);
+  }
+
+  accessRightChanged(type: string, value: string) {
+    this.access_rights[type] = value;
+    if (
+      this.access_rights['access_rights.read'] == 'private' &&
+      this.access_rights['access_rights.write'] != 'private'
+    ) {
+      this.access_rights['access_rights.write'] = 'private';
+    }
   }
 }

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.module.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.module.ts
@@ -6,6 +6,7 @@ import {TranslateModule} from '@ngx-translate/core';
 import {HsAddDataCommonModule} from '../../common/add-data-common.module';
 import {HsAddDataFileShpComponent} from './add-data-file-shp.component';
 import {HsAddDataFileShpService} from './add-data-file-shp.service';
+import {HsLaymanModule} from '../../../../common/layman/layman.module';
 import {HsUiExtensionsModule} from '../../../../common/widgets/ui-extensions.module';
 
 @NgModule({
@@ -16,6 +17,7 @@ import {HsUiExtensionsModule} from '../../../../common/widgets/ui-extensions.mod
     TranslateModule,
     HsUiExtensionsModule,
     HsAddDataCommonModule,
+    HsLaymanModule,
   ],
   exports: [HsAddDataFileShpComponent],
   declarations: [HsAddDataFileShpComponent],

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.service.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.service.ts
@@ -3,6 +3,7 @@ import {HsEndpoint} from '../../../../common/endpoints/endpoint.interface';
 import {HsLogService} from '../../../../common/log/log.service';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
+import {accessRightsInterface} from '../../common/access-rights.interface';
 
 @Injectable({providedIn: 'root'})
 export class HsAddDataFileShpService {
@@ -28,7 +29,7 @@ export class HsAddDataFileShpService {
     abstract: string,
     srs: string,
     sld: FileDescriptor,
-    access_rights: any
+    access_rights: accessRightsInterface
   ): Promise<any> {
     return new Promise((resolve, reject) => {
       const formdata = new FormData();
@@ -50,8 +51,18 @@ export class HsAddDataFileShpService {
       formdata.append('title', title);
       formdata.append('abstract', abstract);
       formdata.append('crs', srs);
-      formdata.append('write', access_rights.write);
-      formdata.append('read', access_rights.read);
+
+      const write =
+        access_rights['access_rights.write'] == 'private'
+          ? endpoint.user
+          : access_rights['access_rights.write'];
+      const read =
+        access_rights['access_rights.read'] == 'private'
+          ? endpoint.user
+          : access_rights['access_rights.read'];
+
+      formdata.append('access_rights.write', write);
+      formdata.append('access_rights.read', read);
       this.httpClient
         .post(
           `${endpoint.url}/rest/workspaces/${

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
@@ -42,8 +42,8 @@ export class HsAddDataVectorComponent {
   // Not possible to save KML to layman yet
   saveAvailable: boolean;
   access_rights: accessRightsInterface = {
-    'write': 'EVERYONE',
-    'read': 'EVERYONE',
+    'access_rights.write': 'EVERYONE',
+    'access_rights.read': 'EVERYONE',
   };
   constructor(
     public HsAddDataVectorService: HsAddDataVectorService,
@@ -81,6 +81,17 @@ export class HsAddDataVectorComponent {
       return false;
     }
   }
+
+  accessRightChanged(type: string, value: string) {
+    this.access_rights[type] = value;
+    if (
+      this.access_rights['access_rights.read'] == 'private' &&
+      this.access_rights['access_rights.write'] != 'private'
+    ) {
+      this.access_rights['access_rights.write'] = 'private';
+    }
+  }
+
   /**
    * Handler for adding nonwms service, file in template.
    *
@@ -99,6 +110,9 @@ export class HsAddDataVectorComponent {
         features: this.features,
         path: this.hsUtilsService.undefineEmptyString(this.folder_name),
         access_rights: this.access_rights,
+        workspace: this.HsCommonEndpointsService.endpoints.filter(
+          (ep) => ep.type == 'layman'
+        )[0]?.user,
       },
       this.addUnder
     );

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
@@ -82,16 +82,6 @@ export class HsAddDataVectorComponent {
     }
   }
 
-  accessRightChanged(type: string, value: string) {
-    this.access_rights[type] = value;
-    if (
-      this.access_rights['access_rights.read'] == 'private' &&
-      this.access_rights['access_rights.write'] != 'private'
-    ) {
-      this.access_rights['access_rights.write'] = 'private';
-    }
-  }
-
   /**
    * Handler for adding nonwms service, file in template.
    *

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
@@ -11,7 +11,7 @@
             </div>
             <p class="px-5">{{'COMMON.or' | translate}}</p>
             <label class="dropzone-label">
-                <input #vectorFileInput type="file" accept=".kml, .gpx, .geojson" id="hs-vector-file" class="inputfile" (change)="handleFileUpload($event.target.files)">
+                <input #vectorFileInput type="file" accept=".kml, .gpx, .geojson, .json" id="hs-vector-file" class="inputfile" (change)="handleFileUpload($event.target.files)">
                 <label for="hs-vector-file" class="p-2 rounded"> <i class="icon-uploadalt pr-2"></i> {{'ADDLAYERS.Vector.chooseFiles' | translate}}</label>
             </label> 
 

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
@@ -61,15 +61,15 @@
             </label>
             <div class="btn-group">
                 <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.read = 'EVERYONE'"
-                    [ngClass]="{'active':access_rights.read == 'EVERYONE'}">
-                    {{'SAVECOMPOSITION.public' | translate}}
-                </button>
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.read = 'private'"
-                    [ngClass]="{'active':access_rights.read == 'private'}">
-                    {{'SAVECOMPOSITION.private' | translate}}
-                </button>
+                (click)="accessRightChanged('access_rights.read','EVERYONE')"
+                [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
+                {{'SAVECOMPOSITION.public' | translate}}
+            </button>
+            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                (click)="accessRightChanged('access_rights.read','private')"
+                [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
+                {{'SAVECOMPOSITION.private' | translate}}
+            </button>
             </div>
         </div>
         <div class="form-group d-flex justify-content-between pl-4" *ngIf="saveToLayman">
@@ -78,13 +78,14 @@
             </label>
             <div class="btn-group">
                 <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.write = 'EVERYONE'"
-                    [ngClass]="{'active':access_rights.write == 'EVERYONE'}">
+                [disabled]="access_rights['access_rights.read'] == 'private'"
+                (click)="accessRightChanged('access_rights.write','EVERYONE')"
+                    [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
                     {{'SAVECOMPOSITION.public' | translate}}
                 </button>
                 <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="access_rights.write = 'private'"
-                    [ngClass]="{'active':access_rights.write == 'private'}">
+                (click)="accessRightChanged('access_rights.write','private')"
+                    [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
                     {{'SAVECOMPOSITION.private' | translate}}
                 </button>
             </div>

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
@@ -55,40 +55,8 @@
                 </button>
             </div>
         </div>
-        <div class="form-group d-flex justify-content-between pl-4" *ngIf="saveToLayman">
-            <label class="pt-2" style="margin-bottom: 0;">
-                {{'SAVECOMPOSITION.readAccessRights' | translate}}
-            </label>
-            <div class="btn-group">
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                (click)="accessRightChanged('access_rights.read','EVERYONE')"
-                [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
-                {{'SAVECOMPOSITION.public' | translate}}
-            </button>
-            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                (click)="accessRightChanged('access_rights.read','private')"
-                [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
-                {{'SAVECOMPOSITION.private' | translate}}
-            </button>
-            </div>
-        </div>
-        <div class="form-group d-flex justify-content-between pl-4" *ngIf="saveToLayman">
-            <label class="pt-2" style="margin-bottom: 0;">
-                {{'SAVECOMPOSITION.writeAccessRights' | translate}}
-            </label>
-            <div class="btn-group">
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                [disabled]="access_rights['access_rights.read'] == 'private'"
-                (click)="accessRightChanged('access_rights.write','EVERYONE')"
-                    [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
-                    {{'SAVECOMPOSITION.public' | translate}}
-                </button>
-                <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                (click)="accessRightChanged('access_rights.write','private')"
-                    [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
-                    {{'SAVECOMPOSITION.private' | translate}}
-                </button>
-            </div>
+        <div class="pl-4">
+            <hs-layman-access-rights *ngIf="saveToLayman" [(access_rights)]="access_rights"></hs-layman-access-rights>
         </div>
 
         <button type="button" class="btn btn-block btn-outline-secondary dropdown-toggle dropdown-toggle-split"

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.module.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.module.ts
@@ -6,11 +6,18 @@ import {TranslateModule} from '@ngx-translate/core';
 import {HsAddDataCommonModule} from '../common/add-data-common.module';
 import {HsAddDataVectorComponent} from './add-data-vector.component';
 import {HsAddDataVectorService} from './add-data-vector.service';
+import {HsLaymanModule} from '../../../common/layman/layman.module';
 import {HsVectorUrlParserService} from './add-data-vector-url-parser.service';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [CommonModule, FormsModule, TranslateModule, HsAddDataCommonModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TranslateModule,
+    HsAddDataCommonModule,
+    HsLaymanModule,
+  ],
   exports: [HsAddDataVectorComponent],
   declarations: [HsAddDataVectorComponent],
   providers: [HsAddDataVectorService, HsVectorUrlParserService],

--- a/projects/hslayers/src/components/draw/draw-layer-metadata.component.ts
+++ b/projects/hslayers/src/components/draw/draw-layer-metadata.component.ts
@@ -59,16 +59,6 @@ export class HsDrawLayerMetadataDialogComponent
     setTitle(this.layer, this.title);
   }
 
-  accessRightChanged(type: string, value: string) {
-    this.access_rights[type] = value;
-    if (
-      this.access_rights['access_rights.read'] == 'private' &&
-      this.access_rights['access_rights.write'] != 'private'
-    ) {
-      this.access_rights['access_rights.write'] = 'private';
-    }
-  }
-
   confirm(): void {
     const dic = {};
 

--- a/projects/hslayers/src/components/draw/draw-layer-metadata.component.ts
+++ b/projects/hslayers/src/components/draw/draw-layer-metadata.component.ts
@@ -33,8 +33,8 @@ export class HsDrawLayerMetadataDialogComponent
   type: string;
   endpoint: any;
   access_rights: accessRightsInterface = {
-    'write': 'EVERYONE',
-    'read': 'EVERYONE',
+    'access_rights.write': 'EVERYONE',
+    'access_rights.read': 'EVERYONE',
   };
   onlyMineFilterVisible = false;
 
@@ -57,6 +57,16 @@ export class HsDrawLayerMetadataDialogComponent
 
   titleChanged(): void {
     setTitle(this.layer, this.title);
+  }
+
+  accessRightChanged(type: string, value: string) {
+    this.access_rights[type] = value;
+    if (
+      this.access_rights['access_rights.read'] == 'private' &&
+      this.access_rights['access_rights.write'] != 'private'
+    ) {
+      this.access_rights['access_rights.write'] = 'private';
+    }
   }
 
   confirm(): void {

--- a/projects/hslayers/src/components/draw/partials/draw-layer-metadata.html
+++ b/projects/hslayers/src/components/draw/partials/draw-layer-metadata.html
@@ -40,41 +40,7 @@
                                 name="title" />
                         </div>
                     </div>
-                    <div class="form-group d-flex justify-content-between" *ngIf="data.isAuthorized">
-                        <label class="pt-2" style="margin-bottom: 0;">
-                            {{'SAVECOMPOSITION.readAccessRights' | translate}}
-                        </label>
-                        <div class="btn-group">
-                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                            (click)="accessRightChanged('access_rights.read','EVERYONE')"
-                            [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
-                            {{'SAVECOMPOSITION.public' | translate}}
-                        </button>
-                        <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                            (click)="accessRightChanged('access_rights.read','private')"
-                            [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
-                            {{'SAVECOMPOSITION.private' | translate}}
-                        </button>
-                        </div>
-                    </div>
-                    <div class="form-group d-flex justify-content-between"  *ngIf="data.isAuthorized">
-                        <label class="pt-2" style="margin-bottom: 0;">
-                            {{'SAVECOMPOSITION.writeAccessRights' | translate}}
-                        </label>
-                        <div class="btn-group">
-                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                            [disabled]="access_rights['access_rights.read'] == 'private'"
-                            (click)="accessRightChanged('access_rights.write','EVERYONE')"
-                                [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
-                                {{'SAVECOMPOSITION.public' | translate}}
-                            </button>
-                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                            (click)="accessRightChanged('access_rights.write','private')"
-                                [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
-                                {{'SAVECOMPOSITION.private' | translate}}
-                            </button>
-                        </div>
-                    </div>
+                    <hs-layman-access-rights  *ngIf="data.isAuthorized" [(access_rights)]="access_rights"></hs-layman-access-rights>
                     <div class="flex-row w-75 align-items-center" style="display: flex;">
                         <a class="p-1 mb-1"
                             (click)="folderVisible = !folderVisible">{{'COMMON.advancedOptions' | translate}}</a>

--- a/projects/hslayers/src/components/draw/partials/draw-layer-metadata.html
+++ b/projects/hslayers/src/components/draw/partials/draw-layer-metadata.html
@@ -46,15 +46,15 @@
                         </label>
                         <div class="btn-group">
                             <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                                (click)="access_rights.read = 'EVERYONE'"
-                                [ngClass]="{'active':access_rights.read == 'EVERYONE'}">
-                                {{'SAVECOMPOSITION.public' | translate}}
-                            </button>
-                            <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                                (click)="access_rights.read = 'private'"
-                                [ngClass]="{'active':access_rights.read == 'private'}">
-                                {{'SAVECOMPOSITION.private' | translate}}
-                            </button>
+                            (click)="accessRightChanged('access_rights.read','EVERYONE')"
+                            [ngClass]="{'active':access_rights['access_rights.read'] == 'EVERYONE'}">
+                            {{'SAVECOMPOSITION.public' | translate}}
+                        </button>
+                        <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
+                            (click)="accessRightChanged('access_rights.read','private')"
+                            [ngClass]="{'active':access_rights['access_rights.read'] == 'private'}">
+                            {{'SAVECOMPOSITION.private' | translate}}
+                        </button>
                         </div>
                     </div>
                     <div class="form-group d-flex justify-content-between"  *ngIf="data.isAuthorized">
@@ -63,13 +63,14 @@
                         </label>
                         <div class="btn-group">
                             <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                                (click)="access_rights.write = 'EVERYONE'"
-                                [ngClass]="{'active':access_rights.write == 'EVERYONE'}">
+                            [disabled]="access_rights['access_rights.read'] == 'private'"
+                            (click)="accessRightChanged('access_rights.write','EVERYONE')"
+                                [ngClass]="{'active':access_rights['access_rights.write'] == 'EVERYONE'}">
                                 {{'SAVECOMPOSITION.public' | translate}}
                             </button>
                             <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                                (click)="access_rights.write = 'private'"
-                                [ngClass]="{'active':access_rights.write == 'private'}">
+                            (click)="accessRightChanged('access_rights.write','private')"
+                                [ngClass]="{'active':access_rights['access_rights.write'] == 'private'}">
                                 {{'SAVECOMPOSITION.private' | translate}}
                             </button>
                         </div>

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -66,14 +66,16 @@ export class HsLaymanService implements HsSaverService {
    * @return {Promise<any>} Promise result of POST
    */
   save(compositionJson, endpoint, compoData, saveAsNew: boolean) {
+    
     const write =
-      compoData.write == 'EVERYONE' ? compoData.write : endpoint.user;
-    let read;
-    if (write == 'EVERYONE') {
-      read = write;
-    } else {
-      read = compoData.read == 'EVERYONE' ? compoData.read : endpoint.user;
-    }
+    compoData.access_rights['access_rights.write'] == 'private'
+        ? endpoint.user
+        : compoData.access_rights['access_rights.write'];
+    const read =
+    compoData.access_rights['access_rights.read'] == 'private'
+        ? endpoint.user
+        : compoData.access_rights['access_rights.read'];
+
     return new Promise(async (resolve, reject) => {
       const formdata = new FormData();
       formdata.append(

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -114,7 +114,7 @@ export class HsLaymanService implements HsSaverService {
    * Send layer definition and features to Layman
    * @param endpoint Endpoint description
    * @param geojson Geojson object with features to send to server
-   * @param description Object containing {name, title, crs, workspace, acces_rights} of
+   * @param description Object containing {name, title, crs, workspace, access_rights} of
    * layer to retrieve
    * @param layerDesc Previously fetched layer descriptor
    * @return Promise result of POST/PATCH
@@ -139,8 +139,18 @@ export class HsLaymanService implements HsSaverService {
     formdata.append('name', description.name);
     formdata.append('title', description.title);
     formdata.append('crs', description.crs);
-    formdata.append('write', description.acces_rights.write ?? 'EVERYONE');
-    formdata.append('read', description.acces_rights.read ?? 'EVERYONE');
+
+    const write =
+      description.access_rights['access_rights.write'] == 'private'
+        ? endpoint.user
+        : description.access_rights['access_rights.write'] ?? 'EVERYONE';
+    const read =
+      description.access_rights['access_rights.read'] == 'private'
+        ? endpoint.user
+        : description.access_rights['access_rights.read'] ?? 'EVERYONE';
+
+    formdata.append('access_rights.write', write);
+    formdata.append('access_rights.read', read);
 
     const headers = new HttpHeaders();
     headers.append('Content-Type', null);
@@ -204,7 +214,7 @@ export class HsLaymanService implements HsSaverService {
         ? this.crs
         : 'EPSG:3857',
       workspace: getWorkspace(layer),
-      acces_rights: getAccessRights(layer),
+      access_rights: getAccessRights(layer),
     });
     setTimeout(async () => {
       await this.makeGetLayerRequest(ep, layer);

--- a/projects/hslayers/src/components/save-map/partials/form.html
+++ b/projects/hslayers/src/components/save-map/partials/form.html
@@ -25,41 +25,7 @@
                 <input type="text" class="form-control" name="hs-save-map-keywords"
                     [(ngModel)]="HsSaveMapManagerService.compoData.keywords">
             </label>
-            <div class="form-group d-flex justify-content-between">
-                <label class="pt-2" style="margin-bottom: 0;">
-                    {{'SAVECOMPOSITION.readAccessRights' | translate}}
-                </label>
-                <div class="btn-group">
-                    <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        (click)="accessRightChanged('read','EVERYONE')"
-                        [ngClass]="{'active':HsSaveMapManagerService.compoData.read == 'EVERYONE'}">
-                        {{'SAVECOMPOSITION.public' | translate}}
-                    </button>
-                    <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                    (click)="accessRightChanged('read','private')"
-                    [ngClass]="{'active':HsSaveMapManagerService.compoData.read == 'private'}">
-                        {{'SAVECOMPOSITION.private' | translate}}
-                    </button>
-                </div>
-            </div>
-            <div class="form-group d-flex justify-content-between">
-                <label class="pt-2" style="margin-bottom: 0;">
-                    {{'SAVECOMPOSITION.writeAccessRights' | translate}}
-                </label>
-                <div class="btn-group">
-                    <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        [disabled]="HsSaveMapManagerService.compoData.read == 'private'"
-                        (click)="accessRightChanged('write','EVERYONE')"
-                        [ngClass]="{'active':HsSaveMapManagerService.compoData.write == 'EVERYONE'}">
-                        {{'SAVECOMPOSITION.public' | translate}}
-                    </button>
-                    <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        (click)="accessRightChanged('write','private')"
-                        [ngClass]="{'active':HsSaveMapManagerService.compoData.write == 'private'}">
-                        {{'SAVECOMPOSITION.private' | translate}}
-                    </button>
-                </div>
-            </div>
+            <hs-layman-access-rights [(access_rights)]="HsSaveMapManagerService.compoData.access_rights"></hs-layman-access-rights>
             <div class="form-group">
                 <label for="stc-extent1" class="form-group">{{'COMMON.extent' | translate}}</label>
                 <div class="form-row stc-extent-row" *ngIf="HsSaveMapManagerService.compoData.bbox">

--- a/projects/hslayers/src/components/save-map/partials/form.html
+++ b/projects/hslayers/src/components/save-map/partials/form.html
@@ -31,13 +31,13 @@
                 </label>
                 <div class="btn-group">
                     <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        (click)="HsSaveMapManagerService.compoData.read = 'EVERYONE'"
+                        (click)="accessRightChanged('read','EVERYONE')"
                         [ngClass]="{'active':HsSaveMapManagerService.compoData.read == 'EVERYONE'}">
                         {{'SAVECOMPOSITION.public' | translate}}
                     </button>
                     <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        (click)="HsSaveMapManagerService.compoData.read = 'private'"
-                        [ngClass]="{'active':HsSaveMapManagerService.compoData.read == 'private'}">
+                    (click)="accessRightChanged('read','private')"
+                    [ngClass]="{'active':HsSaveMapManagerService.compoData.read == 'private'}">
                         {{'SAVECOMPOSITION.private' | translate}}
                     </button>
                 </div>
@@ -48,12 +48,13 @@
                 </label>
                 <div class="btn-group">
                     <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        (click)="HsSaveMapManagerService.compoData.write = 'EVERYONE'"
+                        [disabled]="HsSaveMapManagerService.compoData.read == 'private'"
+                        (click)="accessRightChanged('write','EVERYONE')"
                         [ngClass]="{'active':HsSaveMapManagerService.compoData.write == 'EVERYONE'}">
                         {{'SAVECOMPOSITION.public' | translate}}
                     </button>
                     <button type="button" class="btn btn-light hs-toolbar-button  btn-outline-secondary"
-                        (click)="HsSaveMapManagerService.compoData.write = 'private'"
+                        (click)="accessRightChanged('write','private')"
                         [ngClass]="{'active':HsSaveMapManagerService.compoData.write == 'private'}">
                         {{'SAVECOMPOSITION.private' | translate}}
                     </button>

--- a/projects/hslayers/src/components/save-map/save-map-advanced-form.component.ts
+++ b/projects/hslayers/src/components/save-map/save-map-advanced-form.component.ts
@@ -70,16 +70,6 @@ export class HsSaveMapAdvancedFormComponent implements OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  accessRightChanged(type: string, value: string) {
-    this.HsSaveMapManagerService.compoData[type] = value;
-    if (
-      this.HsSaveMapManagerService.compoData.read == 'private' &&
-      this.HsSaveMapManagerService.compoData.write != 'private'
-    ) {
-      this.HsSaveMapManagerService.compoData.write = 'private';
-    }
-  }
-
   saveCompoJson(): void {
     const compositionJSON = this.HsSaveMapManagerService.generateCompositionJson(
       true

--- a/projects/hslayers/src/components/save-map/save-map-advanced-form.component.ts
+++ b/projects/hslayers/src/components/save-map/save-map-advanced-form.component.ts
@@ -70,6 +70,16 @@ export class HsSaveMapAdvancedFormComponent implements OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
+  accessRightChanged(type: string, value: string) {
+    this.HsSaveMapManagerService.compoData[type] = value;
+    if (
+      this.HsSaveMapManagerService.compoData.read == 'private' &&
+      this.HsSaveMapManagerService.compoData.write != 'private'
+    ) {
+      this.HsSaveMapManagerService.compoData.write = 'private';
+    }
+  }
+
   saveCompoJson(): void {
     const compositionJSON = this.HsSaveMapManagerService.generateCompositionJson(
       true

--- a/projects/hslayers/src/components/save-map/save-map-manager.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map-manager.service.ts
@@ -13,6 +13,7 @@ import {HsSaverService} from './saver-service.interface';
 import {HsStatusManagerService} from './status-manager.service';
 import {HsUtilsService} from '../utils/utils.service';
 import {getShowInLayerManager, getTitle} from '../../common/layer-extensions';
+import {accessRightsInterface} from '../add-data/common/access-rights.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -35,8 +36,10 @@ export class HsSaveMapManagerService {
     bbox: {east: 0, south: 0, west: 0, north: 0},
     currentCompositionTitle: '',
     currentComposition: undefined,
-    write: 'EVERYONE',
-    read: 'EVERYONE',
+    access_rights: <accessRightsInterface>{
+      'access_rights.write': 'EVERYONE',
+      'access_rights.read': 'EVERYONE',
+    }
   };
   userData: any = {
     email: '',


### PR DESCRIPTION
Make sure user can subimt only logicaly valid combination of access rights and unify this behavior acros the library

fixes:#1842