### PR TITLE
Download and upload of SLD files for existing vector layers

### DIFF
--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -751,7 +751,11 @@
     "transform": "Transform",
     "warningAttribNotStoredNotVisualized": "Attribute currently not visualized correctly and not stored in SLD",
     "warningAttribStoredNotVisualized": "Attribute stored in SLD, but currently is not visualized correctly",
-    "width": "Width"
+    "width": "Width",
+    "uploadSld": "Upload style as SLD file",
+    "downloadSld": "Download style as SLD file",
+    "manageStyle": "Manage style",
+    "clear": "Reset to default style"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Measure lines and polygon"

--- a/projects/hslayers/src/common/download/download.directive.ts
+++ b/projects/hslayers/src/common/download/download.directive.ts
@@ -1,0 +1,32 @@
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+@Directive({
+  selector: '[hsDownload]',
+})
+export class HsDownloadDirective {
+  @Input() hsDownload = '';
+  @Input() mimeType = '';
+  @Output() downloadPrepared = new EventEmitter<string>();
+
+  exportedHref: any;
+  constructor(private DomSanitizer: DomSanitizer) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    const data = new Blob([this.hsDownload], {type: this.mimeType});
+    const url = URL.createObjectURL(data);
+    if (this.exportedHref) {
+      URL.revokeObjectURL(this.exportedHref);
+    }
+    this.exportedHref = this.DomSanitizer.bypassSecurityTrustResourceUrl(url);
+    //Timeout is needed, otherwise the hsDownload will be from previous digest i.e undefined
+    setTimeout(() => {
+      this.downloadPrepared.emit(this.exportedHref);
+    }, 0);
+  }
+}

--- a/projects/hslayers/src/common/download/download.module.ts
+++ b/projects/hslayers/src/common/download/download.module.ts
@@ -1,0 +1,12 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {HsDownloadDirective} from './download.directive';
+@NgModule({
+  declarations: [HsDownloadDirective],
+  imports: [CommonModule],
+  providers: [],
+  entryComponents: [],
+  exports: [HsDownloadDirective],
+})
+export class HsDownloadModule {}

--- a/projects/hslayers/src/common/upload/file-drop.directive.ts
+++ b/projects/hslayers/src/common/upload/file-drop.directive.ts
@@ -2,7 +2,7 @@ import {Directive, EventEmitter, HostListener, Output} from '@angular/core';
 @Directive({
   selector: '[fileDrop]',
 })
-export class HsAddDataCommonVectorFileUploadDirective {
+export class HsFileDropDirective {
   @Output() filesDropped = new EventEmitter<FileList>();
   @Output() filesHovered = new EventEmitter<boolean>();
   constructor() {}

--- a/projects/hslayers/src/common/upload/upload.component.ts
+++ b/projects/hslayers/src/common/upload/upload.component.ts
@@ -1,0 +1,29 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+
+export type HsUploadedFiles = {
+  fileList: FileList;
+  uploader: string;
+  dropped: boolean;
+};
+
+@Component({
+  selector: 'hs-file-upload',
+  templateUrl: './upload.html',
+})
+export class HsUploadComponent {
+  @Output() uploaded = new EventEmitter<HsUploadedFiles>();
+  @Input() acceptedFormats: string;
+  @Input() uploader?: string;
+
+  dropzoneActive = false;
+
+  emitHandleUpload(fileList: FileList, dropped: boolean): void {
+    this.uploaded.emit({fileList, uploader: this.uploader, dropped});
+  }
+
+  dropZoneState($event: boolean): void {
+    this.dropzoneActive = $event;
+  }
+
+  constructor() {}
+}

--- a/projects/hslayers/src/common/upload/upload.html
+++ b/projects/hslayers/src/common/upload/upload.html
@@ -1,0 +1,14 @@
+<div class="d-flex justify-content-center align-items-center w-100 dropzone-container">
+    <div class="dropzone p-4" fileDrop (filesDropped)="emitHandleUpload($event, true)"
+        (filesHovered)="dropZoneState($event)" [ngClass]="{'active': dropzoneActive}">
+        <p class="dropzone-label mt-2 text-primary">{{'ADDLAYERS.Vector.dragAndDropFiles' | translate}}</p>
+    </div>
+    <p class="px-5">{{'COMMON.or' | translate}}</p>
+    <label class="dropzone-label">
+        <input #vectorFileInput type="file" [accept]="acceptedFormats" [id]="uploader"
+            class="inputfile" (change)="emitHandleUpload($event.target.files, false)" multiple>
+        <label [for]="uploader" class="p-2 rounded"> <i class="icon-uploadalt pr-2"></i>
+            {{'ADDLAYERS.Vector.chooseFiles' | translate}}</label>
+    </label>
+
+</div>

--- a/projects/hslayers/src/common/upload/upload.module.ts
+++ b/projects/hslayers/src/common/upload/upload.module.ts
@@ -1,0 +1,15 @@
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {NgModule} from '@angular/core';
+import {TranslateModule} from '@ngx-translate/core';
+
+import {HsFileDropDirective} from './file-drop.directive';
+import {HsUploadComponent} from './upload.component';
+@NgModule({
+  declarations: [HsUploadComponent, HsFileDropDirective],
+  imports: [CommonModule, TranslateModule, FormsModule],
+  providers: [],
+  entryComponents: [],
+  exports: [HsUploadComponent, HsFileDropDirective],
+})
+export class HsUploadModule {}

--- a/projects/hslayers/src/common/widgets/ui-extensions.module.ts
+++ b/projects/hslayers/src/common/widgets/ui-extensions.module.ts
@@ -4,7 +4,6 @@ import {NgModule} from '@angular/core';
 import {EndpointsWithDatasourcesPipe} from './endpoints-with-datasources.pipe';
 import {FilterPipe} from './filter.pipe';
 import {HsUiExtensionsRecursiveDdComponent} from './recursive-dd.component';
-
 @NgModule({
   declarations: [
     HsUiExtensionsRecursiveDdComponent,

--- a/projects/hslayers/src/components/add-data/common/add-data-common.module.ts
+++ b/projects/hslayers/src/components/add-data/common/add-data-common.module.ts
@@ -4,7 +4,6 @@ import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 import {TranslateModule} from '@ngx-translate/core';
 
-import {HsAddDataCommonVectorFileUploadDirective} from './add-data-common-vector-file-upload.directive';
 import {HsAddDataTargetPositionComponent} from './add-data-target-position.component';
 import {HsAddDataUrlComponent} from './add-data-url.component';
 import {HsGetCapabilitiesErrorComponent} from './capabilities-error-dialog.component';
@@ -20,7 +19,6 @@ import {WmsLayerHighlightDirective} from './add-data-wms-layer-highlight-directi
     HsAddDataTargetPositionComponent,
     HsGetCapabilitiesErrorComponent,
     HsNestedLayersTableComponent,
-    HsAddDataCommonVectorFileUploadDirective,
     WmsLayerHighlightDirective,
   ],
   declarations: [
@@ -28,7 +26,6 @@ import {WmsLayerHighlightDirective} from './add-data-wms-layer-highlight-directi
     HsAddDataTargetPositionComponent,
     HsGetCapabilitiesErrorComponent,
     HsNestedLayersTableComponent,
-    HsAddDataCommonVectorFileUploadDirective,
     WmsLayerHighlightDirective,
   ],
   providers: [],

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-layer.directive.html
@@ -17,17 +17,7 @@
         <input name="file" type="file" (change)="read($event)" id="shpdbfshx" multiple>
     </div> -->
     <div class="form-group">
-        <div class="d-flex justify-content-center align-items-center w-100 dropzone-container">
-            <div class="dropzone p-4" fileDrop (filesDropped)="read($event)" (filesHovered)="dropZoneState($event)" [ngClass]="{'active': dropzoneActive}">
-                    <p class="dropzone-label mt-2 text-primary">{{'ADDLAYERS.Vector.dragAndDropFiles' | translate}}</p>
-            </div>
-            <p class="px-5">{{'COMMON.or' | translate}}</p>
-            <label class="dropzone-label">
-                <input name="file" type="file"  accept=".shp, .shx, .dbf, .sbn" class="inputfile" (change)="read($event)" id="shpdbfshx" multiple>
-                <label for="shpdbfshx" class="p-2 rounded"> <i class="icon-uploadalt pr-2"></i>{{'ADDLAYERS.Vector.chooseFiles' | translate}}</label>
-            </label> 
-
-        </div>
+        <hs-file-upload (uploaded)="read($event)" acceptedFormats=".shp, .shx, .dbf, .sbn" uploader="shpdbfshx"></hs-file-upload>
         <!-- TODO: Replace this with upcomming toast directive -->
         <div class="text-light text-center bg-danger" *ngIf="errorOccurred">
             <p>{{'ADDLAYERS.couldNotUploadSelectedFile' | translate}}</p>
@@ -66,7 +56,7 @@
         <div class="d-flex justify-content-between align-items-center">
             <p>{{'ADDLAYERS.SHP.SLDStyleFile' | translate}}</p>
             <label class="dropzone-label">
-                <input name="file" type="file" accept=".sld" class="inputfile" (change)="read($event)" id="sld" multiple>
+                <input name="file" type="file" accept=".sld" class="inputfile" (change)="read({fileList: $event.target.files, uploader: 'sld', dropped: false})" id="sld">
                 <label for="sld" class="p-2 rounded" style="font-size: 1em;" [ngClass]="sld ? 'bg-success' : 'bg-primary'"> <i class="icon-uploadalt pr-2"></i>{{sldTitle()}}</label>
             </label> 
         </div>

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.component.ts
@@ -15,6 +15,7 @@ import {HsLaymanLayerDescriptor} from '../../../save-map/layman-layer-descriptor
 import {HsLaymanService} from '../../../save-map/layman.service';
 import {HsLayoutService} from '../../../layout/layout.service';
 import {HsLogService} from '../../../../common/log/log.service';
+import {HsUploadedFiles} from '../../../../common/upload/upload.component';
 import {HsUtilsService} from '../../../utils/utils.service';
 import {accessRightsInterface} from '../../common/access-rights.interface';
 
@@ -178,9 +179,9 @@ export class HsAddDataFileShpComponent implements OnInit {
       });
   }
 
-  read(evt): void {
+  read(evt: HsUploadedFiles): void {
     const filesRead = [];
-    const files = evt.target ? evt.target.files : evt;
+    const files = Array.from(evt.fileList);
 
     const promises = [];
     for (const file of files) {
@@ -199,7 +200,7 @@ export class HsAddDataFileShpComponent implements OnInit {
       promises.push(filePromise);
     }
     Promise.all(promises).then((fileContents) => {
-      if (evt.target?.id === 'sld') {
+      if (evt.uploader === 'sld') {
         this.sld = filesRead[0];
       } else {
         if (this.files.length == 3) {
@@ -224,7 +225,7 @@ export class HsAddDataFileShpComponent implements OnInit {
       }
     });
 
-    if (evt.target?.id === 'shpdbfshx') {
+    if (evt.uploader === 'shpdbfshx') {
       this.files = filesRead;
     }
     console.log(this.files);

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.module.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.module.ts
@@ -8,7 +8,7 @@ import {HsAddDataFileShpComponent} from './add-data-file-shp.component';
 import {HsAddDataFileShpService} from './add-data-file-shp.service';
 import {HsLaymanModule} from '../../../../common/layman/layman.module';
 import {HsUiExtensionsModule} from '../../../../common/widgets/ui-extensions.module';
-import {HsUploadModule} from 'projects/hslayers/src/common/upload/upload.module';
+import {HsUploadModule} from '../../../../common/upload/upload.module';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.module.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/add-data-file-shp.module.ts
@@ -8,6 +8,7 @@ import {HsAddDataFileShpComponent} from './add-data-file-shp.component';
 import {HsAddDataFileShpService} from './add-data-file-shp.service';
 import {HsLaymanModule} from '../../../../common/layman/layman.module';
 import {HsUiExtensionsModule} from '../../../../common/widgets/ui-extensions.module';
+import {HsUploadModule} from 'projects/hslayers/src/common/upload/upload.module';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -16,6 +17,7 @@ import {HsUiExtensionsModule} from '../../../../common/widgets/ui-extensions.mod
     FormsModule,
     TranslateModule,
     HsUiExtensionsModule,
+    HsUploadModule,
     HsAddDataCommonModule,
     HsLaymanModule,
   ],

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
@@ -12,6 +12,7 @@ import {HsLayerManagerService} from '../../layermanager/layermanager.service';
 import {HsLayerUtilsService} from '../../utils/layer-utils.service';
 import {HsLayoutService} from '../../layout/layout.service';
 import {HsToastService} from '../../layout/toast/toast.service';
+import {HsUploadedFiles} from '../../../common/upload/upload.component';
 import {HsUtilsService} from '../../utils/utils.service';
 import {accessRightsInterface} from '../common/access-rights.interface';
 import {getHsLaymanSynchronizing} from '../../../common/layer-extensions';
@@ -33,7 +34,6 @@ export class HsAddDataVectorComponent implements OnInit {
   name = '';
   advancedPanelVisible = false;
   folder_name = '';
-  dropzoneActive = false;
   features: any[] = [];
   featureCount = 0;
   type = '';
@@ -172,11 +172,8 @@ export class HsAddDataVectorComponent implements OnInit {
     return true;
   }
 
-  dropZoneState($event: boolean): void {
-    this.dropzoneActive = $event;
-  }
-  handleFileUpload(fileList: FileList): any {
-    Array.from(fileList).forEach(async (f) => {
+  handleFileUpload(evt: HsUploadedFiles): void {
+    Array.from(evt.fileList).forEach(async (f) => {
       const uploadedData = await this.hsAddDataVectorService.readUploadedFile(
         f
       );
@@ -253,7 +250,6 @@ export class HsAddDataVectorComponent implements OnInit {
     this.name = '';
     this.advancedPanelVisible = false;
     this.folder_name = '';
-    this.dropzoneActive = false;
     this.features = [];
     this.featureCount = 0;
     this.type = '';

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.directive.html
@@ -3,21 +3,7 @@
         [(connect)]="connect"></hs-add-data-common-url>
 
     <div class="form-group m-3" *ngIf="hsAddDataService.typeSelected == 'file'">
-        <div class="d-flex justify-content-center align-items-center w-100 dropzone-container">
-            <!-- <label class="capabilities_label control-label">{{'ADDLAYERS.Vector.uploadVectorFiles' | translate}}</label> -->
-            <div class="dropzone p-4" fileDrop (filesDropped)="handleFileUpload($event)"
-                (filesHovered)="dropZoneState($event)" [ngClass]="{'active': dropzoneActive}">
-                <p class="dropzone-label mt-2 text-primary">{{'ADDLAYERS.Vector.dragAndDropFiles' | translate}}</p>
-            </div>
-            <p class="px-5">{{'COMMON.or' | translate}}</p>
-            <label class="dropzone-label">
-                <input #vectorFileInput type="file" [accept]="acceptedFormats" id="hs-vector-file"
-                    class="inputfile" (change)="handleFileUpload($event.target.files)">
-                <label for="hs-vector-file" class="p-2 rounded"> <i class="icon-uploadalt pr-2"></i>
-                    {{'ADDLAYERS.Vector.chooseFiles' | translate}}</label>
-            </label>
-
-        </div>
+       <hs-file-upload (uploaded)="handleFileUpload($event)" uploader="hs-vector-file" [acceptedFormats]="acceptedFormats"></hs-file-upload>
     </div>
 
     <div *ngIf="showDetails">

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.module.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.module.ts
@@ -7,6 +7,7 @@ import {HsAddDataCommonModule} from '../common/add-data-common.module';
 import {HsAddDataVectorComponent} from './add-data-vector.component';
 import {HsAddDataVectorService} from './add-data-vector.service';
 import {HsLaymanModule} from '../../../common/layman/layman.module';
+import {HsUploadModule} from '../../../common/upload/upload.module';
 import {HsVectorUrlParserService} from './add-data-vector-url-parser.service';
 
 @NgModule({
@@ -17,6 +18,7 @@ import {HsVectorUrlParserService} from './add-data-vector-url-parser.service';
     TranslateModule,
     HsAddDataCommonModule,
     HsLaymanModule,
+    HsUploadModule,
   ],
   exports: [HsAddDataVectorComponent],
   declarations: [HsAddDataVectorComponent],

--- a/projects/hslayers/src/components/query/feature.component.ts
+++ b/projects/hslayers/src/components/query/feature.component.ts
@@ -12,9 +12,20 @@ export class HsQueryFeatureComponent {
   attributeName = '';
   attributeValue = '';
   newAttribVisible = false;
-  exportFormats = [
-    {name: 'WKT', ext: 'wkt'},
-    {name: 'GeoJSON', ext: 'geojson'},
+  exportFormats: {
+    name: 'WKT' | 'GeoJSON';
+    ext: string; //File extension
+    serializedData?: string; //Features as string according to WKT or GeoJSON
+    mimeType: string;
+    downloadData?: any; //Serialized/sanitized data suitable for href
+  }[] = [
+    {name: 'WKT', ext: 'wkt', mimeType: 'text/plain', downloadData: ''},
+    {
+      name: 'GeoJSON',
+      ext: 'geojson',
+      mimeType: 'application/json',
+      downloadData: '',
+    },
   ];
   exportMenuVisible = false;
   constructor(
@@ -60,5 +71,16 @@ export class HsQueryFeatureComponent {
     this.HsMapService.map
       .getView()
       .fit(extent, this.HsMapService.map.getSize());
+  }
+
+  toggleExportMenu(): void {
+    for (const format of this.exportFormats) {
+      format.serializedData = this.HsQueryVectorService.exportData(
+        format.name,
+        this.feature.feature
+      );
+    }
+
+    this.exportMenuVisible = !this.exportMenuVisible;
   }
 }

--- a/projects/hslayers/src/components/query/partials/feature.html
+++ b/projects/hslayers/src/components/query/partials/feature.html
@@ -38,12 +38,16 @@
                     class="icon-calcplus"></i></button>
             <button class="btn btn-primary btn-sm" (click)="zoomToFeature()"><i class="icon-search"></i></button>
             <button class="btn btn-success btn-sm dropdown-toggle" type="button" data-toggle="dropdown"
-                aris-haspopup="true" (click)="exportMenuVisible = !exportMenuVisible"><i
+                aris-haspopup="true" (click)="toggleExportMenu()"><i
                     class="icon-download"></i></button>
             <div class="dropdown-menu dropdown-menu-right" [ngClass]="{'show': exportMenuVisible}">
-                <a class="dropdown-item" download="{{format.name}}_file.{{format.ext}}"
-                    [href]="HsQueryVectorService.exportedFeatureHref" *ngFor="let format of exportFormats"
-                    (click)="HsQueryVectorService.exportData(format.name,feature.feature);">{{format.name}}</a>
+                <a class="dropdown-item" download="{{format.name}}_file.{{format.ext}}" 
+                [hsDownload]="format.serializedData" 
+                [mimeType]="format.mimeType"
+                [href]="format.downloadData"
+                (downloadPrepared)="format.downloadData = $event"
+                *ngFor="let format of exportFormats"
+                >{{format.name}}</a>
             </div>
             <button class="btn btn-danger btn-sm" (click)="removeFeature()" *ngIf="isFeatureRemovable()"><i
                     class="icon-trash"></i></button>

--- a/projects/hslayers/src/components/query/query-vector.service.ts
+++ b/projects/hslayers/src/components/query/query-vector.service.ts
@@ -35,9 +35,11 @@ type AttributeValuePair = {
   providedIn: 'root',
 })
 export class HsQueryVectorService {
-  exportedFeatureHref: any;
   selector: Select;
   featureRemovals: Subject<Feature> = new Subject();
+  serializedFeatures: any;
+  downloadDataType: string;
+  downloadData: any;
 
   constructor(
     public HsQueryBaseService: HsQueryBaseService,
@@ -126,33 +128,22 @@ export class HsQueryVectorService {
     this.HsQueryBaseService.getFeatureInfoCollected.next();
   }
 
-  exportData(clickedFormat: 'WKT' | 'GeoJSON', feature: Feature): void {
+  exportData(clickedFormat: 'WKT' | 'GeoJSON', feature: Feature): string {
     let fmt;
-    let type;
-    let serializedFeatures;
     switch (clickedFormat) {
       case 'WKT':
         fmt = new WKT();
-        type = 'text/plain';
-        serializedFeatures = fmt.writeFeature(feature);
+        return fmt.writeFeature(feature);
         break;
       case 'GeoJSON':
       default:
         fmt = new GeoJSON();
-        type = 'application/json';
-        serializedFeatures = fmt.writeFeatures([feature], {
+        return fmt.writeFeatures([feature], {
           dataProjection: 'EPSG:4326',
           featureProjection: this.HsMapService.getCurrentProj(),
         });
         break;
     }
-    const data = new Blob([serializedFeatures], {type});
-    const url = URL.createObjectURL(data);
-    if (this.exportedFeatureHref) {
-      URL.revokeObjectURL(this.exportedFeatureHref);
-    }
-    this.exportedFeatureHref =
-      this.DomSanitizer.bypassSecurityTrustResourceUrl(url);
   }
 
   /**

--- a/projects/hslayers/src/components/query/query-vector.service.ts
+++ b/projects/hslayers/src/components/query/query-vector.service.ts
@@ -37,9 +37,6 @@ type AttributeValuePair = {
 export class HsQueryVectorService {
   selector: Select;
   featureRemovals: Subject<Feature> = new Subject();
-  serializedFeatures: any;
-  downloadDataType: string;
-  downloadData: any;
 
   constructor(
     public HsQueryBaseService: HsQueryBaseService,

--- a/projects/hslayers/src/components/query/query.module.ts
+++ b/projects/hslayers/src/components/query/query.module.ts
@@ -5,6 +5,8 @@ import {
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
+
+import {HsDownloadModule} from '../../common/download/download.module';
 import {HsPanelHelpersModule} from '../layout/panels/panel-helpers.module';
 import {HsQueryAttributeRowComponent} from './attribute-row.component';
 import {HsQueryBaseService} from './query-base.service';
@@ -26,7 +28,13 @@ import {TranslateModule} from '@ngx-translate/core';
     HsQueryDefaultInfoPanelBodyComponent,
     HsQueryAttributeRowComponent,
   ],
-  imports: [CommonModule, HsPanelHelpersModule, FormsModule, TranslateModule],
+  imports: [
+    CommonModule,
+    HsPanelHelpersModule,
+    FormsModule,
+    TranslateModule,
+    HsDownloadModule,
+  ],
   exports: [
     HsQueryComponent,
     HsQueryFeaturePopupComponent,

--- a/projects/hslayers/src/components/styles/styler.component.ts
+++ b/projects/hslayers/src/components/styles/styler.component.ts
@@ -66,27 +66,16 @@ export class HsStylerComponent implements OnDestroy {
   }
 
   handleFileUpload(evt: HsUploadedFiles): void {
-    const filesRead = [];
     const files = Array.from(evt.fileList);
-
-    const promises = [];
-    for (const file of files) {
-      const filePromise = new Promise((resolve) => {
+    const promises = files.map((file) => {
+      return new Promise((resolve) => {
         const reader = new FileReader();
-        reader.onload = (loadEvent) => {
-          filesRead.push({
-            name: file.name,
-            type: file.type,
-            content: loadEvent.target.result,
-          });
-          resolve(reader.result);
-        };
+        reader.onload = () => resolve(reader.result);
         reader.readAsText(file);
       });
-      promises.push(filePromise);
-    }
+    });
     Promise.all(promises).then(async (fileContents) => {
-      const sld = fileContents[0];
+      const sld = fileContents[0] as string;
       await this.HsStylerService.loadSld(sld);
     });
   }

--- a/projects/hslayers/src/components/styles/styler.component.ts
+++ b/projects/hslayers/src/components/styles/styler.component.ts
@@ -12,7 +12,6 @@ import {HsSaveMapService} from '../save-map/save-map.service';
 import {HsStylerService} from '../styles/styler.service';
 import {HsUploadedFiles} from '../../common/upload/upload.component';
 import {HsUtilsService} from '../utils/utils.service';
-import {setSld} from '../../common/layer-extensions';
 
 @Component({
   selector: 'hs-styles',
@@ -22,6 +21,8 @@ export class HsStylerComponent implements OnDestroy {
   layerTitle: string;
   private ngUnsubscribe = new Subject();
   uploaderVisible = false;
+  downloadData: any;
+
   constructor(
     public HsStylerService: HsStylerService,
     public HsLayoutService: HsLayoutService,
@@ -59,8 +60,6 @@ export class HsStylerComponent implements OnDestroy {
   uploadSld(): void {
     this.uploaderVisible = !this.uploaderVisible;
   }
-
-  downloadSld(): void {}
 
   async clear(): Promise<void> {
     await this.HsStylerService.reset();

--- a/projects/hslayers/src/components/styles/styler.html
+++ b/projects/hslayers/src/components/styles/styler.html
@@ -33,7 +33,10 @@
             <button ngbDropdownItem (click)="HsStylerService.addRule('Simple')">
               {{'STYLER.simpleRule' | translate}}
             </button>
-            <button ngbDropdownItem (click)="HsStylerService.addRule('Cluster')">
+            <button
+              ngbDropdownItem
+              (click)="HsStylerService.addRule('Cluster')"
+            >
               {{'STYLER.clusterRule' | translate}}
             </button>
           </div>
@@ -47,20 +50,51 @@
     >
       <ngb-panel *ngFor="let rule of HsStylerService.styleObject.rules">
         <ng-template ngbPanelTitle>
-          <span style="display: inline-block;text-align: left; width: 18.2em">{{rule.name || 'untitled rule'}}</span>
+          <span style="display: inline-block; text-align: left; width: 18.2em"
+            >{{rule.name || 'untitled rule'}}</span
+          >
           <button
-          class="btn btn-danger btn-sm"
-          (click)="HsStylerService.removeRule(rule)"
-          data-toggle="tooltip"
-          [title]="'STYLER.removeRule' | translate"
-        >
-          <i class="icon-trash"></i>
-        </button>
+            class="btn btn-danger btn-sm"
+            (click)="HsStylerService.removeRule(rule)"
+            data-toggle="tooltip"
+            [title]="'STYLER.removeRule' | translate"
+          >
+            <i class="icon-trash"></i>
+          </button>
         </ng-template>
         <ng-template ngbPanelContent>
           <hs-rule [rule]="rule" (changes)="HsStylerService.save()"></hs-rule>
         </ng-template>
       </ngb-panel>
     </ngb-accordion>
+  </div>
+  <div class="card-footer">
+    <div class="form-group m-3" *ngIf="uploaderVisible">
+      <hs-file-upload (uploaded)="handleFileUpload($event)" uploader="hs-sld-upload" acceptedFormats=".sld"></hs-file-upload>
+   </div>
+    <div
+      class="btn-group"
+      role="group"
+      [attr.aria-label]="'STYLER.manageStyle' | translate"
+    >
+      <button
+        class="btn btn-secondary"
+        (click)="downloadSld()"
+        data-toggle="tooltip"
+        [title]="'STYLER.downloadSld' | translate"
+      >
+        <i class="icon-download"></i>
+      </button>
+      <button
+        class="btn btn-secondary"
+        (click)="uploadSld()"
+        data-toggle="tooltip"
+        [title]="'STYLER.uploadSld' | translate"
+      >
+        <i class="icon-upload"></i>
+      </button>
+      <button class="btn btn-danger" (click)="clear()" data-toggle="tooltip"
+      [title]="'STYLER.clear' | translate"><i class="icon-trash"></i></button>
+    </div>
   </div>
 </div>

--- a/projects/hslayers/src/components/styles/styler.html
+++ b/projects/hslayers/src/components/styles/styler.html
@@ -70,21 +70,29 @@
   </div>
   <div class="card-footer">
     <div class="form-group m-3" *ngIf="uploaderVisible">
-      <hs-file-upload (uploaded)="handleFileUpload($event)" uploader="hs-sld-upload" acceptedFormats=".sld"></hs-file-upload>
-   </div>
+      <hs-file-upload
+        (uploaded)="handleFileUpload($event)"
+        uploader="hs-sld-upload"
+        acceptedFormats=".sld"
+      ></hs-file-upload>
+    </div>
     <div
       class="btn-group"
       role="group"
       [attr.aria-label]="'STYLER.manageStyle' | translate"
     >
-      <button
+      <a
         class="btn btn-secondary"
-        (click)="downloadSld()"
-        data-toggle="tooltip"
+        download="style.sld"
+        [hsDownload]="HsStylerService.sld"
+        mimeType="text/plain"
+        [href]="downloadData"
+        (downloadPrepared)="downloadData = $event"
         [title]="'STYLER.downloadSld' | translate"
       >
-        <i class="icon-download"></i>
-      </button>
+        <i class="icon-download"></i
+      ></a>
+
       <button
         class="btn btn-secondary"
         (click)="uploadSld()"
@@ -93,8 +101,14 @@
       >
         <i class="icon-upload"></i>
       </button>
-      <button class="btn btn-danger" (click)="clear()" data-toggle="tooltip"
-      [title]="'STYLER.clear' | translate"><i class="icon-trash"></i></button>
+      <button
+        class="btn btn-danger"
+        (click)="clear()"
+        data-toggle="tooltip"
+        [title]="'STYLER.clear' | translate"
+      >
+        <i class="icon-trash"></i>
+      </button>
     </div>
   </div>
 </div>

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -39,6 +39,7 @@ export class HsStylerService {
   layerTitle: string;
   styleObject: GeoStylerStyle;
   parser = new SLDParser();
+  sld: string;
 
   pin_white_blue = new Style({
     image: new Icon({
@@ -190,6 +191,7 @@ export class HsStylerService {
         setSld(layer, sld);
       }
     }
+    this.sld = sld;
   }
 
   /**
@@ -349,6 +351,7 @@ export class HsStylerService {
       this.layer.setStyle(style);
       const sld = await this.jsonToSld(this.styleObject);
       setSld(this.layer, sld);
+      this.sld = sld;
       this.onSet.next(this.layer);
     } catch (ex) {
       this.HsLogService.error(ex);

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -382,4 +382,22 @@ export class HsStylerService {
       return tmp;
     };
   }
+
+  async reset(): Promise<void> {
+    setSld(this.layer, undefined);
+    this.layer.setStyle(createDefaultStyle);
+    await this.initLayerStyle(this.layer);
+    await this.save();
+  }
+
+  async loadSld(sld: string): Promise<void> {
+    try {
+      await this.parser.readStyle(sld);
+      setSld(this.layer, sld);
+      await this.fill(this.layer);
+      await this.save();
+    } catch (err) {
+      console.warn('SLD could not be parsed');
+    }
+  }
 }

--- a/projects/hslayers/src/components/styles/styler.spec.ts
+++ b/projects/hslayers/src/components/styles/styler.spec.ts
@@ -14,6 +14,7 @@ import {Point, Polygon} from 'ol/geom';
 import {Vector as VectorSource} from 'ol/source';
 
 import {HsConfig} from '../../config.service';
+import {HsDownloadModule} from '../../common/download/download.module';
 import {HsEventBusService} from '../core/event-bus.service';
 import {HsEventBusServiceMock} from '../core/event-bus.service.mock';
 import {HsLayerUtilsService} from './../utils/layer-utils.service';
@@ -83,6 +84,7 @@ describe('HsStyler', () => {
         FormsModule,
         HttpClientTestingModule,
         TranslateModule.forRoot(),
+        HsDownloadModule,
       ],
       declarations: [HsStylerComponent],
       providers: [

--- a/projects/hslayers/src/components/styles/styles.module.ts
+++ b/projects/hslayers/src/components/styles/styles.module.ts
@@ -30,6 +30,7 @@ import {HsStylerPartBaseComponent} from './style-part-base.component';
 import {HsStylerService} from './styler.service';
 import {HsSymbolizerComponent} from './symbolizers/symbolizer.component';
 import {HsTextSymbolizerComponent} from './symbolizers/text-symbolizer.component';
+import {HsUploadModule} from '../../common/upload/upload.module';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
@@ -59,6 +60,7 @@ import {HsTextSymbolizerComponent} from './symbolizers/text-symbolizer.component
     FormsModule,
     NgbModule,
     TranslateModule,
+    HsUploadModule,
   ],
   exports: [
     HsStylerComponent,

--- a/projects/hslayers/src/components/styles/styles.module.ts
+++ b/projects/hslayers/src/components/styles/styles.module.ts
@@ -31,6 +31,7 @@ import {HsStylerService} from './styler.service';
 import {HsSymbolizerComponent} from './symbolizers/symbolizer.component';
 import {HsTextSymbolizerComponent} from './symbolizers/text-symbolizer.component';
 import {HsUploadModule} from '../../common/upload/upload.module';
+import { HsDownloadModule } from '../../common/download/download.module';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
@@ -61,6 +62,7 @@ import {HsUploadModule} from '../../common/upload/upload.module';
     NgbModule,
     TranslateModule,
     HsUploadModule,
+    HsDownloadModule,
   ],
   exports: [
     HsStylerComponent,

--- a/projects/hslayers/src/components/styles/symbolizers/icon-symbolizer.html
+++ b/projects/hslayers/src/components/styles/symbolizers/icon-symbolizer.html
@@ -81,6 +81,7 @@
         max="1.0"
         [ngModelOptions]="{standalone: true}"
         [(ngModel)]="symbolizer.offset[0]"
+        *ngIf="symbolizer.offset != undefined"
         (change)="emitChange()"
       />
     </div>
@@ -99,6 +100,7 @@
         max="1.0"
         [ngModelOptions]="{standalone: true}"
         [(ngModel)]="symbolizer.offset[1]"
+        *ngIf="symbolizer.offset != undefined"
         (change)="emitChange()"
       />
     </div>

--- a/projects/hslayers/src/components/styles/symbolizers/text-symbolizer.html
+++ b/projects/hslayers/src/components/styles/symbolizers/text-symbolizer.html
@@ -143,6 +143,7 @@
         max="40"
         [ngModelOptions]="{standalone: true}"
         [(ngModel)]="symbolizer.offset[0]"
+        *ngIf="symbolizer.offset != undefined"
         (change)="emitChange()"
       />
     </div>
@@ -159,6 +160,7 @@
         max="40"
         [ngModelOptions]="{standalone: true}"
         [(ngModel)]="symbolizer.offset[1]"
+        *ngIf="symbolizer.offset != undefined"
         (change)="emitChange()"
       />
     </div>

--- a/projects/hslayers/src/public-api.ts
+++ b/projects/hslayers/src/public-api.ts
@@ -53,4 +53,7 @@ export * from './common/log/log.module';
 export * from './common/log/log.service';
 export * from './common/queues/queues.module';
 export * from './common/queues/queues.service';
+export * from './common/widgets/ui-extensions.module';
+export * from './common/upload/upload.module';
+export * from './common/upload/upload.component';
 export * from './common/get-capabilities/wms-get-capabilities-response.interface';


### PR DESCRIPTION
## Description

This PR does several things:
+ Extracts upload file picker / drop zone into separate reusable component which now is used to upload SHP, Geojson, KML and SLD for shapefiles
+ Provides uploading of SLD file in Styler panel for all existing vector layers
+ Refactors existing dynamic generation of downloadable content functionality into a directive, to which a string is given as input and event is emited back with a sanitized href attribute content
+ Provides download button for SLD style in styler panel

## Related issues or pull requests

#2046 
## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
