### PR TITLE
refactor(feature-popup): All displayed text should be translatable

### DIFF
--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -582,7 +582,8 @@
     },
     "reallyDelete": "Really delete this feature?",
     "reallyDeleteAllFeaturesFrom": "Really delete all features from layer {0}?",
-    "untitledFeature": "Untitled feature"
+    "untitledFeature": "Untitled feature",
+    "clusterContaining": "Cluster containing {{count}} features"
   },
   "SAVECOMPOSITION": {
     "dialogResult": {

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -582,7 +582,8 @@
     },
     "reallyDelete": "Vai tiešām vēlaties dzēst šo objektu?",
     "reallyDeleteAllFeaturesFrom": "Vai tiešām vēlaties izdzēst visus objektus no slāņa {0}?",
-    "untitledFeature": "Objekts bez nosaukuma"
+    "untitledFeature": "Objekts bez nosaukuma",
+    "clusterContaining": "Objektu apvienojums, kas satur {{count}} objektus"
   },
   "SAVECOMPOSITION": {
     "dialogResult": {

--- a/projects/hslayers/src/components/query/feature-popup.component.ts
+++ b/projects/hslayers/src/components/query/feature-popup.component.ts
@@ -108,9 +108,9 @@ export class HsQueryFeaturePopupComponent implements OnDestroy {
       return getFeatureLabel(feature);
     }
     if (getFeatures(feature)) {
-      return (
-        'Cluster containing ' + getFeatures(feature).length + ' ' + 'features'
-      );
+      return this.HsLanguageService.getTranslation('QUERY.clusterContaining', {
+        count: getFeatures(feature).length,
+      });
     }
     return this.HsLanguageService.getTranslation('QUERY.untitledFeature');
   }

--- a/projects/hslayers/src/components/sidebar/partials/sidebar.html
+++ b/projects/hslayers/src/components/sidebar/partials/sidebar.html
@@ -9,11 +9,11 @@
         [ngClass]="{'active': HsLayoutService.mainpanel == button.panel,  'hs-panel-hidden' : !button.fits}" title="{{HsSidebarService.getButtonDescription(button)}}">
         <i *ngIf="button.icon" class="menu-icon {{button.icon}}" data-toggle="tooltip" data-container="body" data-placement="auto"></i>
         <span *ngIf="button.content" data-toggle="tooltip" data-container="body" data-placement="auto" class="" title="{{HsSidebarService.getButtonDescription(button)}}">{{button.content()}}</span>
-        <span class="hs-sidebar-item-title">{{HsSidebarService.getButtonTitle(button)}}</span>
+        <span [ngStyle]="{'margin-left' : button.panel == 'language' ? '14px' : '20px'}" class="hs-sidebar-item-title">{{HsSidebarService.getButtonTitle(button)}}</span>
     </span>
 
     <span class="hs-sidebar-item  list-group-item" *ngIf="HsLayoutService.minisidebar" (click)="HsLayoutService.setMainPanel('sidebar', true)" [ngClass]="{'active': HsLayoutService.mainpanel == 'sidebar'}">
-        <i class="menu-icon icon-equals" data-toggle="tooltip" data-container="body" data-placement="auto" title="Menu"></i>
+        <i class="menu-icon icon-equals" data-toggle="tooltip" data-container="body" data-placement="auto" title="Menu" style="margin-left: 0px !important;"></i>
         <span class="hs-sidebar-item-title">{{HsSidebarService.getButtonTitle(HsSidebarService.miniSidebarButton)}}</span>
     </span>
     <hs-impressum class="mt-auto"></hs-impressum>


### PR DESCRIPTION
## Description

There shouldn't be a hardcoded English text that is being displayed for feature popup.  

## Related issues or pull requests



## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
