### PR TITLE
Allow to disable automatic legend

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -8,8 +8,10 @@ import {accessRightsInterface} from '../components/add-data/common/access-rights
 const TITLE = 'title';
 const NAME = 'name';
 const ABSTRACT = 'abstract';
+const ACCESS_RIGHTS = 'access_rights';
 const ACTIVE = 'active';
 const ATTRIBUTION = 'attribution';
+const AUTO_LEGEND = 'autoLegend';
 const CAPABILITIES = 'capabilities';
 const BASE = 'base';
 const CLUSTER = 'cluster';
@@ -46,7 +48,6 @@ const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
 const LEGENDS = 'legends';
 const SUB_LAYERS = 'sublayers';
 const WORKSPACE = 'workspace';
-const ACCESS_RIGHTS = 'access_rights';
 
 export type Attribution = {
   onlineResource?: string;
@@ -86,7 +87,10 @@ export function getAccessRights(layer: Layer): accessRightsInterface {
   return layer.get(ACCESS_RIGHTS);
 }
 
-export function setAccessRights(layer: Layer, access_rights:accessRightsInterface ){
+export function setAccessRights(
+  layer: Layer,
+  access_rights: accessRightsInterface
+): void {
   layer.set(ACCESS_RIGHTS, access_rights);
 }
 
@@ -128,6 +132,14 @@ export function setAttribution(layer: Layer, attribution: Attribution): void {
 
 export function getAttribution(layer: Layer): Attribution {
   return layer.get(ATTRIBUTION);
+}
+
+export function setAutoLegend(layer: Layer): void {
+  layer.set(AUTO_LEGEND);
+}
+
+export function getAutoLegend(layer: Layer): boolean {
+  return layer.get(AUTO_LEGEND);
 }
 
 export function getCachedCapabilities(layer: Layer): any {

--- a/projects/hslayers/src/components/legend/legend.service.ts
+++ b/projects/hslayers/src/components/legend/legend.service.ts
@@ -10,6 +10,7 @@ import {HsLayerSelectorService} from '../layermanager/layer-selector.service';
 import {HsLegendDescriptor} from './legend-descriptor.interface';
 import {HsUtilsService} from '../utils/utils.service';
 import {
+  getAutoLegend,
   getBase,
   getEnableProxy,
   getLegends,
@@ -75,9 +76,11 @@ export class HsLegendService {
     return tmp;
   }
 
-  findFeatureGeomTypes(
-    features: Array<Feature>
-  ): {line: boolean; polygon: boolean; point: boolean} {
+  findFeatureGeomTypes(features: Array<Feature>): {
+    line: boolean;
+    polygon: boolean;
+    point: boolean;
+  } {
     const found = {
       line: false,
       point: false,
@@ -342,7 +345,7 @@ export class HsLegendService {
         getShowInLayerManager(layer) == true)
     ) {
       return {
-        autoLegend: layer.get('autoLegend') ?? true,
+        autoLegend: getAutoLegend(layer) ?? true,
         title: getTitle(layer),
         lyr: layer,
         type: 'vector',

--- a/projects/hslayers/src/components/legend/legend.service.ts
+++ b/projects/hslayers/src/components/legend/legend.service.ts
@@ -342,7 +342,7 @@ export class HsLegendService {
         getShowInLayerManager(layer) == true)
     ) {
       return {
-        autoLegend: true,
+        autoLegend: layer.get('autoLegend') ?? true,
         title: getTitle(layer),
         lyr: layer,
         type: 'vector',


### PR DESCRIPTION
Useful when automatic legend does not represent the map naturally, like in the rural-attractiveness apps.
I wanted to implement this before (in #1702) but forgot to finish it. Hence this PR is more than simple.