### PR TITLE
fix: Pass all view options when cloning the view

### DIFF
--- a/projects/hslayers/src/components/map/map.service.ts
+++ b/projects/hslayers/src/components/map/map.service.ts
@@ -414,18 +414,7 @@ export class HsMapService {
    * @param template
    */
   cloneView(template: View): View {
-    const view = new View({
-      extent: template.options_.extent,
-      maxZoom: template.getMaxZoom(),
-      minZoom: template.getMinZoom(),
-      center: template.getCenter(),
-      zoom: template.getZoom(),
-      projection: template.getProjection(),
-      rotation: template.getRotation(),
-      constrainOnlyCenter: template.options_.constrainOnlyCenter || false,
-      smoothExtentConstraint: template.options_.smoothExtentConstraint || true,
-      multiWorld: template.options_.multiWorld || false,
-    });
+    const view = new View(template.options_);
     return view;
   }
 


### PR DESCRIPTION
We are cloning the view passed in configuration so it alsways uses the OL from hslayers and not some
other external OL. In this cloning process all options should be passed along, not just selected
few.

fix #2034