### PR TITLE
Stick ol to version 6.5 for a while

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "geostyler-style": "^4.0.2",
     "ngx-color": "^6.0.0",
     "ngx-cookie-service": "^11.0.2",
-    "ol": "^6.5.0",
+    "ol": "~6.5.0",
     "ol-popup": "^4.0.0",
     "passport-oauth2-middleware": "^1.0.3",
     "proj4": "^2.7.5",

--- a/projects/hslayers/package.json
+++ b/projects/hslayers/package.json
@@ -48,7 +48,7 @@
     "geostyler-style": "^4.0.2",
     "ngx-color": "^6.0.0",
     "ngx-cookie-service": "^11.0.0",
-    "ol": "^6.5.0",
+    "ol": "~6.5.0",
     "ol-popup": "^4.0.0",
     "proj4": "^2.7.2",
     "rxjs": "^6.6.7",


### PR DESCRIPTION
This is temporarily preserving from upgrade to @openlayers >= 6.6, as it is creating a throng of errors during build.