### PR TITLE
Add warning to unsupported sliders in geostyler

### DIFF
--- a/projects/hslayers/src/components/styles/symbolizers/mark-symbolizer.html
+++ b/projects/hslayers/src/components/styles/symbolizers/mark-symbolizer.html
@@ -30,6 +30,7 @@
     min="0"
     max="1"
     label="{{'STYLER.opacity' | translate}}"
+    warning="{{'STYLER.warningAttribStoredNotVisualized' | translate}}"
   ></hs-symbolizer-slider>
 
   <hs-symbolizer-slider
@@ -57,6 +58,7 @@
     min="0"
     max="1"
     label="{{'STYLER.strokeOpacity' | translate}}"
+    warning="{{'STYLER.warningAttribStoredNotVisualized' | translate}}"
   ></hs-symbolizer-slider>
 
   <hs-symbolizer-slider


### PR DESCRIPTION
Adding the warning signs to MarkerSymbolizer too, as it does not visualize the opacity slider value. Currently only IconSymbolizer can handle it.

![image](https://user-images.githubusercontent.com/5598693/125529211-06e53092-9382-4ad2-a391-ef8b24806326.png)

refs #1956 (but does not closes it!)