### PR TITLE
Fix sublayers toggle

### DIFF
--- a/projects/hslayers/src/components/layermanager/partials/sub-layer-checkboxes.html
+++ b/projects/hslayers/src/components/layermanager/partials/sub-layer-checkboxes.html
@@ -34,7 +34,7 @@
                 </div>
             </div>
         </div>
-        <div *ngIf="subLayer.Layer" class="collapse ml-4" [ngClass]="{'show': expanded}">
+        <div *ngIf="subLayer.Layer" class="collapse ml-4" [hidden]="!expanded">
             <div *ngFor="let subLayer of subLayer.Layer">
                 <div *ngIf="subLayerIsString(subLayer)">
                     <input class="form-check-input" type="checkbox" [(ngModel)]="checkedSubLayers[subLayer]"


### PR DESCRIPTION
A very streamline fix. There was no other class bound when the `expanded` property was set to `false`, so this change simplifies it a bit.
Other places where the 'show' class occurs are worth the check.

fixes #1873