### PR TITLE
Issue 2052/default old style cluster

### DIFF
--- a/projects/hslayers/src/components/draw/draw.service.ts
+++ b/projects/hslayers/src/components/draw/draw.service.ts
@@ -23,6 +23,7 @@ import {HsUtilsService} from '../utils/utils.service';
 import {Injectable} from '@angular/core';
 import {Layer} from 'ol/layer';
 import {Subject} from 'rxjs';
+import {defaultStyle} from '../styles/styles';
 import {fromCircle} from 'ol/geom/Polygon';
 import {
   getDefinition,
@@ -72,52 +73,6 @@ export class HsDrawService {
   onSelected: any;
   currentStyle: any;
   highlightDrawButton = false; // Toggles toolbar button 'Draw' class
-  defaultStyle = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-  <StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <NamedLayer>
-      <Name/>
-      <UserStyle>
-        <Name/>
-        <Title/>
-        <FeatureTypeStyle>
-          <Rule>
-            <Name/>
-            <PointSymbolizer>
-              <Graphic>
-                <Mark>
-                  <WellKnownName>circle</WellKnownName>
-                  <Fill>
-                    <CssParameter name="fill">rgba(255, 255, 255, 0.41)</CssParameter>
-                  </Fill>
-                  <Stroke>
-                    <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
-                    <CssParameter name="stroke-width">1.25</CssParameter>
-                  </Stroke>
-                </Mark>
-                <Size>10</Size>
-              </Graphic>
-            </PointSymbolizer>
-            <PolygonSymbolizer>
-              <Fill>
-                <CssParameter name="fill-opacity">0.45</CssParameter>
-              </Fill>
-              <Stroke>
-                <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
-                <CssParameter name="stroke-width">1.25</CssParameter>
-                <CssParameter name="stroke-opacity">0.3</CssParameter>
-              </Stroke>
-            </PolygonSymbolizer>
-            <LineSymbolizer>
-              <Stroke>
-                <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
-                <CssParameter name="stroke-width">1.25</CssParameter>
-              </Stroke>
-            </LineSymbolizer>
-          </Rule>
-        </FeatureTypeStyle>
-      </UserStyle>
-    </NamedLayer>
-  </StyledLayerDescriptor>`;
   onDeselected: any;
   public drawingLayerChanges: Subject<{
     layer: BaseLayer;
@@ -281,7 +236,7 @@ export class HsDrawService {
       showInLayerManager: true,
       visible: true,
       removable: true,
-      sld: this.defaultStyle,
+      sld: defaultStyle,
       editable: true,
       path: this.HsConfig.defaultDrawLayerPath || 'User generated', //TODO: Translate this
       definition: {

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -8,8 +8,8 @@ import OpenLayersParser from 'geostyler-openlayers-parser';
 import SLDParser from 'geostyler-sld-parser';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import {Circle, Fill, Icon, Stroke, Style, Text} from 'ol/style';
 import {Filter, Style as GeoStylerStyle, Rule} from 'geostyler-style';
+import {Icon, Style} from 'ol/style';
 import {StyleFunction} from 'ol/style';
 import {createDefaultStyle} from 'ol/style/Style';
 
@@ -20,6 +20,7 @@ import {HsMapService} from '../map/map.service';
 import {HsQueryVectorService} from '../query/query-vector.service';
 import {HsSaveMapService} from '../save-map/save-map.service';
 import {HsUtilsService} from '../utils/utils.service';
+import {defaultStyle} from './styles';
 import {
   getCluster,
   getSld,
@@ -35,37 +36,9 @@ import {parseStyle} from './backwards-compatibility';
 export class HsStylerService {
   layer: VectorLayer = null;
   onSet: Subject<VectorLayer> = new Subject();
-  measure_style = new Style({
-    fill: new Fill({
-      color: 'rgba(255, 255, 255, 1)',
-    }),
-    stroke: new Stroke({
-      color: '#ffcc33',
-      width: 2,
-    }),
-    image: new Circle({
-      radius: 7,
-      fill: new Fill({
-        color: '#ffcc33',
-      }),
-    }),
-  });
-
-  simple_style = new Style({
-    fill: new Fill({
-      color: 'rgba(255, 255, 255, 1)',
-    }),
-    stroke: new Stroke({
-      color: '#ffcc33',
-      width: 1,
-    }),
-    image: new Circle({
-      radius: 7,
-      fill: new Fill({
-        color: '#ffcc33',
-      }),
-    }),
-  });
+  layerTitle: string;
+  styleObject: GeoStylerStyle;
+  parser = new SLDParser();
 
   pin_white_blue = new Style({
     image: new Icon({
@@ -74,17 +47,6 @@ export class HsStylerService {
       anchor: [0.5, 1],
     }),
   });
-  clusterStyle = new Style({
-    stroke: new Stroke({
-      color: '#fff',
-    }),
-    fill: new Fill({
-      color: '#3399CC',
-    }),
-  });
-  layerTitle: string;
-  styleObject: GeoStylerStyle;
-  parser = new SLDParser();
 
   constructor(
     public HsQueryVectorService: HsQueryVectorService,
@@ -207,8 +169,12 @@ export class HsStylerService {
     if (!this.isVectorLayer(layer)) {
       return;
     }
-    const sld = getSld(layer);
+    let sld = getSld(layer);
     let style = layer.getStyle();
+    if ((!style || style == createDefaultStyle) && !sld) {
+      sld = defaultStyle;
+      setSld(layer, defaultStyle);
+    }
     if (sld && (!style || style == createDefaultStyle)) {
       style = (await this.parseStyle(sld)).style;
       if (style) {

--- a/projects/hslayers/src/components/styles/styles.ts
+++ b/projects/hslayers/src/components/styles/styles.ts
@@ -1,0 +1,64 @@
+import {Circle, Fill, Icon, Stroke, Style} from 'ol/style';
+
+export const defaultStyle = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name/>
+    <UserStyle>
+      <Name/>
+      <Title/>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name/>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">rgba(255, 255, 255, 0.41)</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
+                  <CssParameter name="stroke-width">1.25</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>10</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill-opacity">0.45</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
+              <CssParameter name="stroke-width">1.25</CssParameter>
+              <CssParameter name="stroke-opacity">0.3</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
+              <CssParameter name="stroke-width">1.25</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export const simple_style = new Style({
+  fill: new Fill({
+    color: 'rgba(255, 255, 255, 1)',
+  }),
+  stroke: new Stroke({
+    color: '#ffcc33',
+    width: 1,
+  }),
+  image: new Circle({
+    radius: 7,
+    fill: new Fill({
+      color: '#ffcc33',
+    }),
+  }),
+});


### PR DESCRIPTION
## Description

When layers are defined in HsConfig without any style or SLD default OL style is used, but SLD was
not generated from that. This commit fills the SLD attribute with a hardcoded xml very similar to
default OL style. This generated SLD can later be used when the layer is clustered. In that case there will be a SLD which to add new filters to, which check if the feature is single or a merged collection of features.

## Related issues or pull requests

#2052 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
