### PR TITLE
Potential fix - do not  add null or undefined url to history list

### DIFF
--- a/projects/hslayers/src/common/history-list/history-list.service.ts
+++ b/projects/hslayers/src/common/history-list/history-list.service.ts
@@ -34,6 +34,9 @@ export class HsHistoryListService {
   }
 
   addSourceHistory(forWhat: string, url: string): void {
+    if (url === null || url === undefined) {
+      return;
+    }
     if (this.items[forWhat]?.history === undefined) {
       this.items[forWhat] = {
         history: [],


### PR DESCRIPTION
@jmacura Would appreciate if You could try to test if the values null or undefined still pops up in the history list dropdown.
This fix does not guaranty that it will work, but at least could be a starting point.