### PR TITLE
Fix missing icons

### DIFF
--- a/projects/hslayers/src/components/compositions/dialogs/dialog_info.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_info.html
@@ -26,9 +26,9 @@
                     </div>
                     <br>
                 </div>
-                <div class="row"  *ngIf="data.info.thumbnail">
+                <div class="row" *ngIf="data.info.thumbnail">
                     <div class="col-md-3"><b>{{'COMMON.thumbnail' | translate}}</b></div>
-                    <div class="col-md-9"><img src="{{data.info.thumbnail}}"></div>
+                    <div class="col-md-9"><img src="{{data.info.thumbnail.url ? data.info.thumbnail.url : data.info.thumbnail}}"></div>
                 </div>
                 <div class="row" *ngIf="data.info.url && data.info">
                     <div class="col-md-3"><b>{{'COMMON.url' | translate}}</b></div>

--- a/projects/hslayers/src/components/compositions/dialogs/info-dialog.component.ts
+++ b/projects/hslayers/src/components/compositions/dialogs/info-dialog.component.ts
@@ -12,10 +12,11 @@ export class HsCompositionsInfoDialogComponent implements HsDialogComponent {
   data: any;
   constructor(
     public HsDialogContainerService: HsDialogContainerService,
-    public HsCompositionsService: HsCompositionsService,
+    public HsCompositionsService: HsCompositionsService
   ) {}
 
   close(): void {
+    console.log(this.data);
     this.HsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -11,6 +11,12 @@ export type SymbolizerIcon = {
 
 @Injectable()
 export class HsConfig {
+  private defaultSymbolizerIcons? = [
+    {name: 'favourite', url: 'img/icons/favourite28.svg'},
+    {name: 'gps', url: 'img/icons/gps43.svg'},
+    {name: 'information', url: 'img/icons/information78.svg'},
+    {name: 'wifi', url: 'img/icons/wifi8.svg'},
+  ];
   cesiumTime?: any;
   componentsEnabled?: any = {
     guiOverlay: true,
@@ -136,19 +142,34 @@ export class HsConfig {
    */
   pathExclusivity?: boolean = false;
   constructor() {
-    this.symbolizerIcons = [
-      {name: 'favourite', url: '/assets/img/icons/favourite28.svg'},
-      {name: 'gps', url: '/assets/img/icons/gps43.svg'},
-      {name: 'information', url: '/assets/img/icons/information78.svg'},
-      {name: 'wifi', url: '/assets/img/icons/wifi8.svg'},
-    ];
+    this.symbolizerIcons = this.defaultSymbolizerIcons.map((val) => {
+      val.url = (this.assetsPath ?? '') + val.url;
+      return val;
+    });
   }
 
   update?(newConfig: HsConfig): void {
     Object.assign(this.componentsEnabled, newConfig.componentsEnabled);
     delete newConfig.componentsEnabled;
+    this.symbolizerIcons = [
+      ...this.updateSymbolizers(newConfig),
+      ...(newConfig.symbolizerIcons ?? []),
+    ];
+    delete newConfig.symbolizerIcons;
     Object.assign(this, newConfig);
 
     this.configChanges.next(this);
+  }
+
+  /**
+   * This kind of duplicates getAssetsPath() in HsUtilsService, which can't be used here due to circular dependency
+   */
+  private updateSymbolizers?(config: HsConfig) {
+    let assetsPath = config.assetsPath ?? '';
+    assetsPath += assetsPath.endsWith('/') ? '' : '/';
+    return this.defaultSymbolizerIcons.map((val) => {
+      val.url = assetsPath + val.url;
+      return val;
+    });
   }
 }


### PR DESCRIPTION
I claimed this issue.
Works nice for me. The default icon set can be extended by developer-user like so:
```
this.HsConfig.update({
      symbolizerIcons: [
        {name: 'aerialway', url: 'https://raw.githubusercontent.com/mapbox/maki/main/icons/aerialway.svg'},
        {name: 'home', url: 'https://raw.githubusercontent.com/mapbox/maki/main/icons/home.svg'}
      ],
})
```

with a result like 
![image](https://user-images.githubusercontent.com/5598693/125102922-184c1b80-e0dc-11eb-87dd-63d345120590.png)


closes #1982 