### PR TITLE
fix: Set correct add url vector type

### DIFF
--- a/projects/hslayers/src/components/add-data/url/add-data-url.component.html
+++ b/projects/hslayers/src/components/add-data/url/add-data-url.component.html
@@ -14,6 +14,6 @@
         <hs-add-data-url-wfs *ngIf="typeSelected === 'wfs'"></hs-add-data-url-wfs>
         <hs-add-data-url-wms *ngIf="typeSelected === 'wms'"></hs-add-data-url-wms>
         <hs-add-data-url-wmts *ngIf="typeSelected === 'wmts'"></hs-add-data-url-wmts>
-        <hs-add-data-url-vector *ngIf="typeSelected === 'kml' || typeSelected === 'geojson' "></hs-add-data-url-vector>
+        <hs-add-data-url-vector *ngIf="typeSelected === 'kml' || typeSelected === 'geojson' " [dataType]="typeSelected"></hs-add-data-url-vector>
     </div>
 </div>

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
@@ -136,7 +136,7 @@ export class HsAddDataVectorComponent implements OnInit {
 
   async addNewLayer(): Promise<any> {
     const layer = await this.hsAddDataVectorService.addVectorLayer(
-      this.type,
+      this.features.length != 0 ? this.type : this.dataType,
       this.url || this.base64url,
       this.name,
       this.title,

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.component.ts
@@ -22,7 +22,7 @@ import {getHsLaymanSynchronizing} from '../../../common/layer-extensions';
   templateUrl: './add-data-vector.component.html',
 })
 export class HsAddDataVectorComponent implements OnInit {
-  @Input() dataType: string;
+  @Input() dataType: 'geojson' | 'kml';
   @ViewChild('vectorFileInput') vectorFileInput: ElementRef;
 
   srs = 'EPSG:4326';
@@ -36,7 +36,7 @@ export class HsAddDataVectorComponent implements OnInit {
   folder_name = '';
   features: any[] = [];
   featureCount = 0;
-  type = '';
+  type: 'geojson' | 'kml' | '' = '';
   errorOccurred = false;
   addUnder: Layer<Source> = null;
   showDetails = false;

--- a/projects/hslayers/src/components/add-data/vector/add-data-vector.spec.ts
+++ b/projects/hslayers/src/components/add-data/vector/add-data-vector.spec.ts
@@ -112,6 +112,7 @@ describe('add-layers-vector', () => {
 
   it('GeoJSON layer should be added', async () => {
     component.vectorFileInput = viewChild;
+    component.dataType = 'geojson';
     component.url =
       'http://data-lakecountyil.opendata.arcgis.com/datasets/cd63911cc52841f38b289aeeeff0f300_1.geojson';
     component.title = 'Cancer rates';


### PR DESCRIPTION
------------

## Description

Select data type when adding GeoJSON or KML using url (when adding file directly type needs to stay empty in order to coply with [default ](https://github.com/hslayers/hslayers-ng/blob/ab78f6e315d5b670fc5f6bae287d7cadacc106cd/projects/hslayers/src/components/add-data/vector/vector-descriptors/vector-source-descriptor.ts#L78)case)

## Related issues or pull requests

fixes #2169 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
