### PR TITLE
Ol6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "geostyler-style": "^4.0.2",
         "ngx-color": "^7.2.0",
         "ngx-cookie-service": "^12.0.3",
-        "ol": "^6.6.0",
+        "ol": "^6.7.0",
         "ol-popup": "^4.0.0",
         "passport-oauth2-middleware": "^1.0.3",
         "proj4": "^2.7.5",
@@ -296,15 +296,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/@babel/core/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@babel/generator": {
@@ -3774,24 +3765,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@compodoc/live-server/node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@compodoc/ngd-core": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@compodoc/ngd-core/-/ngd-core-2.1.0.tgz",
@@ -4602,6 +4575,16 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "deprecated": "critical bug fixed in v3.1.1",
+      "dependencies": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -8838,7 +8821,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13640,6 +13622,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -14924,6 +14915,40 @@
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "dependencies": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      },
+      "engines": {
+        "browsers": "defaults",
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/geotiff/node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
@@ -17055,6 +17080,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -17794,6 +17830,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
+    },
     "node_modules/less": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.1.tgz",
@@ -18213,6 +18254,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash._basecopy": {
       "version": "3.0.1",
@@ -20093,6 +20139,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -20100,10 +20151,11 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
-      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
       "dependencies": {
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -20582,6 +20634,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -24264,7 +24321,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -26982,6 +27038,23 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "dependencies": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/andywer/threads.js?sponsor=1"
+      },
+      "optionalDependencies": {
+        "tiny-worker": ">= 2"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -27037,6 +27110,15 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true
+    },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
     },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
@@ -27333,6 +27415,23 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "node_modules/txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "dependencies": {
+        "through2": "^3.0.1"
+      }
+    },
+    "node_modules/txml/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -30168,12 +30267,6 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
               "dev": true
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true
             }
           }
         },
@@ -32650,20 +32743,6 @@
         "proxy-middleware": "latest",
         "send": "latest",
         "serve-index": "^1.9.1"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "@compodoc/ngd-core": {
@@ -33306,6 +33385,15 @@
           "integrity": "sha512-8eblPHTL7ZWRkyjIZJjnGf+TijiKJSwA24svzLRVvtgoi/RZiKa9fFQTrlx0OKLnyHSdt/enrdadji6WFfESVA==",
           "dev": true
         }
+      }
+    },
+    "@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "requires": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -36917,8 +37005,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -40711,6 +40798,12 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -41745,6 +41838,35 @@
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
+      }
+    },
+    "geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "requires": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "pako": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+        }
       }
     },
     "get-assigned-identifiers": {
@@ -43414,6 +43536,11 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
+    "is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw=="
+    },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -43987,6 +44114,11 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
+    },
     "less": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.1.tgz",
@@ -44321,6 +44453,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -45805,6 +45942,11 @@
         "es-abstract": "^1.18.2"
       }
     },
+    "observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -45812,10 +45954,11 @@
       "dev": true
     },
     "ol": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
-      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
       "requires": {
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -46179,6 +46322,11 @@
         "map-cache": "^0.2.0",
         "path-root": "^0.1.1"
       }
+    },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -48921,7 +49069,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -51069,6 +51216,18 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "requires": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1",
+        "tiny-worker": ">= 2"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -51118,6 +51277,15 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true
+    },
+    "tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "requires": {
+        "esm": "^3.2.25"
+      }
     },
     "tinyqueue": {
       "version": "2.0.3",
@@ -51340,6 +51508,25 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "requires": {
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "geostyler-style": "^4.0.2",
     "ngx-color": "^7.2.0",
     "ngx-cookie-service": "^12.0.3",
-    "ol": "^6.6.0",
+    "ol": "^6.7.0",
     "ol-popup": "^4.0.0",
     "passport-oauth2-middleware": "^1.0.3",
     "proj4": "^2.7.5",

--- a/projects/hslayers-cesium/package-lock.json
+++ b/projects/hslayers-cesium/package-lock.json
@@ -1,20 +1,2297 @@
 {
   "name": "hslayers-cesium",
-  "version": "5.1.0",
-  "lockfileVersion": 1,
+  "version": "6.0.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "hslayers-cesium",
+      "version": "6.0.0",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^12.0.0",
+        "@angular/core": "^12.0.0",
+        "@angular/forms": "^12.0.0",
+        "@angular/localize": "^12.0.0",
+        "@ngx-translate/core": "^13.0.0",
+        "@ngx-translate/http-loader": "^6.0.0",
+        "@types/cesium": "^1.67.12",
+        "cesium": "^1.85.0",
+        "dayjs": "^1.0.0",
+        "ol": "^6.7.0",
+        "ol-popup": "^4.0.0",
+        "proj4": "^2.6.0",
+        "rxjs": "^6.0.0"
+      }
+    },
+    "node_modules/@angular/common": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.7.tgz",
+      "integrity": "sha512-Gug5a59c4NwfmSvO9Ya7DoYjl6ndK7nDuBoPSpp6IHTlNE8FY/BOd29qEp/lYJ4cAWxVk14+lonUPs6C+Szekw==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "12.2.7",
+        "rxjs": "^6.5.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@angular/compiler": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.7.tgz",
+      "integrity": "sha512-9X7Vrfg6dWfYKPAJLQYR5W7N8WnESg8PG07gNzHZtavETPrDIoX+Av/kQcEdPu14zTZE5NWx5u5TUByFgouQiQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      }
+    },
+    "node_modules/@angular/compiler-cli": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.7.tgz",
+      "integrity": "sha512-otsy3t3psrEWNbnjADaZVhBGBmBmBGxqknNoJ1+UeqSWf4z7su736jyzerxD684vmk08U6X2loxOuDr90idjPA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.8.6",
+        "@babel/types": "^7.8.6",
+        "canonical-path": "1.0.0",
+        "chokidar": "^3.0.0",
+        "convert-source-map": "^1.5.1",
+        "dependency-graph": "^0.11.0",
+        "magic-string": "^0.25.0",
+        "minimist": "^1.2.0",
+        "reflect-metadata": "^0.1.2",
+        "semver": "^7.0.0",
+        "source-map": "^0.6.1",
+        "sourcemap-codec": "^1.4.8",
+        "tslib": "^2.2.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "ivy-ngcc": "ngcc/main-ivy-ngcc.js",
+        "ng-xi18n": "src/extract_i18n.js",
+        "ngc": "src/main.js",
+        "ngcc": "ngcc/main-ngcc.js"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "12.2.7",
+        "typescript": ">=4.2.3 <4.4"
+      }
+    },
+    "node_modules/@angular/core": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.7.tgz",
+      "integrity": "sha512-no4mQ4O1euNH6odho1H27dcUmYBaNuyYvpPvv0wbb1pMT3Mm2J/uueePx/fvwg3nQ+vnk/yL1VCCqR7Mt62nHA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.5.3 || ^7.0.0",
+        "zone.js": "~0.11.4"
+      }
+    },
+    "node_modules/@angular/forms": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.7.tgz",
+      "integrity": "sha512-TtXnwE/bouEtGddaaSGytwCoyRN8YPNN/yf81fFM9LOGef4ZpABMtuMnsZxlDS+91AGpVSzvR511O5DG1BXc4Q==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "12.2.7",
+        "@angular/core": "12.2.7",
+        "@angular/platform-browser": "12.2.7",
+        "rxjs": "^6.5.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@angular/localize": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.7.tgz",
+      "integrity": "sha512-zTWL4e67sgqefI0Gd362W3z7clGZ+TouuTCx8/1SRCqIeOthz59Km7pJEsrPgboMVqSqqtRQMluguSBW8fEDvg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "7.8.3",
+        "glob": "7.1.7",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "localize-extract": "src/tools/src/extract/main.js",
+        "localize-migrate": "src/tools/src/migrate/main.js",
+        "localize-translate": "src/tools/src/translate/main.js"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "12.2.7",
+        "@angular/compiler-cli": "12.2.7"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/@babel/core": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+      "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.3",
+        "@babel/helpers": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@angular/platform-browser": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-12.2.7.tgz",
+      "integrity": "sha512-mCQ5KqskMb98DLowyKfixH+ZpTjs5WuIZw9BqPc2knOlUxmfTuDRf5xDQn9Nur2ASF1wfJpaOogW685nB3ojnQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "12.2.7",
+        "@angular/common": "12.2.7",
+        "@angular/core": "12.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
+      "peer": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-style-spec": {
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
+      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.5",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      },
+      "bin": {
+        "gl-style-composite": "bin/gl-style-composite",
+        "gl-style-format": "bin/gl-style-format",
+        "gl-style-migrate": "bin/gl-style-migrate",
+        "gl-style-validate": "bin/gl-style-validate"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
+      "peer": true
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
+      "peer": true
+    },
+    "node_modules/@ngx-translate/core": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-13.0.0.tgz",
+      "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=10.0.0",
+        "rxjs": ">=6.5.3"
+      }
+    },
+    "node_modules/@ngx-translate/http-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
+      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=10.0.0",
+        "@ngx-translate/core": ">=13.0.0",
+        "rxjs": ">=6.5.3"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "deprecated": "critical bug fixed in v3.1.1",
+      "peer": true,
+      "dependencies": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
+      }
+    },
+    "node_modules/@types/cesium": {
+      "version": "1.67.14",
+      "resolved": "https://registry.npmjs.org/@types/cesium/-/cesium-1.67.14.tgz",
+      "integrity": "sha512-BGek4o6VY25IqmpdBd1awlULSVjyRrbn111xI/LRZQf4QUPlYfsXOYkun8vcXr+u+iYQkh9LAYNf2h0lE95xcA==",
+      "peer": true
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "peer": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "peer": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "peer": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
+        "escalade": "^3.1.1",
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "peer": true,
+      "dependencies": {
+        "nanocolors": "^0.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/canonical-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
+      "peer": true
+    },
+    "node_modules/cesium": {
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.85.0.tgz",
+      "integrity": "sha512-GqcEkcG5owC7rDroZzy3ic9d5oCrpqmpLZ9kWVnVBgvtjL/aAS+eUZ2wz8vCYAcYW77wYnIWeBRbMbaqdAH2XQ==",
+      "peer": true
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "peer": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
+      "peer": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
+      "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.849",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz",
+      "integrity": "sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==",
+      "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "peer": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "peer": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "peer": true,
+      "dependencies": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      },
+      "engines": {
+        "browsers": "defaults",
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "peer": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "peer": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "peer": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "peer": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
+      "peer": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "peer": true
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "peer": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "node_modules/mapbox-to-css-font": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
+      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
+      "peer": true
+    },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk=",
+      "peer": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "peer": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "peer": true
+    },
+    "node_modules/nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "peer": true
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
+      "peer": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "peer": true
+    },
+    "node_modules/ol": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
+      "peer": true,
+      "dependencies": {
+        "geotiff": "^1.0.5",
+        "ol-mapbox-style": "^6.4.1",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol-mapbox-style": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
+      "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "mapbox-to-css-font": "^2.4.0",
+        "webfont-matcher": "^1.1.0"
+      },
+      "peerDependencies": {
+        "ol": ">= 6.1.0 < 7"
+      }
+    },
+    "node_modules/ol-popup": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
+      "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw==",
+      "peer": true,
+      "peerDependencies": {
+        "ol": ">=5.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "peer": true
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
+      "peer": true
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "peer": true
+    },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "peer": true,
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proj4": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.5.tgz",
+      "integrity": "sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==",
+      "peer": true,
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.1"
+      }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.2.tgz",
+      "integrity": "sha512-LPzSaBYp/TcbuSlpGwqT5jR9kvJ3Zp5ic2N5c2ybx6XB/lSfEHq2D7ja8AgoxHoMD91wXFALJoXsvshKPuXyew==",
+      "peer": true
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "peer": true
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "peer": true,
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "peer": true
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "peer": true,
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
+      "peer": true
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sort-asc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+      "peer": true,
+      "dependencies": {
+        "sort-asc": "^0.1.0",
+        "sort-desc": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "peer": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/andywer/threads.js?sponsor=1"
+      },
+      "optionalDependencies": {
+        "tiny-worker": ">= 2"
+      }
+    },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "peer": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/to-regex-range/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
+    "node_modules/txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "peer": true,
+      "dependencies": {
+        "through2": "^3.0.1"
+      }
+    },
+    "node_modules/txml/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/txml/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "peer": true
+    },
+    "node_modules/webfont-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
+      "peer": true
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.1.tgz",
+      "integrity": "sha512-XK5qV+Y5gsygQfHx2/cS5a7Zxsgleaw8iX5UPC5eOXPc0TgJAu1JB9lr0iYYX3zAnN3p0aNiaN5c+1Bdblxwrg==",
+      "peer": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "peer": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "peer": true
+    },
+    "node_modules/yargs": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    }
+  },
   "dependencies": {
+    "@angular/common": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.7.tgz",
+      "integrity": "sha512-Gug5a59c4NwfmSvO9Ya7DoYjl6ndK7nDuBoPSpp6IHTlNE8FY/BOd29qEp/lYJ4cAWxVk14+lonUPs6C+Szekw==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/compiler": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.7.tgz",
+      "integrity": "sha512-9X7Vrfg6dWfYKPAJLQYR5W7N8WnESg8PG07gNzHZtavETPrDIoX+Av/kQcEdPu14zTZE5NWx5u5TUByFgouQiQ==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/compiler-cli": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.7.tgz",
+      "integrity": "sha512-otsy3t3psrEWNbnjADaZVhBGBmBmBGxqknNoJ1+UeqSWf4z7su736jyzerxD684vmk08U6X2loxOuDr90idjPA==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "^7.8.6",
+        "@babel/types": "^7.8.6",
+        "canonical-path": "1.0.0",
+        "chokidar": "^3.0.0",
+        "convert-source-map": "^1.5.1",
+        "dependency-graph": "^0.11.0",
+        "magic-string": "^0.25.0",
+        "minimist": "^1.2.0",
+        "reflect-metadata": "^0.1.2",
+        "semver": "^7.0.0",
+        "source-map": "^0.6.1",
+        "sourcemap-codec": "^1.4.8",
+        "tslib": "^2.2.0",
+        "yargs": "^17.0.0"
+      }
+    },
+    "@angular/core": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.7.tgz",
+      "integrity": "sha512-no4mQ4O1euNH6odho1H27dcUmYBaNuyYvpPvv0wbb1pMT3Mm2J/uueePx/fvwg3nQ+vnk/yL1VCCqR7Mt62nHA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/forms": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.7.tgz",
+      "integrity": "sha512-TtXnwE/bouEtGddaaSGytwCoyRN8YPNN/yf81fFM9LOGef4ZpABMtuMnsZxlDS+91AGpVSzvR511O5DG1BXc4Q==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/localize": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.7.tgz",
+      "integrity": "sha512-zTWL4e67sgqefI0Gd362W3z7clGZ+TouuTCx8/1SRCqIeOthz59Km7pJEsrPgboMVqSqqtRQMluguSBW8fEDvg==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "7.8.3",
+        "glob": "7.1.7",
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+          "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+          "peer": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helpers": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "peer": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "peer": true
+        }
+      }
+    },
+    "@angular/platform-browser": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-12.2.7.tgz",
+      "integrity": "sha512-mCQ5KqskMb98DLowyKfixH+ZpTjs5WuIZw9BqPc2knOlUxmfTuDRf5xDQn9Nur2ASF1wfJpaOogW685nB3ojnQ==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "peer": true,
+      "requires": {
+        "@babel/highlight": "^7.14.5"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "peer": true
+    },
+    "@babel/core": {
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "peer": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "peer": true
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "peer": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "peer": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "peer": true
+    },
+    "@babel/helpers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+      "peer": true,
+      "requires": {
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
+      "peer": true
+    },
+    "@babel/template": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "dev": true
+      "peer": true
     },
     "@mapbox/mapbox-gl-style-spec": {
       "version": "13.21.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
       "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -30,71 +2307,563 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
-      "dev": true
+      "peer": true
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
-      "dev": true
+      "peer": true
+    },
+    "@ngx-translate/core": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-13.0.0.tgz",
+      "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@ngx-translate/http-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
+      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "peer": true,
+      "requires": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
+      }
+    },
+    "@types/cesium": {
+      "version": "1.67.14",
+      "resolved": "https://registry.npmjs.org/@types/cesium/-/cesium-1.67.14.tgz",
+      "integrity": "sha512-BGek4o6VY25IqmpdBd1awlULSVjyRrbn111xI/LRZQf4QUPlYfsXOYkun8vcXr+u+iYQkh9LAYNf2h0lE95xcA==",
+      "peer": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "peer": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "peer": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "peer": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "peer": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "peer": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "peer": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
+      "peer": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
+        "escalade": "^3.1.1",
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "peer": true,
+      "requires": {
+        "nanocolors": "^0.1.0"
+      }
+    },
+    "canonical-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
+      "peer": true
     },
     "cesium": {
       "version": "1.85.0",
       "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.85.0.tgz",
       "integrity": "sha512-GqcEkcG5owC7rDroZzy3ic9d5oCrpqmpLZ9kWVnVBgvtjL/aAS+eUZ2wz8vCYAcYW77wYnIWeBRbMbaqdAH2XQ==",
-      "dev": true
+      "peer": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "peer": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "peer": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "peer": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "peer": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "peer": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
-      "dev": true
+      "peer": true
     },
     "dayjs": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
       "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
-      "dev": true
+      "peer": true
     },
-    "hslayers-ng": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hslayers-ng/-/hslayers-ng-5.0.0.tgz",
-      "integrity": "sha512-OXyqk9BpqzWTv3tmZjWOv/G846H8GBKx9s/4IZvKJWLTHL7XBq/kOfvw+hC8z/FP96lHHHDz98PUUZAJH9JfFw==",
-      "dev": true,
+    "debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "peer": true,
       "requires": {
-        "tslib": "^2.0.0"
+        "ms": "2.1.2"
       }
+    },
+    "dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "peer": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.849",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz",
+      "integrity": "sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==",
+      "peer": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "peer": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "peer": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "peer": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true,
+      "peer": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "peer": true
+    },
+    "geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "peer": true,
+      "requires": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "peer": true
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "peer": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "peer": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "peer": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true
     },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "peer": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "peer": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "peer": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "peer": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "peer": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "peer": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "peer": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "peer": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "peer": true
     },
     "json-stringify-pretty-compact": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
       "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
+      "peer": true
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "peer": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "peer": true
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "peer": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
     },
     "mapbox-to-css-font": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
-      "dev": true
+      "peer": true
+    },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk=",
+      "peer": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "peer": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "peer": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "peer": true
+    },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "peer": true
+    },
+    "node-releases": {
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
+      "peer": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "peer": true
+    },
+    "observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "peer": true
     },
     "ol": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
-      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
-      "dev": true,
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
+      "peer": true,
       "requires": {
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -104,49 +2873,136 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
       "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
         "webfont-matcher": "^1.1.0"
       }
     },
+    "ol-popup": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
+      "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw==",
+      "peer": true,
+      "requires": {}
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "peer": true
+    },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
+      "peer": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "peer": true
+    },
     "pbf": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
+      }
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "peer": true
+    },
+    "proj4": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.5.tgz",
+      "integrity": "sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==",
+      "peer": true,
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.1"
       }
     },
     "protocol-buffers-schema": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.2.tgz",
       "integrity": "sha512-LPzSaBYp/TcbuSlpGwqT5jR9kvJ3Zp5ic2N5c2ybx6XB/lSfEHq2D7ja8AgoxHoMD91wXFALJoXsvshKPuXyew==",
-      "dev": true
+      "peer": true
     },
     "quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "peer": true
     },
     "rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "quickselect": "^2.0.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "peer": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "peer": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "peer": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "peer": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-protobuf-schema": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -155,28 +3011,164 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
+      "peer": true
+    },
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "peer": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
       "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true
+      "peer": true
     },
     "sort-desc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
       "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true
+      "peer": true
     },
     "sort-object": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "peer": true
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "peer": true
+        }
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "peer": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "peer": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "peer": true,
+      "requires": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1",
+        "tiny-worker": ">= 2"
+      }
+    },
+    "tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "esm": "^3.2.25"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "peer": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "peer": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "peer": true
+        }
       }
     },
     "tslib": {
@@ -184,11 +3176,146 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
+    "txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "peer": true,
+      "requires": {
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
+    "typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "peer": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "peer": true
+    },
     "webfont-matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
       "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
-      "dev": true
+      "peer": true
+    },
+    "wkt-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.1.tgz",
+      "integrity": "sha512-XK5qV+Y5gsygQfHx2/cS5a7Zxsgleaw8iX5UPC5eOXPc0TgJAu1JB9lr0iYYX3zAnN3p0aNiaN5c+1Bdblxwrg==",
+      "peer": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "peer": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "peer": true
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "peer": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "peer": true
+    },
+    "yargs": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
+      "peer": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "peer": true
+    },
+    "zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     }
   }
 }

--- a/projects/hslayers-cesium/package.json
+++ b/projects/hslayers-cesium/package.json
@@ -4,24 +4,18 @@
   "scripts": {},
   "peerDependencies": {
     "@types/cesium": "^1.67.12",
-    "cesium": "^1.65.0",
+    "cesium": "^1.85.0",
     "@angular/common": "^12.0.0",
     "@angular/core": "^12.0.0",
     "@angular/forms": "^12.0.0",
     "@angular/localize": "^12.0.0",
-    "@ngx-translate/core": "^12.0.0",
+    "@ngx-translate/core": "^13.0.0",
     "@ngx-translate/http-loader": "^6.0.0",
     "dayjs": "^1.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.7.0",
     "ol-popup": "^4.0.0",
     "proj4": "^2.6.0",
     "rxjs": "^6.0.0"
-  },
-  "devDependencies": {
-    "ol": "^6.6.0",
-    "cesium": "^1.85.0",
-    "dayjs": "^1.10.4",
-    "hslayers-ng": "^6.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/projects/hslayers-sensors/package-lock.json
+++ b/projects/hslayers-sensors/package-lock.json
@@ -1,79 +1,165 @@
 {
   "name": "hslayers-sensors",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@angular/common": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.3.tgz",
-      "integrity": "sha512-AkOeknm35kzLqqh5dIz1143e3Q1MjWgi7THlY3StY63yphseQUUvGQSNHkDSIpfwBN8Mt+ZykKFjhY+cNFYt7w==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.2.0"
+  "packages": {
+    "": {
+      "name": "hslayers-sensors",
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "devDependencies": {
+        "vega": "^5.20.2",
+        "vega-embed": "^6.17.0",
+        "vega-lite": "~5.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^12.0.0",
+        "@angular/compiler": "12.0.0",
+        "@angular/core": "^12.0.0",
+        "@angular/forms": "^12.0.0",
+        "@angular/localize": "^12.0.0",
+        "@ngx-translate/core": "^13.0.0",
+        "@ngx-translate/http-loader": "^6.0.0",
+        "bootstrap": "^4.0.0",
+        "dayjs": "^1.0.0",
+        "ol": "^6.0.0",
+        "ol-popup": "^4.0.0",
+        "proj4": "^2.6.0",
+        "rxjs": "^6.0.0",
+        "vega": "^5.0.0",
+        "vega-embed": "^6.0.0",
+        "vega-lite": "~5.0.0"
       }
     },
-    "@angular/core": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.3.tgz",
-      "integrity": "sha512-gv3FJPiwDKugySzPepBzXrbr8HxeK2enotEmducNv3IdtGZPS0/qrbDVt7W0woRt7BGAeWaZKEaPoFzMZeEbCw==",
-      "dev": true,
-      "requires": {
+    "node_modules/@angular/common": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.7.tgz",
+      "integrity": "sha512-Gug5a59c4NwfmSvO9Ya7DoYjl6ndK7nDuBoPSpp6IHTlNE8FY/BOd29qEp/lYJ4cAWxVk14+lonUPs6C+Szekw==",
+      "peer": true,
+      "dependencies": {
         "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "12.2.7",
+        "rxjs": "^6.5.3 || ^7.0.0"
       }
     },
-    "@angular/forms": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.3.tgz",
-      "integrity": "sha512-euc2omQ8YVRLjmJDGXRBNLLTzOQZjLYn/DxB3yChWNcsiOZoqhBQprgioQZt4GnCoQJyBH9iQZENnHOZk0TD1w==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.2.0"
+    "node_modules/@angular/compiler": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.0.0.tgz",
+      "integrity": "sha512-7NdZNyxm9KLlRMmmtId6RfV6VbQIUMDxN44R+ax66BoWsuhdYXUDsDO554LwYwrjnnXXGkurDJhv7umeRwaZGw==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || ^14.0.0"
       }
     },
-    "@angular/localize": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.3.tgz",
-      "integrity": "sha512-vIF2MXNsLYfa3yAwxhtv/dcVuojYtCaP/Zxf6vEvGrIxEFV5Q5vqqXU5Rg77CUgGV1vDYcDgGp4V8xd2R2hHoQ==",
-      "dev": true,
-      "requires": {
+    "node_modules/@angular/compiler-cli": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.7.tgz",
+      "integrity": "sha512-otsy3t3psrEWNbnjADaZVhBGBmBmBGxqknNoJ1+UeqSWf4z7su736jyzerxD684vmk08U6X2loxOuDr90idjPA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.8.6",
+        "@babel/types": "^7.8.6",
+        "canonical-path": "1.0.0",
+        "chokidar": "^3.0.0",
+        "convert-source-map": "^1.5.1",
+        "dependency-graph": "^0.11.0",
+        "magic-string": "^0.25.0",
+        "minimist": "^1.2.0",
+        "reflect-metadata": "^0.1.2",
+        "semver": "^7.0.0",
+        "source-map": "^0.6.1",
+        "sourcemap-codec": "^1.4.8",
+        "tslib": "^2.2.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "ivy-ngcc": "ngcc/main-ivy-ngcc.js",
+        "ng-xi18n": "src/extract_i18n.js",
+        "ngc": "src/main.js",
+        "ngcc": "ngcc/main-ngcc.js"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "12.2.7",
+        "typescript": ">=4.2.3 <4.4"
+      }
+    },
+    "node_modules/@angular/core": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.7.tgz",
+      "integrity": "sha512-no4mQ4O1euNH6odho1H27dcUmYBaNuyYvpPvv0wbb1pMT3Mm2J/uueePx/fvwg3nQ+vnk/yL1VCCqR7Mt62nHA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.5.3 || ^7.0.0",
+        "zone.js": "~0.11.4"
+      }
+    },
+    "node_modules/@angular/forms": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.7.tgz",
+      "integrity": "sha512-TtXnwE/bouEtGddaaSGytwCoyRN8YPNN/yf81fFM9LOGef4ZpABMtuMnsZxlDS+91AGpVSzvR511O5DG1BXc4Q==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "12.2.7",
+        "@angular/core": "12.2.7",
+        "@angular/platform-browser": "12.2.7",
+        "rxjs": "^6.5.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@angular/localize": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.7.tgz",
+      "integrity": "sha512-zTWL4e67sgqefI0Gd362W3z7clGZ+TouuTCx8/1SRCqIeOthz59Km7pJEsrPgboMVqSqqtRQMluguSBW8fEDvg==",
+      "peer": true,
+      "dependencies": {
         "@babel/core": "7.8.3",
         "glob": "7.1.7",
         "yargs": "^17.0.0"
       },
-      "dependencies": {
-        "yargs": {
-          "version": "17.1.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        }
+      "bin": {
+        "localize-extract": "src/tools/src/extract/main.js",
+        "localize-migrate": "src/tools/src/migrate/main.js",
+        "localize-translate": "src/tools/src/translate/main.js"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "12.2.7",
+        "@angular/compiler-cli": "12.2.7"
       }
     },
-    "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.14.5"
-      }
-    },
-    "@babel/core": {
+    "node_modules/@angular/localize/node_modules/@babel/core": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
       "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
-      "dev": true,
-      "requires": {
+      "peer": true,
+      "dependencies": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.8.3",
         "@babel/helpers": "^7.8.3",
@@ -89,79 +175,2881 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@angular/localize/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@angular/platform-browser": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-12.2.7.tgz",
+      "integrity": "sha512-mCQ5KqskMb98DLowyKfixH+ZpTjs5WuIZw9BqPc2knOlUxmfTuDRf5xDQn9Nur2ASF1wfJpaOogW685nB3ojnQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "12.2.7",
+        "@angular/common": "12.2.7",
+        "@angular/core": "12.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
+      "peer": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-style-spec": {
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
+      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.5",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      },
+      "bin": {
+        "gl-style-composite": "bin/gl-style-composite",
+        "gl-style-format": "bin/gl-style-format",
+        "gl-style-migrate": "bin/gl-style-migrate",
+        "gl-style-validate": "bin/gl-style-validate"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
+      "peer": true
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
+      "peer": true
+    },
+    "node_modules/@ngx-translate/core": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-13.0.0.tgz",
+      "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=10.0.0",
+        "rxjs": ">=6.5.3"
+      }
+    },
+    "node_modules/@ngx-translate/http-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
+      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=10.0.0",
+        "@ngx-translate/core": ">=13.0.0",
+        "rxjs": ">=6.5.3"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "deprecated": "critical bug fixed in v3.1.1",
+      "peer": true,
+      "dependencies": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
+      }
+    },
+    "node_modules/@types/clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
+    "node_modules/@types/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-IyNhGHu71jH1jCXTHmafuoAAdsbBON3kDh7u/UUhLmjYgN5TYB54e1R8ckTCiIevl2UuZaCsi9XRxineY5yUjw==",
+      "deprecated": "This is a stub types definition. fast-json-stable-stringify provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "*"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "peer": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "peer": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
+      },
+      "peerDependencies": {
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "peer": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
+        "escalade": "^3.1.1",
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "peer": true,
+      "dependencies": {
+        "nanocolors": "^0.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/canonical-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
+      "peer": true
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "peer": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
+      "peer": true
+    },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "dev": true
+    },
+    "node_modules/d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "dev": true,
+      "dependencies": {
+        "delaunator": "4"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "dev": true
+    },
+    "node_modules/d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "dev": true,
+      "dependencies": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json",
+        "csv2tsv": "bin/dsv2dsv",
+        "dsv2dsv": "bin/dsv2dsv",
+        "dsv2json": "bin/dsv2json",
+        "json2csv": "bin/json2dsv",
+        "json2dsv": "bin/json2dsv",
+        "json2tsv": "bin/json2dsv",
+        "tsv2csv": "bin/dsv2dsv",
+        "tsv2json": "bin/dsv2json"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "dev": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "dev": true
+    },
+    "node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
+      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "2",
+        "d3-array": "1 - 2",
+        "d3-geo": "1.12.0 - 2",
+        "resolve": "^1.1.10"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg",
+        "geograticule": "bin/geograticule",
+        "geoproject": "bin/geoproject",
+        "geoquantize": "bin/geoquantize",
+        "geostitch": "bin/geostitch"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+      "dev": true
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "dev": true,
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "dev": true
+    },
+    "node_modules/d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==",
+      "dev": true
+    },
+    "node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "dev": true,
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dev": true,
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "dev": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+      "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "dev": true
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.849",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz",
+      "integrity": "sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==",
+      "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
+      "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "peer": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "peer": true,
+      "dependencies": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      },
+      "engines": {
+        "browsers": "defaults",
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "peer": true
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "peer": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "peer": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
+      "peer": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "peer": true
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "peer": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "node_modules/mapbox-to-css-font": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
+      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
+      "peer": true
+    },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk=",
+      "peer": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "peer": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "peer": true
+    },
+    "node_modules/nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "peer": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
+      "peer": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "peer": true
+    },
+    "node_modules/ol": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
+      "peer": true,
+      "dependencies": {
+        "geotiff": "^1.0.5",
+        "ol-mapbox-style": "^6.4.1",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol-mapbox-style": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.1.tgz",
+      "integrity": "sha512-diGjCUlYjCA855vJjQjPzxXLn/skm0iQLD2/yDsXaKdNxFd35hNfRm5Li+Vxh/FxraCodxRvd8IplhrhvXoqbQ==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "mapbox-to-css-font": "^2.4.0",
+        "webfont-matcher": "^1.1.0"
+      }
+    },
+    "node_modules/ol-popup": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
+      "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw==",
+      "peer": true,
+      "peerDependencies": {
+        "ol": ">=5.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "peer": true
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
+      "peer": true
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "peer": true,
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/proj4": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.5.tgz",
+      "integrity": "sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==",
+      "peer": true,
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.1"
+      }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "peer": true
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "peer": true
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "peer": true,
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "peer": true
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "peer": true,
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sort-asc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+      "peer": true,
+      "dependencies": {
+        "sort-asc": "^0.1.0",
+        "sort-desc": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "peer": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/andywer/threads.js?sponsor=1"
+      },
+      "optionalDependencies": {
+        "tiny-worker": ">= 2"
+      }
+    },
+    "node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "peer": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "peer": true,
+      "dependencies": {
+        "through2": "^3.0.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "peer": true
+    },
+    "node_modules/vega": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.21.0.tgz",
+      "integrity": "sha512-yqqRa9nAqYoAxe7sVhRpsh0b001fly7Yx05klPkXmrvzjxXd07gClW1mOuGgSnVQqo7jTp/LYgbO1bD37FbEig==",
+      "dev": true,
+      "dependencies": {
+        "vega-crossfilter": "~4.0.5",
+        "vega-dataflow": "~5.7.4",
+        "vega-encode": "~4.8.3",
+        "vega-event-selector": "~3.0.0",
+        "vega-expression": "~5.0.0",
+        "vega-force": "~4.0.7",
+        "vega-format": "~1.0.4",
+        "vega-functions": "~5.12.1",
+        "vega-geo": "~4.3.8",
+        "vega-hierarchy": "~4.0.9",
+        "vega-label": "~1.1.0",
+        "vega-loader": "~4.4.1",
+        "vega-parser": "~6.1.4",
+        "vega-projection": "~1.4.5",
+        "vega-regression": "~1.0.9",
+        "vega-runtime": "~6.1.3",
+        "vega-scale": "~7.1.1",
+        "vega-scenegraph": "~4.9.4",
+        "vega-statistics": "~1.7.10",
+        "vega-time": "~2.0.4",
+        "vega-transforms": "~4.9.4",
+        "vega-typings": "~0.22.0",
+        "vega-util": "~1.17.0",
+        "vega-view": "~5.10.1",
+        "vega-view-transforms": "~4.5.8",
+        "vega-voronoi": "~4.1.5",
+        "vega-wordcloud": "~4.1.3"
+      }
+    },
+    "node_modules/vega-canvas": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
+      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q==",
+      "dev": true
+    },
+    "node_modules/vega-crossfilter": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
+      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-dataflow": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
+      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "dev": true,
+      "dependencies": {
+        "vega-format": "^1.0.4",
+        "vega-loader": "^4.3.2",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "node_modules/vega-embed": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.19.1.tgz",
+      "integrity": "sha512-ILhenUl+sJtSeJtr0FhJ1zeaGOPGxST5AiAtKWmGBq9nFPf1T90TZ1duKcIhTgXI5ql/Q0UwgYpvQQT2qYK+EQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-patch": "^3.1.0",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "semver": "^7.3.5",
+        "tslib": "^2.3.1",
+        "vega-interpreter": "^1.0.4",
+        "vega-schema-url-parser": "^2.2.0",
+        "vega-themes": "^2.10.0",
+        "vega-tooltip": "^0.27.0"
+      },
+      "peerDependencies": {
+        "vega": "^5.20.2",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-embed/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "dev": true
+    },
+    "node_modules/vega-embed/node_modules/vega-themes": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.10.0.tgz",
+      "integrity": "sha512-prePRUKFUFGWniuZsJOfkdb+27Gwrrm82yAlVuU+912kcknsx1DVmMSg2yF79f4jdtqnAFIGycZgxoj13SEIuQ==",
+      "dev": true,
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-encode": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
+      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-event-selector": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
+      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ==",
+      "dev": true
+    },
+    "node_modules/vega-expression": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
+      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^0.0.50",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-force": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
+      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
+      "dev": true,
+      "dependencies": {
+        "d3-force": "^2.1.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
+      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-format": "^2.0.0",
+        "d3-time-format": "^3.0.0",
+        "vega-time": "^2.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-functions": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.1.tgz",
+      "integrity": "sha512-7cHfcjXOj27qEbh2FTzWDl7FJK4xGcMFF7+oiyqa0fp7BU/wNT5YdNV0t5kCX9WjV7mfJWACKV74usLJbyM6GA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-expression": "^5.0.0",
+        "vega-scale": "^7.1.1",
+        "vega-scenegraph": "^4.9.3",
+        "vega-selections": "^5.3.1",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-geo": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.8.tgz",
+      "integrity": "sha512-fsGxV96Q/QRgPqOPtMBZdI+DneIiROKTG3YDZvGn0EdV16OG5LzFhbNgLT5GPzI+kTwgLpAsucBHklexlB4kfg==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-projection": "^1.4.5",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-hierarchy": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
+      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
+      "dev": true,
+      "dependencies": {
+        "d3-hierarchy": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-interpreter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.0.4.tgz",
+      "integrity": "sha512-6tpYIa/pJz0cZo5fSxDSkZkAA51pID2LjOtQkOQvbzn+sJiCaWKPFhur8MBqbcmYZ9bnap1OYNwlrvpd2qBLvg==",
+      "dev": true
+    },
+    "node_modules/vega-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.1.0.tgz",
+      "integrity": "sha512-LAThIiDEsZxYvbSkvPLJ93eJF+Ts8RXv1IpBh8gmew8XGmaLJvVkzdsMe7WJJwuaVEsK7ZZFyB/Inkp842GW6w==",
+      "dev": true,
+      "dependencies": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-lite": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.0.0.tgz",
+      "integrity": "sha512-CrMAy3D2E662qtShrOeGttwwthRxUOZUfdu39THyxkOfLNJBCLkNjfQpFekEidxwbtFTO1zMZzyFIP3AE2I8kQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/clone": "~2.1.0",
+        "@types/fast-json-stable-stringify": "^2.0.0",
+        "array-flat-polyfill": "^1.0.1",
+        "clone": "~2.1.2",
+        "fast-deep-equal": "~3.1.3",
+        "fast-json-stable-stringify": "~2.1.0",
+        "json-stringify-pretty-compact": "~3.0.0",
+        "tslib": "~2.1.0",
+        "vega-event-selector": "~2.0.6",
+        "vega-expression": "~4.0.1",
+        "vega-util": "~1.16.0",
+        "yargs": "~16.2.0"
+      },
+      "bin": {
+        "vl2pdf": "bin/vl2pdf",
+        "vl2png": "bin/vl2png",
+        "vl2svg": "bin/vl2svg",
+        "vl2vg": "bin/vl2vg"
+      },
+      "peerDependencies": {
+        "vega": "^5.19.1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "dev": true
+    },
+    "node_modules/vega-lite/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "node_modules/vega-lite/node_modules/vega-event-selector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew==",
+      "dev": true
+    },
+    "node_modules/vega-lite/node_modules/vega-expression": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
+      "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
+      "dev": true,
+      "dependencies": {
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/vega-util": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
+      "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==",
+      "dev": true
+    },
+    "node_modules/vega-lite/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vega-loader": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.1.tgz",
+      "integrity": "sha512-dj65i4qlNhK0mOmjuchHgUrF5YUaWrYpx0A8kXA68lBk5Hkx8FNRztkcl07CZJ1+8V81ymEyJii9jzGbhEX0ag==",
+      "dev": true,
+      "dependencies": {
+        "d3-dsv": "^2.0.0",
+        "node-fetch": "^2.6.1",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.0.4",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
+      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "dev": true,
+      "dependencies": {
+        "vega-dataflow": "^5.7.3",
+        "vega-event-selector": "^3.0.0",
+        "vega-functions": "^5.12.1",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-projection": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
+      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
+      "dev": true,
+      "dependencies": {
+        "d3-geo": "^2.0.1",
+        "d3-geo-projection": "^3.0.0"
+      }
+    },
+    "node_modules/vega-regression": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
+      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-runtime": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
+      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "dev": true,
+      "dependencies": {
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-scale": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
+      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.2",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-scenegraph": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.4.tgz",
+      "integrity": "sha512-QaegQzbFE2yhYLNWAmHwAuguW3yTtQrmwvfxYT8tk0g+KKodrQ5WSmNrphWXhqwtsgVSvtdZkfp2IPeumcOQJg==",
+      "dev": true,
+      "dependencies": {
+        "d3-path": "^2.0.0",
+        "d3-shape": "^2.0.0",
+        "vega-canvas": "^1.2.5",
+        "vega-loader": "^4.3.3",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-schema-url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
+      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
+      "dev": true
+    },
+    "node_modules/vega-selections": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
+      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
+      "dev": true,
+      "dependencies": {
+        "vega-expression": "^5.0.0",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-statistics": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.10.tgz",
+      "integrity": "sha512-QLb12gcfpDZ9K5h3TLGrlz4UXDH9wSPyg9LLfOJZacxvvJEPohacUQNrGEAVtFO9ccUCerRfH9cs25ZtHsOZrw==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1"
+      }
+    },
+    "node_modules/vega-time": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
+      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-time": "^2.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-tooltip": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.27.0.tgz",
+      "integrity": "sha512-FRcHNfMNo9D/7an5nZuP6JC2JGEsc85qcGjyMU7VlPpjQj9eBj1P+sZSNbb54Z20g7inVSBRyd8qgNn5EYTxJA==",
+      "dev": true,
+      "dependencies": {
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-transforms": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.4.tgz",
+      "integrity": "sha512-JGBhm5Bf6fiGTUSB5Qr5ckw/KU9FJcSV5xIe/y4IobM/i/KNwI1i1fP45LzP4F4yZc0DMTwJod2UvFHGk9plKA==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.4",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "node_modules/vega-typings": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.0.tgz",
+      "integrity": "sha512-TgBGRkZHQgcduGsoFKq3Scpn6eNY4L3p0YKRhgCPVU3HEaCeYkPFGaR8ynK+XrKmvrqpDv0YHIOwCt7Gn3RpCA==",
+      "dev": true,
+      "dependencies": {
+        "vega-event-selector": "^3.0.0",
+        "vega-expression": "^5.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-util": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
+      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w==",
+      "dev": true
+    },
+    "node_modules/vega-view": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.10.1.tgz",
+      "integrity": "sha512-4xvQ5KZcgKdZx1Z7jjenCUumvlyr/j4XcHLRf9gyeFrFvvS596dVpL92V8twhV6O++DmS2+fj+rHagO8Di4nMg==",
+      "dev": true,
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-timer": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-format": "^1.0.4",
+        "vega-functions": "^5.10.0",
+        "vega-runtime": "^6.1.3",
+        "vega-scenegraph": "^4.9.4",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "node_modules/vega-view-transforms": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
+      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "dev": true,
+      "dependencies": {
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-voronoi": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
+      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
+      "dev": true,
+      "dependencies": {
+        "d3-delaunay": "^5.3.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-wordcloud": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
+      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "dev": true,
+      "dependencies": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.1.1",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/webfont-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
+      "peer": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.1.tgz",
+      "integrity": "sha512-XK5qV+Y5gsygQfHx2/cS5a7Zxsgleaw8iX5UPC5eOXPc0TgJAu1JB9lr0iYYX3zAnN3p0aNiaN5c+1Bdblxwrg==",
+      "peer": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@angular/common": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.7.tgz",
+      "integrity": "sha512-Gug5a59c4NwfmSvO9Ya7DoYjl6ndK7nDuBoPSpp6IHTlNE8FY/BOd29qEp/lYJ4cAWxVk14+lonUPs6C+Szekw==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/compiler": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.0.0.tgz",
+      "integrity": "sha512-7NdZNyxm9KLlRMmmtId6RfV6VbQIUMDxN44R+ax66BoWsuhdYXUDsDO554LwYwrjnnXXGkurDJhv7umeRwaZGw==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@angular/compiler-cli": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.7.tgz",
+      "integrity": "sha512-otsy3t3psrEWNbnjADaZVhBGBmBmBGxqknNoJ1+UeqSWf4z7su736jyzerxD684vmk08U6X2loxOuDr90idjPA==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "^7.8.6",
+        "@babel/types": "^7.8.6",
+        "canonical-path": "1.0.0",
+        "chokidar": "^3.0.0",
+        "convert-source-map": "^1.5.1",
+        "dependency-graph": "^0.11.0",
+        "magic-string": "^0.25.0",
+        "minimist": "^1.2.0",
+        "reflect-metadata": "^0.1.2",
+        "semver": "^7.0.0",
+        "source-map": "^0.6.1",
+        "sourcemap-codec": "^1.4.8",
+        "tslib": "^2.2.0",
+        "yargs": "^17.0.0"
+      }
+    },
+    "@angular/core": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.7.tgz",
+      "integrity": "sha512-no4mQ4O1euNH6odho1H27dcUmYBaNuyYvpPvv0wbb1pMT3Mm2J/uueePx/fvwg3nQ+vnk/yL1VCCqR7Mt62nHA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/forms": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.7.tgz",
+      "integrity": "sha512-TtXnwE/bouEtGddaaSGytwCoyRN8YPNN/yf81fFM9LOGef4ZpABMtuMnsZxlDS+91AGpVSzvR511O5DG1BXc4Q==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@angular/localize": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.7.tgz",
+      "integrity": "sha512-zTWL4e67sgqefI0Gd362W3z7clGZ+TouuTCx8/1SRCqIeOthz59Km7pJEsrPgboMVqSqqtRQMluguSBW8fEDvg==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "7.8.3",
+        "glob": "7.1.7",
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+          "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+          "peer": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helpers": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "peer": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "peer": true
+        }
+      }
+    },
+    "@angular/platform-browser": {
+      "version": "12.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-12.2.7.tgz",
+      "integrity": "sha512-mCQ5KqskMb98DLowyKfixH+ZpTjs5WuIZw9BqPc2knOlUxmfTuDRf5xDQn9Nur2ASF1wfJpaOogW685nB3ojnQ==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "peer": true,
+      "requires": {
+        "@babel/highlight": "^7.14.5"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "peer": true
+    },
+    "@babel/core": {
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "peer": true
+        }
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+      "peer": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "peer": true
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "peer": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
+        }
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "peer": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "peer": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "peer": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "peer": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-      "dev": true
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "peer": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "peer": true
     },
     "@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+      "peer": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
@@ -169,44 +3057,44 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
-      "dev": true
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
+      "peer": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
-      "dev": true,
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
-      "dev": true,
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "peer": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -216,13 +3104,13 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "dev": true
+      "peer": true
     },
     "@mapbox/mapbox-gl-style-spec": {
       "version": "13.21.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
       "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -238,36 +3126,52 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
-      "dev": true
+      "peer": true
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
-      "dev": true
-    },
-    "@ng-bootstrap/ng-bootstrap": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-9.1.3.tgz",
-      "integrity": "sha512-Sl4lis1F5uSPrd4WsLEMX8b3fqzeHr4rgTFhocpx/IedZPaPdGec4a91TjdqcM/fNwzoXj1AdGrcMLpFFOxmvw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.0"
-      }
+      "peer": true
     },
     "@ngx-translate/core": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-13.0.0.tgz",
       "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.0.0"
+      }
+    },
+    "@ngx-translate/http-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
+      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "peer": true,
+      "requires": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
       }
     },
     "@types/clone": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
       "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
     },
     "@types/fast-json-stable-stringify": {
@@ -282,16 +3186,25 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "peer": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "array-flat-polyfill": {
@@ -304,34 +3217,105 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "peer": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "peer": true
+    },
+    "bootstrap": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "peer": true,
+      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "peer": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
+      "peer": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
+        "escalade": "^3.1.1",
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "peer": true,
+      "requires": {
+        "nanocolors": "^0.1.0"
+      }
+    },
+    "canonical-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
+      "peer": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
     },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "peer": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -348,7 +3332,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -357,7 +3341,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "peer": true
     },
     "commander": {
       "version": "2.20.3",
@@ -369,13 +3353,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "peer": true
     },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -384,7 +3368,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
-      "dev": true
+      "peer": true
     },
     "d3-array": {
       "version": "2.12.1",
@@ -445,12 +3429,12 @@
       "dev": true
     },
     "d3-geo": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.1.tgz",
-      "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
       "dev": true,
       "requires": {
-        "d3-array": ">=2.5"
+        "d3-array": "^2.5.0"
       }
     },
     "d3-geo-projection": {
@@ -539,16 +3523,16 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
-      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
-      "dev": true
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+      "peer": true
     },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -559,23 +3543,40 @@
       "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
       "dev": true
     },
+    "dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "peer": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.849",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz",
+      "integrity": "sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==",
+      "peer": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "peer": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "peer": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -584,9 +3585,9 @@
       "dev": true
     },
     "fast-json-patch": {
-      "version": "3.0.0-1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
-      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
+      "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -595,35 +3596,64 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "peer": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "peer": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true,
+      "peer": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "peer": true
+    },
+    "geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "peer": true,
+      "requires": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -633,17 +3663,25 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "peer": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "peer": true
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -652,22 +3690,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "hslayers-ng": {
-      "version": "file:../../dist/hslayers",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        }
-      }
+      "peer": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -682,13 +3705,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "peer": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -698,7 +3721,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "peer": true
     },
     "internmap": {
       "version": "1.0.1",
@@ -706,74 +3729,140 @@
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "peer": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-      "dev": true,
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "requires": {
         "has": "^1.0.3"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "peer": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "peer": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "peer": true
+    },
+    "is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "peer": true
+    },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "peer": true
     },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "peer": true
     },
     "json-stringify-pretty-compact": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
       "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
+      "peer": true
     },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "peer": true
     },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "peer": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
     },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "peer": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "mapbox-to-css-font": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
-      "dev": true
+      "peer": true
+    },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk=",
+      "peer": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -782,107 +3871,199 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "peer": true
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "peer": true
+    },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "peer": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
-    },
-    "ol": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
-      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
       "dev": true,
       "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-releases": {
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
+      "peer": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "peer": true
+    },
+    "observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "peer": true
+    },
+    "ol": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
+      "peer": true,
+      "requires": {
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       }
     },
     "ol-mapbox-style": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
-      "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
-      "dev": true,
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.1.tgz",
+      "integrity": "sha512-diGjCUlYjCA855vJjQjPzxXLn/skm0iQLD2/yDsXaKdNxFd35hNfRm5Li+Vxh/FxraCodxRvd8IplhrhvXoqbQ==",
+      "peer": true,
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
         "webfont-matcher": "^1.1.0"
       }
     },
+    "ol-popup": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
+      "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw==",
+      "peer": true,
+      "requires": {}
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "wrappy": "1"
       }
+    },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "peer": true
+    },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
+      "peer": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "peer": true
     },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "pbf": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       }
     },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "peer": true
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "peer": true
+    },
+    "proj4": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.5.tgz",
+      "integrity": "sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==",
+      "peer": true,
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.1"
+      }
+    },
     "protocol-buffers-schema": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.2.tgz",
-      "integrity": "sha512-LPzSaBYp/TcbuSlpGwqT5jR9kvJ3Zp5ic2N5c2ybx6XB/lSfEHq2D7ja8AgoxHoMD91wXFALJoXsvshKPuXyew==",
-      "dev": true
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "peer": true
     },
     "quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "peer": true
     },
     "rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "quickselect": "^2.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "peer": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "peer": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-      "dev": true,
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -890,7 +4071,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -898,14 +4079,13 @@
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       },
@@ -914,7 +4094,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "peer": true
         }
       }
     },
@@ -922,7 +4102,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "peer": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -931,73 +4111,138 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
       "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true
+      "peer": true
     },
     "sort-desc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
       "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true
+      "peer": true
     },
     "sort-object": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "peer": true
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "peer": true
+        }
+      }
     },
     "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "peer": true,
+      "requires": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1",
+        "tiny-worker": ">= 2"
+      }
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "peer": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "esm": "^3.2.25"
       }
     },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "peer": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "peer": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "topojson-client": {
       "version": "3.1.0",
@@ -1008,52 +4253,71 @@
         "commander": "2"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "peer": true,
+      "requires": {
+        "through2": "^3.0.1"
+      }
+    },
+    "typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "peer": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "peer": true
     },
     "vega": {
-      "version": "5.20.2",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.20.2.tgz",
-      "integrity": "sha512-qmH7aD9GGPpssVdxL1xgcdxTbQzyRUeRR16Os385ymvQhiwCYQNA6+eXUPAZDTVLfk0RXu6Jzj6kUE5jQ80EVw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.21.0.tgz",
+      "integrity": "sha512-yqqRa9nAqYoAxe7sVhRpsh0b001fly7Yx05klPkXmrvzjxXd07gClW1mOuGgSnVQqo7jTp/LYgbO1bD37FbEig==",
       "dev": true,
       "requires": {
         "vega-crossfilter": "~4.0.5",
         "vega-dataflow": "~5.7.4",
         "vega-encode": "~4.8.3",
-        "vega-event-selector": "~2.0.6",
-        "vega-expression": "~4.0.1",
+        "vega-event-selector": "~3.0.0",
+        "vega-expression": "~5.0.0",
         "vega-force": "~4.0.7",
         "vega-format": "~1.0.4",
-        "vega-functions": "~5.12.0",
+        "vega-functions": "~5.12.1",
         "vega-geo": "~4.3.8",
         "vega-hierarchy": "~4.0.9",
-        "vega-label": "~1.0.0",
-        "vega-loader": "~4.4.0",
-        "vega-parser": "~6.1.3",
+        "vega-label": "~1.1.0",
+        "vega-loader": "~4.4.1",
+        "vega-parser": "~6.1.4",
         "vega-projection": "~1.4.5",
         "vega-regression": "~1.0.9",
         "vega-runtime": "~6.1.3",
         "vega-scale": "~7.1.1",
         "vega-scenegraph": "~4.9.4",
-        "vega-statistics": "~1.7.9",
+        "vega-statistics": "~1.7.10",
         "vega-time": "~2.0.4",
         "vega-transforms": "~4.9.4",
-        "vega-typings": "~0.21.0",
-        "vega-util": "~1.16.1",
+        "vega-typings": "~0.22.0",
+        "vega-util": "~1.17.0",
         "vega-view": "~5.10.1",
         "vega-view-transforms": "~4.5.8",
         "vega-voronoi": "~4.1.5",
         "vega-wordcloud": "~4.1.3"
-      },
-      "dependencies": {
-        "vega-util": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
-          "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==",
-          "dev": true
-        }
       }
     },
     "vega-canvas": {
@@ -1082,28 +4346,22 @@
         "vega-format": "^1.0.4",
         "vega-loader": "^4.3.2",
         "vega-util": "^1.16.1"
-      },
-      "dependencies": {
-        "vega-util": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
-          "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==",
-          "dev": true
-        }
       }
     },
     "vega-embed": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.17.0.tgz",
-      "integrity": "sha512-9eiVZCrLDb/EiVCMbMYouWB/q9dOeVkL5Bh0vU6wsUpIV/bbEvS47uljuo3YSxFqkfNpJ+Qt8xvLRiYSnN4lqw==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.19.1.tgz",
+      "integrity": "sha512-ILhenUl+sJtSeJtr0FhJ1zeaGOPGxST5AiAtKWmGBq9nFPf1T90TZ1duKcIhTgXI5ql/Q0UwgYpvQQT2qYK+EQ==",
       "dev": true,
       "requires": {
-        "fast-json-patch": "^3.0.0-1",
+        "fast-json-patch": "^3.1.0",
         "json-stringify-pretty-compact": "^3.0.0",
         "semver": "^7.3.5",
-        "vega-schema-url-parser": "^2.1.0",
+        "tslib": "^2.3.1",
+        "vega-interpreter": "^1.0.4",
+        "vega-schema-url-parser": "^2.2.0",
         "vega-themes": "^2.10.0",
-        "vega-tooltip": "^0.25.1"
+        "vega-tooltip": "^0.27.0"
       },
       "dependencies": {
         "json-stringify-pretty-compact": {
@@ -1112,14 +4370,12 @@
           "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
           "dev": true
         },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+        "vega-themes": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.10.0.tgz",
+          "integrity": "sha512-prePRUKFUFGWniuZsJOfkdb+27Gwrrm82yAlVuU+912kcknsx1DVmMSg2yF79f4jdtqnAFIGycZgxoj13SEIuQ==",
           "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "requires": {}
         }
       }
     },
@@ -1137,17 +4393,18 @@
       }
     },
     "vega-event-selector": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
-      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
+      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ==",
       "dev": true
     },
     "vega-expression": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
-      "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
+      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
       "dev": true,
       "requires": {
+        "@types/estree": "^0.0.50",
         "vega-util": "^1.16.0"
       }
     },
@@ -1176,19 +4433,19 @@
       }
     },
     "vega-functions": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.0.tgz",
-      "integrity": "sha512-3hljmGs+gR7TbO/yYuvAP9P5laKISf1GKk4yRHLNdM61fWgKm8pI3f6LY2Hvq9cHQFTiJ3/5/Bx2p1SX5R4quQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.1.tgz",
+      "integrity": "sha512-7cHfcjXOj27qEbh2FTzWDl7FJK4xGcMFF7+oiyqa0fp7BU/wNT5YdNV0t5kCX9WjV7mfJWACKV74usLJbyM6GA==",
       "dev": true,
       "requires": {
         "d3-array": "^2.7.1",
         "d3-color": "^2.0.0",
         "d3-geo": "^2.0.1",
         "vega-dataflow": "^5.7.3",
-        "vega-expression": "^4.0.1",
+        "vega-expression": "^5.0.0",
         "vega-scale": "^7.1.1",
         "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.0",
+        "vega-selections": "^5.3.1",
         "vega-statistics": "^1.7.9",
         "vega-time": "^2.0.4",
         "vega-util": "^1.16.0"
@@ -1221,10 +4478,16 @@
         "vega-util": "^1.15.2"
       }
     },
+    "vega-interpreter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.0.4.tgz",
+      "integrity": "sha512-6tpYIa/pJz0cZo5fSxDSkZkAA51pID2LjOtQkOQvbzn+sJiCaWKPFhur8MBqbcmYZ9bnap1OYNwlrvpd2qBLvg==",
+      "dev": true
+    },
     "vega-label": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.0.0.tgz",
-      "integrity": "sha512-hCdm2pcHgkKgxnzW9GvX5JmYNiUMlOXOibtMmBzvFBQHX3NiV9giQ5nsPiQiFbV08VxEPtM+VYXr2HyrIcq5zQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.1.0.tgz",
+      "integrity": "sha512-LAThIiDEsZxYvbSkvPLJ93eJF+Ts8RXv1IpBh8gmew8XGmaLJvVkzdsMe7WJJwuaVEsK7ZZFyB/Inkp842GW6w==",
       "dev": true,
       "requires": {
         "vega-canvas": "^1.2.5",
@@ -1264,13 +4527,49 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
           "dev": true
+        },
+        "vega-event-selector": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+          "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew==",
+          "dev": true
+        },
+        "vega-expression": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
+          "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
+          "dev": true,
+          "requires": {
+            "vega-util": "^1.16.0"
+          }
+        },
+        "vega-util": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
+          "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
         }
       }
     },
     "vega-loader": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.0.tgz",
-      "integrity": "sha512-e5enQECdau7rJob0NFB5pGumh3RaaSWWm90+boxMy3ay2b4Ki/3XIvo+C4F1Lx04qSxvQF7tO2LJcklRm6nqRA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.1.tgz",
+      "integrity": "sha512-dj65i4qlNhK0mOmjuchHgUrF5YUaWrYpx0A8kXA68lBk5Hkx8FNRztkcl07CZJ1+8V81ymEyJii9jzGbhEX0ag==",
       "dev": true,
       "requires": {
         "d3-dsv": "^2.0.0",
@@ -1281,14 +4580,14 @@
       }
     },
     "vega-parser": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.3.tgz",
-      "integrity": "sha512-8oiVhhW26GQ4GZBvolId8FVFvhn3s1KGgPlD7Z+4P2wkV+xe5Nqu0TEJ20F/cn3b88fd0Vj48X3BH3dlSeKNFg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
+      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
       "dev": true,
       "requires": {
         "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^2.0.6",
-        "vega-functions": "^5.12.0",
+        "vega-event-selector": "^3.0.0",
+        "vega-functions": "^5.12.1",
         "vega-scale": "^7.1.1",
         "vega-util": "^1.16.0"
       }
@@ -1353,35 +4652,29 @@
       }
     },
     "vega-schema-url-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.1.0.tgz",
-      "integrity": "sha512-JHT1PfOyVzOohj89uNunLPirs05Nf59isPT5gnwIkJph96rRgTIBJE7l7yLqndd7fLjr3P8JXHGAryRp74sCaQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
+      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
       "dev": true
     },
     "vega-selections": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.0.tgz",
-      "integrity": "sha512-vC4NPsuN+IffruFXfH0L3i2A51RgG4PqpLv85TvrEAIYnSkyKDE4bf+wVraR3aPdnLLkc3+tYuMi6le5FmThIA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
+      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
       "dev": true,
       "requires": {
-        "vega-expression": "^4.0.1",
+        "vega-expression": "^5.0.0",
         "vega-util": "^1.16.0"
       }
     },
     "vega-statistics": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.9.tgz",
-      "integrity": "sha512-T0sd2Z08k/mHxr1Vb4ajLWytPluLFYnsYqyk4SIS5czzUs4errpP2gUu63QJ0B7CKNu33vnS9WdOMOo/Eprr/Q==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.10.tgz",
+      "integrity": "sha512-QLb12gcfpDZ9K5h3TLGrlz4UXDH9wSPyg9LLfOJZacxvvJEPohacUQNrGEAVtFO9ccUCerRfH9cs25ZtHsOZrw==",
       "dev": true,
       "requires": {
         "d3-array": "^2.7.1"
       }
-    },
-    "vega-themes": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.10.0.tgz",
-      "integrity": "sha512-prePRUKFUFGWniuZsJOfkdb+27Gwrrm82yAlVuU+912kcknsx1DVmMSg2yF79f4jdtqnAFIGycZgxoj13SEIuQ==",
-      "dev": true
     },
     "vega-time": {
       "version": "2.0.4",
@@ -1395,9 +4688,9 @@
       }
     },
     "vega-tooltip": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.25.1.tgz",
-      "integrity": "sha512-ugGwGi2/p3OpB8N15xieuzP8DyV5DreqMWcmJ9zpWT8GlkyKtef4dGRXnvHeHQ+iJFmWrq4oZJ+kLTrdiECjAg==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.27.0.tgz",
+      "integrity": "sha512-FRcHNfMNo9D/7an5nZuP6JC2JGEsc85qcGjyMU7VlPpjQj9eBj1P+sZSNbb54Z20g7inVSBRyd8qgNn5EYTxJA==",
       "dev": true,
       "requires": {
         "vega-util": "^1.16.0"
@@ -1414,29 +4707,23 @@
         "vega-statistics": "^1.7.9",
         "vega-time": "^2.0.4",
         "vega-util": "^1.16.1"
-      },
-      "dependencies": {
-        "vega-util": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
-          "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==",
-          "dev": true
-        }
       }
     },
     "vega-typings": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.21.0.tgz",
-      "integrity": "sha512-dG0RtnJUn3+BQMO4NjjTdcp5UTBR56yQsLXPPCAFUHeLuycEVKlyhBa/kbvAZv2r+QxdeEYwKUNYy9CQotF5KA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.0.tgz",
+      "integrity": "sha512-TgBGRkZHQgcduGsoFKq3Scpn6eNY4L3p0YKRhgCPVU3HEaCeYkPFGaR8ynK+XrKmvrqpDv0YHIOwCt7Gn3RpCA==",
       "dev": true,
       "requires": {
+        "vega-event-selector": "^3.0.0",
+        "vega-expression": "^5.0.0",
         "vega-util": "^1.15.2"
       }
     },
     "vega-util": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.0.tgz",
-      "integrity": "sha512-6mmz6mI+oU4zDMeKjgvE2Fjz0Oh6zo6WGATcvCfxH2gXBzhBHmy5d25uW5Zjnkc6QBXSWPLV9Xa6SiqMsrsKog==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
+      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w==",
       "dev": true
     },
     "vega-view": {
@@ -1453,14 +4740,6 @@
         "vega-runtime": "^6.1.3",
         "vega-scenegraph": "^4.9.4",
         "vega-util": "^1.16.1"
-      },
-      "dependencies": {
-        "vega-util": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
-          "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==",
-          "dev": true
-        }
       }
     },
     "vega-view-transforms": {
@@ -1502,13 +4781,34 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
       "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
+      "peer": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wkt-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.1.tgz",
+      "integrity": "sha512-XK5qV+Y5gsygQfHx2/cS5a7Zxsgleaw8iX5UPC5eOXPc0TgJAu1JB9lr0iYYX3zAnN3p0aNiaN5c+1Bdblxwrg==",
+      "peer": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1519,7 +4819,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -1528,7 +4827,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1536,8 +4834,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },
@@ -1545,25 +4842,23 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "peer": true
     },
     "y18n": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-      "dev": true
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
+      "peer": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -1575,10 +4870,18 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "dev": true
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+    },
+    "zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     }
   }
 }

--- a/projects/hslayers-sensors/package.json
+++ b/projects/hslayers-sensors/package.json
@@ -11,7 +11,7 @@
     "@angular/core": "^12.0.0",
     "@angular/forms": "^12.0.0",
     "@angular/localize": "^12.0.0",
-    "@ngx-translate/core": "^12.0.0",
+    "@ngx-translate/core": "^13.0.0",
     "@ngx-translate/http-loader": "^6.0.0",
     "bootstrap": "^4.0.0",
     "dayjs": "^1.0.0",
@@ -23,16 +23,6 @@
     "vega-lite": "~5.0.0"
   },
   "devDependencies": {
-    "ol": "^6.6.0",
-    "hslayers-ng": "file:../../dist/hslayers",
-    "@angular/common": "^12.2.3",
-    "@angular/core": "^12.2.3",
-    "@angular/forms": "^12.2.3",
-    "@angular/localize": "^12.2.3",
-    "@ngx-translate/core": "^13.0.0",
-    "@ng-bootstrap/ng-bootstrap": "^9.1.3",
-    "dayjs": "^1.10.4",
-    "rxjs": "^6.6.7",
     "vega": "^5.20.2",
     "vega-embed": "^6.17.0",
     "vega-lite": "~5.0.0"

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -2,7 +2,7 @@ import Feature from 'ol/Feature';
 import VectorLayer from 'ol/layer/Vector';
 import dayjs from 'dayjs';
 import {Fill, Icon, Stroke, Style, Text} from 'ol/style';
-import {Geometry} from 'ol/geom';
+import {Geometry, MultiPolygon} from 'ol/geom';
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Vector as VectorSource} from 'ol/source';
@@ -38,7 +38,7 @@ export class HsSensorsService {
       let geometry = feature.getGeometry();
       if (geometry.getType() == 'MultiPolygon') {
         // Only render label for the widest polygon of a multipolygon
-        const polygons = geometry.getPolygons();
+        const polygons = (geometry as MultiPolygon).getPolygons();
         let widest = 0;
         for (let i = 0, ii = polygons.length; i < ii; ++i) {
           const polygon = polygons[i];

--- a/projects/hslayers/package-lock.json
+++ b/projects/hslayers/package-lock.json
@@ -30,7 +30,7 @@
         "geostyler-style": "^4.0.0",
         "ngx-color": "^7.0.0",
         "ngx-cookie-service": "^12.0.0",
-        "ol": "^6.6.0",
+        "ol": "^6.7.0",
         "ol-popup": "^4.0.0",
         "proj4": "^2.6.0",
         "queue": "^6.0.0",
@@ -722,6 +722,17 @@
         "@angular/common": ">=10.0.0",
         "@ngx-translate/core": ">=13.0.0",
         "rxjs": ">=6.5.3"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "deprecated": "critical bug fixed in v3.1.1",
+      "peer": true,
+      "dependencies": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
       }
     },
     "node_modules/@terrestris/base-util": {
@@ -2357,6 +2368,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001260",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
@@ -2624,6 +2644,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2723,6 +2753,43 @@
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "peer": true,
+      "dependencies": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      },
+      "engines": {
+        "browsers": "defaults",
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/geotiff/node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "peer": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2971,6 +3038,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
@@ -3035,6 +3114,12 @@
         "pako": "~1.0.2"
       }
     },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "peer": true
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -3054,6 +3139,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "peer": true
     },
     "node_modules/loglevel": {
@@ -3209,12 +3300,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "peer": true
+    },
     "node_modules/ol": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
-      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
       "peer": true,
       "dependencies": {
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -3260,6 +3358,12 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "peer": true
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
       "peer": true
     },
     "node_modules/parse5": {
@@ -3387,6 +3491,20 @@
       "peer": true,
       "dependencies": {
         "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -3621,6 +3739,35 @@
         "node": ">=4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
     "node_modules/string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -3665,11 +3812,49 @@
       "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==",
       "peer": true
     },
+    "node_modules/threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/andywer/threads.js?sponsor=1"
+      },
+      "optionalDependencies": {
+        "tiny-worker": ">= 2"
+      }
+    },
+    "node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
     "node_modules/timers": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/timers/-/timers-0.1.1.tgz",
       "integrity": "sha1-hqxceMHuQZaU81pY3k/UGDz7nB4=",
       "peer": true
+    },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
     },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
@@ -3735,6 +3920,15 @@
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==",
       "peer": true
     },
+    "node_modules/txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "peer": true,
+      "dependencies": {
+        "through2": "^3.0.1"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
@@ -3763,6 +3957,12 @@
       "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-1.1.0.tgz",
       "integrity": "sha512-XiO5GLAxmlZgdLob/RmKZRc2INHrssMbpwD6O46JkB1aEJO4fkV3x3mR6+CDX01ijfEUwvfwCiUQZrKqfm1ILw==",
       "deprecated": "now available as @ungap/url-search-params",
+      "peer": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "peer": true
     },
     "node_modules/validator": {
@@ -4410,6 +4610,16 @@
       "peer": true,
       "requires": {
         "tslib": "^2.0.0"
+      }
+    },
+    "@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "peer": true,
+      "requires": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
       }
     },
     "@terrestris/base-util": {
@@ -6013,6 +6223,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true
+    },
     "caniuse-lite": {
       "version": "1.0.30001260",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
@@ -6239,6 +6455,13 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "peer": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "peer": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6325,6 +6548,38 @@
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
+      }
+    },
+    "geotiff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "peer": true,
+      "requires": {
+        "@petamoriken/float16": "^1.0.7",
+        "lerc": "^3.0.0",
+        "lru-cache": "^6.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "threads": "^1.3.1",
+        "txml": "^5.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "pako": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+          "peer": true
+        }
       }
     },
     "get-caller-file": {
@@ -6497,6 +6752,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "peer": true
     },
+    "is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "peer": true
+    },
     "is-regex": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
@@ -6543,6 +6804,12 @@
         "pako": "~1.0.2"
       }
     },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "peer": true
+    },
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -6562,6 +6829,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "peer": true
     },
     "loglevel": {
@@ -6684,12 +6957,19 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "peer": true
     },
+    "observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "peer": true
+    },
     "ol": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
-      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
+      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
       "peer": true,
       "requires": {
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -6726,6 +7006,12 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "peer": true
+    },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
       "peer": true
     },
     "parse5": {
@@ -6835,6 +7121,17 @@
       "peer": true,
       "requires": {
         "quickselect": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "peer": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -7032,6 +7329,23 @@
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "peer": true
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "peer": true
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -7067,11 +7381,44 @@
       "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==",
       "peer": true
     },
+    "threads": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "peer": true,
+      "requires": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1",
+        "tiny-worker": ">= 2"
+      }
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "peer": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
     "timers": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/timers/-/timers-0.1.1.tgz",
       "integrity": "sha1-hqxceMHuQZaU81pY3k/UGDz7nB4=",
       "peer": true
+    },
+    "tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "esm": "^3.2.25"
+      }
     },
     "tinyqueue": {
       "version": "2.0.3",
@@ -7123,6 +7470,15 @@
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==",
       "peer": true
     },
+    "txml": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "peer": true,
+      "requires": {
+        "through2": "^3.0.1"
+      }
+    },
     "typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
@@ -7143,6 +7499,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-1.1.0.tgz",
       "integrity": "sha512-XiO5GLAxmlZgdLob/RmKZRc2INHrssMbpwD6O46JkB1aEJO4fkV3x3mR6+CDX01ijfEUwvfwCiUQZrKqfm1ILw==",
+      "peer": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "peer": true
     },
     "validator": {

--- a/projects/hslayers/package-lock.json
+++ b/projects/hslayers/package-lock.json
@@ -10,33 +10,6 @@
       "dependencies": {
         "tslib": "^2.0.0"
       },
-      "devDependencies": {
-        "@angular/cdk": "^12.2.7",
-        "@angular/common": "^12.2.7",
-        "@angular/compiler": "^12.2.7",
-        "@angular/core": "^12.2.7",
-        "@angular/forms": "^12.2.7",
-        "@angular/localize": "^12.2.7",
-        "@ng-bootstrap/ng-bootstrap": "^10.0.0",
-        "@ngx-translate/core": "^12.1.2",
-        "@ngx-translate/http-loader": "^6.0.0",
-        "bootstrap": ">=4.6.0",
-        "dayjs": "^1.10.4",
-        "deepmerge": "^4.2.2",
-        "geostyler-openlayers-parser": "^2.3.0",
-        "geostyler-sld-parser": "^2.3.0",
-        "geostyler-style": "^4.0.2",
-        "ngx-color": "^7.2.0",
-        "ngx-cookie-service": "^12.0.0",
-        "ol": "^6.6.0",
-        "ol-popup": "^4.0.0",
-        "proj4": "^2.7.2",
-        "queue": "^6.0.2",
-        "resumablejs": "^1.1.0",
-        "rxjs": "^6.6.7",
-        "share-api-polyfill": "^1.0.18",
-        "xml-js": "^1.6.11"
-      },
       "peerDependencies": {
         "@angular/cdk": "^12.0.0",
         "@angular/common": "^12.0.0",
@@ -72,7 +45,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.7.tgz",
       "integrity": "sha512-OMPewaE1VxCSFkLDZQLFMkGQCQEvbizuVRzArZBB5xfxl98YMjntNQjlWH4rGbRhF+eZlpOrC+UAVnzTX2BzAw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -89,6 +62,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.7.tgz",
       "integrity": "sha512-Gug5a59c4NwfmSvO9Ya7DoYjl6ndK7nDuBoPSpp6IHTlNE8FY/BOd29qEp/lYJ4cAWxVk14+lonUPs6C+Szekw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -104,6 +78,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.7.tgz",
       "integrity": "sha512-9X7Vrfg6dWfYKPAJLQYR5W7N8WnESg8PG07gNzHZtavETPrDIoX+Av/kQcEdPu14zTZE5NWx5u5TUByFgouQiQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -115,7 +90,6 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.7.tgz",
       "integrity": "sha512-otsy3t3psrEWNbnjADaZVhBGBmBmBGxqknNoJ1+UeqSWf4z7su736jyzerxD684vmk08U6X2loxOuDr90idjPA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.8.6",
@@ -151,7 +125,6 @@
       "version": "7.15.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
       "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
@@ -182,7 +155,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -192,7 +164,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -202,7 +173,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -215,7 +185,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -231,7 +200,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -241,6 +209,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.7.tgz",
       "integrity": "sha512-no4mQ4O1euNH6odho1H27dcUmYBaNuyYvpPvv0wbb1pMT3Mm2J/uueePx/fvwg3nQ+vnk/yL1VCCqR7Mt62nHA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -256,7 +225,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.7.tgz",
       "integrity": "sha512-TtXnwE/bouEtGddaaSGytwCoyRN8YPNN/yf81fFM9LOGef4ZpABMtuMnsZxlDS+91AGpVSzvR511O5DG1BXc4Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -274,7 +243,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.7.tgz",
       "integrity": "sha512-zTWL4e67sgqefI0Gd362W3z7clGZ+TouuTCx8/1SRCqIeOthz59Km7pJEsrPgboMVqSqqtRQMluguSBW8fEDvg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.8.3",
         "glob": "7.1.7",
@@ -337,7 +306,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/highlight": "^7.14.5"
       },
@@ -349,7 +318,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
       "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -359,7 +327,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
       "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.8.3",
@@ -389,7 +357,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
       "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
@@ -403,7 +371,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
       "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.15.0",
@@ -422,7 +389,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -432,7 +398,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
       "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-get-function-arity": "^7.15.4",
         "@babel/template": "^7.15.4",
@@ -446,7 +412,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
       "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
       },
@@ -458,7 +424,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
       "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
       },
@@ -470,7 +436,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
       "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
@@ -483,7 +448,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
       "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
@@ -496,7 +460,6 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
       "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.15.4",
@@ -516,7 +479,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
       "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
@@ -529,7 +491,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
       "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.15.4",
@@ -545,7 +506,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
       "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
@@ -558,7 +518,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
       "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
       },
@@ -570,7 +530,7 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -579,7 +539,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
       "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -589,7 +548,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
       "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
@@ -603,7 +562,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
@@ -617,7 +576,7 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
       "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
-      "dev": true,
+      "peer": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -629,7 +588,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
       "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.15.4",
@@ -643,7 +602,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
       "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.4",
@@ -663,7 +622,7 @@
       "version": "7.15.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
       "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -676,7 +635,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
       "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -685,7 +644,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -694,7 +653,7 @@
       "version": "13.21.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
       "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -716,19 +675,19 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
-      "dev": true
+      "peer": true
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
-      "dev": true
+      "peer": true
     },
     "node_modules/@ng-bootstrap/ng-bootstrap": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-10.0.0.tgz",
       "integrity": "sha512-Sz+QaxjuyJYJ+zyUbf0TevgcgVesCPQiiFiggEzxKjzY5R+Hvq3YgryLdXf2r/ryePL+C3FXCcmmKpTM5bfczQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -744,7 +703,7 @@
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-12.1.2.tgz",
       "integrity": "sha512-ZudJsqIxTKlLmPoqK8gJY3UpMGujR0Xm7HfXL6AR79yGRS23QqpjAhMfx4v5qUCcHMmQ9/78bW8QJLfp31c7vQ==",
-      "dev": true,
+      "peer": true,
       "peerDependencies": {
         "@angular/core": ">=8.0.0",
         "rxjs": ">=6.3.0",
@@ -755,7 +714,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
       "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -769,7 +728,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-1.0.1.tgz",
       "integrity": "sha512-ML1IaqZXGWlXrI8pEAnGZv6qPmW72uBZkbc5NvZcBDattpXmrE3rCntTou1t/zLaOz0v4qmG5KORMTSzOeScRQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/lodash": "^4.14.168",
         "@types/loglevel": "^1.6.3",
@@ -788,7 +747,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
       "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@terrestris/base-util": "^1.0.0",
         "@turf/turf": "^5.1.6",
@@ -807,7 +766,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
       "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -819,7 +778,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
       "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -829,7 +788,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
       "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -839,7 +798,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
       "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -850,7 +809,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
       "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -859,7 +818,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
       "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -869,7 +828,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
       "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -879,7 +838,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
       "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -889,7 +848,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
       "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -902,7 +861,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
       "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -915,7 +874,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
       "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -928,7 +887,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
       "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -940,7 +899,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
       "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -954,7 +913,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
       "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -966,7 +925,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
       "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -976,7 +935,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
       "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -986,7 +945,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
       "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -999,7 +958,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
       "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -1014,7 +973,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
       "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -1024,7 +983,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
       "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1035,7 +994,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
       "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/center-mean": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -1048,7 +1007,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
       "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/centroid": "^5.1.5",
         "@turf/convex": "^5.1.5",
@@ -1061,7 +1020,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
       "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -1071,7 +1030,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
       "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/destination": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -1081,7 +1040,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
       "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1091,7 +1050,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
       "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -1100,7 +1059,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
       "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -1110,7 +1069,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
       "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -1124,7 +1083,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
       "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1137,7 +1096,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
       "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -1149,13 +1108,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
       "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/collect/node_modules/rbush": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
       "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "quickselect": "^1.0.1"
       }
@@ -1164,7 +1123,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
       "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -1174,7 +1133,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
       "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -1190,7 +1149,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
       "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5",
@@ -1201,7 +1160,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
       "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1211,7 +1170,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
       "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/area": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1224,7 +1183,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
       "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-overlap": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -1241,7 +1200,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
       "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1251,7 +1210,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
       "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -1263,7 +1222,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
       "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -1274,7 +1233,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
       "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -1284,7 +1243,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
       "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -1294,7 +1253,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
       "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1305,7 +1264,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
       "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1315,13 +1274,13 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
       "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/hex-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
       "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1333,7 +1292,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
       "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -1352,7 +1311,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
       "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1365,7 +1324,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
       "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -1374,7 +1333,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
       "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/area": "^5.1.5",
         "@turf/bbox": "^5.1.5",
@@ -1389,7 +1348,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
       "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1401,7 +1360,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
       "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -1410,7 +1369,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
       "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1421,7 +1380,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
       "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/circle": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -1432,7 +1391,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
       "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/length": "^5.1.5",
@@ -1444,7 +1403,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
       "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -1457,7 +1416,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
       "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -1468,7 +1427,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
       "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-on-line": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1483,7 +1442,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
       "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -1494,7 +1453,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
       "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -1505,7 +1464,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
       "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -1517,7 +1476,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
       "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1535,7 +1494,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
       "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1546,7 +1505,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
       "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1559,13 +1518,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
       "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/mask/node_modules/rbush": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
       "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "quickselect": "^1.0.1"
       }
@@ -1574,7 +1533,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
       "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -1583,7 +1542,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
       "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -1595,7 +1554,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
       "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -1607,7 +1566,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
       "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -1622,7 +1581,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
       "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "6.x",
         "@turf/invariant": "6.x",
@@ -1635,13 +1594,13 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.4.0.tgz",
       "integrity": "sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.4.0.tgz",
       "integrity": "sha512-ncAiOLkL6Ul6NnyOZSSmEbTwcZZ8PTx7O1IzB89Ed/mAe1g5PvFnyFieWbcnERGmuqH1ftzgtWMFFHFi2PQLsg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0"
       }
@@ -1650,7 +1609,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.4.0.tgz",
       "integrity": "sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0"
       }
@@ -1659,7 +1618,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
       "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1669,7 +1628,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
       "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-within": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -1681,7 +1640,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
       "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -1694,7 +1653,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
       "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bearing": "6.x",
         "@turf/distance": "6.x",
@@ -1710,7 +1669,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.4.0.tgz",
       "integrity": "sha512-CmMsT8hSzzhZWe0+49OP48m/EAXryZjNh/7D/0nqMIlayslRZ+bHuV3KcrOCD20xoDFtBuSEdwEd6i4+2Nw3LA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0",
         "@turf/invariant": "^6.4.0"
@@ -1720,7 +1679,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.4.0.tgz",
       "integrity": "sha512-m0MzpW601CQJ7al3XireJNPrKz6KHMnbWysS6p4qkG7E70c+S8ST0y6gj1CfdkdS7ee3GevEg7V6sxdj2lCs4w==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0"
       }
@@ -1729,7 +1688,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.4.0.tgz",
       "integrity": "sha512-EyNEfHfFNVwLHsD31hIpaDInoxlwUFZAVryTWxDu6O+XNE+VfVomMUxLYPm3t0tVqVNUGwOhYo5Z4HfTlr6V1g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0",
         "@turf/invariant": "^6.4.0"
@@ -1739,13 +1698,13 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.4.0.tgz",
       "integrity": "sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.4.0.tgz",
       "integrity": "sha512-ncAiOLkL6Ul6NnyOZSSmEbTwcZZ8PTx7O1IzB89Ed/mAe1g5PvFnyFieWbcnERGmuqH1ftzgtWMFFHFi2PQLsg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0"
       }
@@ -1754,7 +1713,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.4.0.tgz",
       "integrity": "sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0"
       }
@@ -1763,7 +1722,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.4.0.tgz",
       "integrity": "sha512-UtirO+dz0XMgQUG1y50anzHpFsfGObSwT3zsYJIWm3nsJmYMWOBJpsSQ6hMNua3P9GeQrzphG4qJTsQPQveOcA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^6.4.0",
         "@turf/helpers": "^6.4.0",
@@ -1774,7 +1733,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.4.0.tgz",
       "integrity": "sha512-6KeNTzKsTjmvladtKKtaF3/QLPey9Ui954PuNvb6YGW6FSvS4qlMgznyYz18YYhBAkN1OqSjcqTeVvFjXfzoRw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0",
         "@turf/invariant": "^6.4.0"
@@ -1784,7 +1743,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.4.0.tgz",
       "integrity": "sha512-r4dsy8sPyp8k5rR6FwXek8c1RG+nLNH1B43yjmIpaLDKcRYoXJSGt1K8SWOkFOGHl36nukq46Meh2IcH43K6aw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.4.0",
         "@turf/invariant": "^6.4.0"
@@ -1794,7 +1753,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
       "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1805,7 +1764,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
       "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1815,7 +1774,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
       "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1825,7 +1784,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
       "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/envelope": "^5.1.5",
@@ -1838,7 +1797,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
       "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1849,7 +1808,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
       "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -1858,7 +1817,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
       "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-clockwise": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -1871,7 +1830,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
       "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1881,7 +1840,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
       "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1891,7 +1850,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
       "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -1901,7 +1860,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
       "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -1910,7 +1869,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
       "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/circle": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -1923,7 +1882,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
       "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -1940,7 +1899,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
       "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -1952,7 +1911,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
       "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -1962,7 +1921,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
       "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-contains": "^5.1.5",
         "@turf/boolean-overlap": "^5.1.5",
@@ -1976,7 +1935,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
       "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/center-mean": "^5.1.5",
         "@turf/ellipse": "^5.1.5",
@@ -1990,7 +1949,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
       "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -2002,7 +1961,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
       "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "earcut": "^2.0.0"
@@ -2012,7 +1971,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
       "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5"
       }
@@ -2021,7 +1980,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
       "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/centroid": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -2037,7 +1996,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
       "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -2055,7 +2014,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
       "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -2068,7 +2027,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
       "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -2080,7 +2039,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
       "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -2090,7 +2049,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
       "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/along": "5.1.x",
         "@turf/area": "5.1.x",
@@ -2198,7 +2157,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
       "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "turf-jsts": "*"
@@ -2208,7 +2167,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
       "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/area": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -2221,13 +2180,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
       "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/unkink-polygon/node_modules/rbush": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
       "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "quickselect": "^1.0.1"
       }
@@ -2236,7 +2195,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
       "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -2247,14 +2206,14 @@
       "version": "4.14.170",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
       "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/loglevel": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha512-v2YWQQgqtNXAzybOT9qV3CIJqSeoaMUwmBfIMTQdvhsWUybYic/zNGccKH494naWKJ7zUm+VTgFepJfTrbCCJQ==",
       "deprecated": "This is a stub types definition. loglevel provides its own type definitions, so you do not need this installed.",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loglevel": "*"
       }
@@ -2263,25 +2222,25 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/url-search-params": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/url-search-params/-/url-search-params-1.1.0.tgz",
       "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/validator": {
       "version": "13.1.4",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.4.tgz",
       "integrity": "sha512-19C02B8mr53HufY7S+HO/EHBD7a/R22IwEwyqiHaR19iwL37dN3o0M8RianVInfSSqP7InVSg/o0mUATM4JWsQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2290,7 +2249,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2302,7 +2261,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2316,13 +2274,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -2332,7 +2289,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
       "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
-      "dev": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
@@ -2346,7 +2303,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2356,7 +2313,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -2369,7 +2325,6 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
       "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001259",
@@ -2393,7 +2348,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -2406,7 +2361,6 @@
       "version": "1.0.30001260",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
       "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "nanocolors": "^0.1.0"
@@ -2420,14 +2374,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
       "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2441,7 +2394,6 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2463,7 +2415,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2474,7 +2426,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2483,25 +2435,25 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "peer": true
     },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "peer": true
     },
     "node_modules/concaveman": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.0.tgz",
       "integrity": "sha512-OcqechF2/kubbffomKqjGEkb0ndlYhEbmyg/fxIGqdfYp5AZjD2Kl5hc97Hh3ngEuHU2314Z4KDbxL7qXGWrQQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "point-in-polygon": "^1.0.1",
         "rbush": "^3.0.0",
@@ -2513,7 +2465,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -2522,19 +2474,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
-      "dev": true
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/d3-geo": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
       "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "d3-array": "1"
       }
@@ -2543,19 +2495,19 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=",
-      "dev": true
+      "peer": true
     },
     "node_modules/dayjs": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
       "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2572,7 +2524,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2581,7 +2533,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -2598,7 +2550,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2607,7 +2559,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -2619,13 +2571,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
       "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU=",
-      "dev": true
+      "peer": true
     },
     "node_modules/dependency-graph": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -2635,32 +2586,31 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
       "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.849",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz",
       "integrity": "sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==",
-      "dev": true,
       "peer": true
     },
     "node_modules/emitter-component": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
-      "dev": true
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "peer": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2669,7 +2619,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2678,7 +2628,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2691,7 +2640,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2700,34 +2649,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "peer": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "peer": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2736,7 +2670,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
       "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "deep-equal": "^1.0.0"
       }
@@ -2745,7 +2679,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
       "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "*",
         "@turf/meta": "*",
@@ -2756,7 +2690,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.3.1.tgz",
       "integrity": "sha512-gV0brwiPkNka6uqHNvzE5gZC4YmYXgddK3lodj3cF03P+FEFP70hRkCpvK75CnmHC6slFlFphIGJcJCWNaQVmQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@terrestris/ol-util": "^4.0.1",
         "geostyler-style": "^4.0.0",
@@ -2770,7 +2704,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-2.3.0.tgz",
       "integrity": "sha512-2uEHhOQDxPJaWlguPr8y5DdHxNMJyyN89I5Wxn6owe5G5IaD6y00xbQAk4o9nUDwnubCk7Z7IJ9JuwnjHDR+1Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "geostyler-style": "^4.0.1",
         "lodash": "^4.17.21",
@@ -2784,7 +2718,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
       "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
@@ -2794,7 +2728,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2803,13 +2737,13 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
       "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8=",
-      "dev": true
+      "peer": true
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -2823,7 +2757,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2843,7 +2777,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2856,7 +2789,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -2865,7 +2798,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2877,7 +2810,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -2886,7 +2819,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2898,7 +2831,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2910,7 +2843,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2924,19 +2856,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2946,13 +2879,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/is-arguments": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
       "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.0"
       },
@@ -2967,7 +2900,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -2980,7 +2912,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
       "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2992,7 +2924,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
       "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3004,7 +2936,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3014,7 +2945,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3023,7 +2954,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3036,7 +2966,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.12.0"
@@ -3046,7 +2975,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
       "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.2"
@@ -3062,13 +2991,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -3080,13 +3009,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
       "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -3101,7 +3030,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
       "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "pako": "~1.0.2"
       }
@@ -3110,7 +3039,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -3119,19 +3048,19 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
       "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM=",
-      "dev": true
+      "peer": true
     },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/loglevel": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -3144,13 +3073,12 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
+      "peer": true
     },
     "node_modules/magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
@@ -3160,25 +3088,25 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/mgrs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
       "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk=",
-      "dev": true
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3190,26 +3118,25 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "peer": true
     },
     "node_modules/nanocolors": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
       "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/ngx-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ngx-color/-/ngx-color-7.2.0.tgz",
       "integrity": "sha512-bX7xelfMDTMtr8oL5eUrz+j70CwPhzoqthIg2aHYwaAHBUZk+T/xGB1RXlRfUSV3oZua8OZ7qUtQ1Wo2Zc+suQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.0",
         "material-colors": "^1.2.6",
@@ -3224,7 +3151,7 @@
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-12.0.3.tgz",
       "integrity": "sha512-F5xJBTrrreI2DERGOrO6U+L7s031HxTER+3Z4gDCwxdTl4AXmtWddMxxQVw7KflOLZ4InYEs6FjQsXmKU4HsJg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -3237,14 +3164,12 @@
       "version": "1.1.76",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
       "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
-      "dev": true,
       "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3254,7 +3179,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3263,7 +3188,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -3279,7 +3204,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3288,7 +3213,7 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
       "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
@@ -3303,7 +3228,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
       "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
@@ -3317,7 +3242,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
       "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw==",
-      "dev": true,
+      "peer": true,
       "peerDependencies": {
         "ol": ">=5.0.0"
       }
@@ -3326,7 +3251,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3335,20 +3260,20 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/parsedbf": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.1.1.tgz",
       "integrity": "sha512-jndFmhcrzSAGCMccM4za+3bIRxqV6L2doQjYN8Xgz0kZUpyBT5I8Gs6Y6hL5GcO2rih9OBkPcLlx2uBoLi8R8Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.4.15",
         "text-encoding-polyfill": "^0.6.7"
@@ -3358,7 +3283,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3367,13 +3292,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/pbf": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -3386,7 +3311,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=8.6"
@@ -3399,13 +3323,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/proj4": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.2.tgz",
       "integrity": "sha512-x/EboBmIq48a9FED0Z9zWCXkd8VIpXHLsyEXljGtsnzeztC41bFjPjJ0S//wBbNLDnDYRe0e6c3FSSiqMCebDA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.2.4"
@@ -3415,13 +3339,13 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
       "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/query-string": {
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
       "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -3439,13 +3363,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "inherits": "~2.0.3"
       }
@@ -3454,13 +3378,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "quickselect": "^2.0.0"
       }
@@ -3469,7 +3393,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -3482,14 +3405,13 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
       "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -3505,7 +3427,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3514,13 +3436,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -3533,7 +3455,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -3542,24 +3464,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resumablejs/-/resumablejs-1.1.0.tgz",
       "integrity": "sha512-gUTWTtJ2aheRb5svHDGHMtQsBkGxTILpZApT11ODoxEe5D75GhYL7Nc/WYgCcJXY+5RVmm2BEsp2qriCkKWRRg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/robust-predicates": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
       "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
+      "peer": true
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -3570,31 +3493,32 @@
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -3603,13 +3527,13 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/share-api-polyfill/-/share-api-polyfill-1.0.20.tgz",
       "integrity": "sha512-yEPJmckdBz38E+cu966MVRAeRwVIbEtnhG6Ox4d0+Q0P5BVQtulzzA7LaFmDFNKGFp8LDhsuESnPZmWxE0hWPw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/shpjs": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
       "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "jszip": "^2.4.0",
         "lie": "^3.0.1",
@@ -3622,13 +3546,13 @@
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
       "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
       "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3637,7 +3561,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
       "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3646,7 +3570,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -3659,7 +3583,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3668,14 +3592,13 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true,
       "peer": true
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3684,7 +3607,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "emitter-component": "^1.1.1"
       }
@@ -3693,7 +3616,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -3702,7 +3625,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3716,7 +3639,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -3728,7 +3651,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3740,25 +3663,25 @@
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
       "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/timers": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/timers/-/timers-0.1.1.tgz",
       "integrity": "sha1-hqxceMHuQZaU81pY3k/UGDz7nB4=",
-      "dev": true
+      "peer": true
     },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "dev": true
+      "peer": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -3767,7 +3690,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
@@ -3780,7 +3702,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "commander": "2"
       },
@@ -3794,7 +3716,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
       "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "commander": "2"
       },
@@ -3811,13 +3733,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==",
-      "dev": true
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3831,7 +3752,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
       "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -3842,13 +3763,13 @@
       "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-1.1.0.tgz",
       "integrity": "sha512-XiO5GLAxmlZgdLob/RmKZRc2INHrssMbpwD6O46JkB1aEJO4fkV3x3mR6+CDX01ijfEUwvfwCiUQZrKqfm1ILw==",
       "deprecated": "now available as @ungap/url-search-params",
-      "dev": true
+      "peer": true
     },
     "node_modules/validator": {
       "version": "13.6.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
       "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -3857,19 +3778,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
       "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
-      "dev": true
+      "peer": true
     },
     "node_modules/wkt-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.4.tgz",
       "integrity": "sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3886,7 +3807,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3901,7 +3822,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3913,19 +3834,19 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "peer": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "peer": true
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
       "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "sax": "^1.2.4"
       },
@@ -3937,7 +3858,7 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -3950,7 +3871,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3959,7 +3880,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
       "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3968,7 +3889,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3977,14 +3898,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "peer": true
     },
     "node_modules/yargs": {
       "version": "17.1.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
       "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -4002,7 +3922,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4022,7 +3942,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.7.tgz",
       "integrity": "sha512-OMPewaE1VxCSFkLDZQLFMkGQCQEvbizuVRzArZBB5xfxl98YMjntNQjlWH4rGbRhF+eZlpOrC+UAVnzTX2BzAw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^2.2.0"
@@ -4032,6 +3952,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.7.tgz",
       "integrity": "sha512-Gug5a59c4NwfmSvO9Ya7DoYjl6ndK7nDuBoPSpp6IHTlNE8FY/BOd29qEp/lYJ4cAWxVk14+lonUPs6C+Szekw==",
+      "peer": true,
       "requires": {
         "tslib": "^2.2.0"
       }
@@ -4040,6 +3961,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.7.tgz",
       "integrity": "sha512-9X7Vrfg6dWfYKPAJLQYR5W7N8WnESg8PG07gNzHZtavETPrDIoX+Av/kQcEdPu14zTZE5NWx5u5TUByFgouQiQ==",
+      "peer": true,
       "requires": {
         "tslib": "^2.2.0"
       }
@@ -4048,7 +3970,6 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.7.tgz",
       "integrity": "sha512-otsy3t3psrEWNbnjADaZVhBGBmBmBGxqknNoJ1+UeqSWf4z7su736jyzerxD684vmk08U6X2loxOuDr90idjPA==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/core": "^7.8.6",
@@ -4071,7 +3992,6 @@
           "version": "7.15.5",
           "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
           "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
-          "dev": true,
           "peer": true,
           "requires": {
             "@babel/code-frame": "^7.14.5",
@@ -4095,14 +4015,12 @@
               "version": "6.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true,
               "peer": true
             },
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
               "peer": true
             }
           }
@@ -4111,7 +4029,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "peer": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -4121,7 +4038,6 @@
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
           "peer": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4131,7 +4047,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "peer": true
         }
       }
@@ -4140,6 +4055,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.7.tgz",
       "integrity": "sha512-no4mQ4O1euNH6odho1H27dcUmYBaNuyYvpPvv0wbb1pMT3Mm2J/uueePx/fvwg3nQ+vnk/yL1VCCqR7Mt62nHA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.2.0"
       }
@@ -4148,7 +4064,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-12.2.7.tgz",
       "integrity": "sha512-TtXnwE/bouEtGddaaSGytwCoyRN8YPNN/yf81fFM9LOGef4ZpABMtuMnsZxlDS+91AGpVSzvR511O5DG1BXc4Q==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.2.0"
       }
@@ -4157,7 +4073,7 @@
       "version": "12.2.7",
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-12.2.7.tgz",
       "integrity": "sha512-zTWL4e67sgqefI0Gd362W3z7clGZ+TouuTCx8/1SRCqIeOthz59Km7pJEsrPgboMVqSqqtRQMluguSBW8fEDvg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/core": "7.8.3",
         "glob": "7.1.7",
@@ -4186,7 +4102,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/highlight": "^7.14.5"
       }
@@ -4195,14 +4111,13 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
       "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
-      "dev": true,
       "peer": true
     },
     "@babel/core": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
       "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.8.3",
@@ -4225,7 +4140,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
       "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
@@ -4236,7 +4151,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
       "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
@@ -4249,7 +4163,6 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true,
           "peer": true
         }
       }
@@ -4258,7 +4171,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
       "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.15.4",
         "@babel/template": "^7.15.4",
@@ -4269,7 +4182,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
       "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
       }
@@ -4278,7 +4191,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
       "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
       }
@@ -4287,7 +4200,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
       "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
@@ -4297,7 +4209,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
       "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
@@ -4307,7 +4218,6 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
       "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/helper-module-imports": "^7.15.4",
@@ -4324,7 +4234,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
       "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
@@ -4334,7 +4243,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
       "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.15.4",
@@ -4347,7 +4255,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
       "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
-      "dev": true,
       "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
@@ -4357,7 +4264,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
       "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/types": "^7.15.4"
       }
@@ -4366,20 +4273,19 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true
+      "peer": true
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
       "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true,
       "peer": true
     },
     "@babel/helpers": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
       "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
@@ -4390,7 +4296,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
@@ -4401,13 +4307,13 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
       "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
-      "dev": true
+      "peer": true
     },
     "@babel/template": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
       "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.15.4",
@@ -4418,7 +4324,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
       "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.4",
@@ -4435,7 +4341,7 @@
       "version": "7.15.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
       "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -4445,19 +4351,19 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
       "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==",
-      "dev": true
+      "peer": true
     },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "dev": true
+      "peer": true
     },
     "@mapbox/mapbox-gl-style-spec": {
       "version": "13.21.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
       "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -4473,19 +4379,19 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
-      "dev": true
+      "peer": true
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
-      "dev": true
+      "peer": true
     },
     "@ng-bootstrap/ng-bootstrap": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-10.0.0.tgz",
       "integrity": "sha512-Sz+QaxjuyJYJ+zyUbf0TevgcgVesCPQiiFiggEzxKjzY5R+Hvq3YgryLdXf2r/ryePL+C3FXCcmmKpTM5bfczQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -4494,14 +4400,14 @@
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-12.1.2.tgz",
       "integrity": "sha512-ZudJsqIxTKlLmPoqK8gJY3UpMGujR0Xm7HfXL6AR79yGRS23QqpjAhMfx4v5qUCcHMmQ9/78bW8QJLfp31c7vQ==",
-      "dev": true,
+      "peer": true,
       "requires": {}
     },
     "@ngx-translate/http-loader": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
       "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -4510,7 +4416,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-1.0.1.tgz",
       "integrity": "sha512-ML1IaqZXGWlXrI8pEAnGZv6qPmW72uBZkbc5NvZcBDattpXmrE3rCntTou1t/zLaOz0v4qmG5KORMTSzOeScRQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/lodash": "^4.14.168",
         "@types/loglevel": "^1.6.3",
@@ -4529,7 +4435,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-4.1.3.tgz",
       "integrity": "sha512-vTS7rXxOcvTpXQzRGR6DVldEYcbFjADQ9/ArSKeq9yCmmY9wb3dkeGKw+rN/dltu6oZbaswjsUsBQe060kiMOQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@terrestris/base-util": "^1.0.0",
         "@turf/turf": "^5.1.6",
@@ -4542,7 +4448,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
       "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -4554,7 +4460,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
       "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -4564,7 +4470,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
       "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -4574,7 +4480,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
       "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -4585,7 +4491,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
       "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -4594,7 +4500,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
       "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4604,7 +4510,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
       "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4614,7 +4520,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
       "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4624,7 +4530,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
       "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -4637,7 +4543,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
       "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4650,7 +4556,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
       "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4663,7 +4569,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
       "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4675,7 +4581,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
       "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -4689,7 +4595,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
       "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4701,7 +4607,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
       "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4711,7 +4617,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
       "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4721,7 +4627,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
       "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -4734,7 +4640,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
       "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -4749,7 +4655,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
       "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -4759,7 +4665,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
       "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4770,7 +4676,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
       "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/center-mean": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -4783,7 +4689,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
       "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/centroid": "^5.1.5",
         "@turf/convex": "^5.1.5",
@@ -4796,7 +4702,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
       "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -4806,7 +4712,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
       "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/destination": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -4816,7 +4722,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
       "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4826,7 +4732,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
       "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -4835,7 +4741,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
       "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -4845,7 +4751,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
       "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -4859,7 +4765,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
       "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4872,7 +4778,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
       "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -4884,13 +4790,13 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
           "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-          "dev": true
+          "peer": true
         },
         "rbush": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
           "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "quickselect": "^1.0.1"
           }
@@ -4901,7 +4807,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
       "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -4911,7 +4817,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
       "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -4927,7 +4833,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
       "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5",
@@ -4938,7 +4844,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
       "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4948,7 +4854,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
       "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/area": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -4961,7 +4867,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
       "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-overlap": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -4978,7 +4884,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
       "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -4988,7 +4894,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
       "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -5000,7 +4906,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
       "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -5011,7 +4917,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
       "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -5021,7 +4927,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
       "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -5031,7 +4937,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
       "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5042,7 +4948,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
       "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5052,13 +4958,13 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
       "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=",
-      "dev": true
+      "peer": true
     },
     "@turf/hex-grid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
       "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5070,7 +4976,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
       "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/centroid": "^5.1.5",
@@ -5089,7 +4995,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
       "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5102,7 +5008,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
       "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -5111,7 +5017,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
       "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/area": "^5.1.5",
         "@turf/bbox": "^5.1.5",
@@ -5126,7 +5032,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
       "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5138,7 +5044,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
       "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -5147,7 +5053,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
       "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5158,7 +5064,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
       "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/circle": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -5169,7 +5075,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
       "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/length": "^5.1.5",
@@ -5181,7 +5087,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
       "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -5194,7 +5100,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
       "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -5205,7 +5111,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
       "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-on-line": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5220,7 +5126,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
       "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -5231,7 +5137,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
       "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -5242,7 +5148,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
       "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -5254,7 +5160,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
       "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5272,7 +5178,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
       "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5283,7 +5189,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
       "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5296,13 +5202,13 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
           "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-          "dev": true
+          "peer": true
         },
         "rbush": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
           "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "quickselect": "^1.0.1"
           }
@@ -5313,7 +5219,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
       "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -5322,7 +5228,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
       "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -5334,7 +5240,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
       "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -5346,7 +5252,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
       "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bearing": "^5.1.5",
         "@turf/destination": "^5.1.5",
@@ -5361,7 +5267,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
       "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "6.x",
         "@turf/invariant": "6.x",
@@ -5374,13 +5280,13 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.4.0.tgz",
           "integrity": "sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ==",
-          "dev": true
+          "peer": true
         },
         "@turf/invariant": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.4.0.tgz",
           "integrity": "sha512-ncAiOLkL6Ul6NnyOZSSmEbTwcZZ8PTx7O1IzB89Ed/mAe1g5PvFnyFieWbcnERGmuqH1ftzgtWMFFHFi2PQLsg==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0"
           }
@@ -5389,7 +5295,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.4.0.tgz",
           "integrity": "sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0"
           }
@@ -5400,7 +5306,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
       "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5410,7 +5316,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
       "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-within": "^5.1.5",
         "@turf/distance": "^5.1.5",
@@ -5422,7 +5328,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
       "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -5435,7 +5341,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
       "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bearing": "6.x",
         "@turf/distance": "6.x",
@@ -5451,7 +5357,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.4.0.tgz",
           "integrity": "sha512-CmMsT8hSzzhZWe0+49OP48m/EAXryZjNh/7D/0nqMIlayslRZ+bHuV3KcrOCD20xoDFtBuSEdwEd6i4+2Nw3LA==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0",
             "@turf/invariant": "^6.4.0"
@@ -5461,7 +5367,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.4.0.tgz",
           "integrity": "sha512-m0MzpW601CQJ7al3XireJNPrKz6KHMnbWysS6p4qkG7E70c+S8ST0y6gj1CfdkdS7ee3GevEg7V6sxdj2lCs4w==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0"
           }
@@ -5470,7 +5376,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.4.0.tgz",
           "integrity": "sha512-EyNEfHfFNVwLHsD31hIpaDInoxlwUFZAVryTWxDu6O+XNE+VfVomMUxLYPm3t0tVqVNUGwOhYo5Z4HfTlr6V1g==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0",
             "@turf/invariant": "^6.4.0"
@@ -5480,13 +5386,13 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.4.0.tgz",
           "integrity": "sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ==",
-          "dev": true
+          "peer": true
         },
         "@turf/invariant": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.4.0.tgz",
           "integrity": "sha512-ncAiOLkL6Ul6NnyOZSSmEbTwcZZ8PTx7O1IzB89Ed/mAe1g5PvFnyFieWbcnERGmuqH1ftzgtWMFFHFi2PQLsg==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0"
           }
@@ -5495,7 +5401,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.4.0.tgz",
           "integrity": "sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0"
           }
@@ -5504,7 +5410,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.4.0.tgz",
           "integrity": "sha512-UtirO+dz0XMgQUG1y50anzHpFsfGObSwT3zsYJIWm3nsJmYMWOBJpsSQ6hMNua3P9GeQrzphG4qJTsQPQveOcA==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/clone": "^6.4.0",
             "@turf/helpers": "^6.4.0",
@@ -5515,7 +5421,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.4.0.tgz",
           "integrity": "sha512-6KeNTzKsTjmvladtKKtaF3/QLPey9Ui954PuNvb6YGW6FSvS4qlMgznyYz18YYhBAkN1OqSjcqTeVvFjXfzoRw==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0",
             "@turf/invariant": "^6.4.0"
@@ -5525,7 +5431,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.4.0.tgz",
           "integrity": "sha512-r4dsy8sPyp8k5rR6FwXek8c1RG+nLNH1B43yjmIpaLDKcRYoXJSGt1K8SWOkFOGHl36nukq46Meh2IcH43K6aw==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "@turf/helpers": "^6.4.0",
             "@turf/invariant": "^6.4.0"
@@ -5537,7 +5443,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
       "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5548,7 +5454,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
       "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5558,7 +5464,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
       "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5568,7 +5474,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
       "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/envelope": "^5.1.5",
@@ -5581,7 +5487,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
       "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5592,7 +5498,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
       "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -5601,7 +5507,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
       "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-clockwise": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -5614,7 +5520,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
       "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5624,7 +5530,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
       "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5634,7 +5540,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
       "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
@@ -5644,7 +5550,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
       "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -5653,7 +5559,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
       "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/circle": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5666,7 +5572,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
       "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/bbox-polygon": "^5.1.5",
@@ -5683,7 +5589,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
       "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clean-coords": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -5695,7 +5601,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
       "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5"
@@ -5705,7 +5611,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
       "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-contains": "^5.1.5",
         "@turf/boolean-overlap": "^5.1.5",
@@ -5719,7 +5625,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
       "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/center-mean": "^5.1.5",
         "@turf/ellipse": "^5.1.5",
@@ -5733,7 +5639,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
       "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/boolean-point-in-polygon": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -5745,7 +5651,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
       "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "earcut": "^2.0.0"
@@ -5755,7 +5661,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
       "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5"
       }
@@ -5764,7 +5670,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
       "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/centroid": "^5.1.5",
         "@turf/clone": "^5.1.5",
@@ -5780,7 +5686,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
       "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/bbox": "^5.1.5",
         "@turf/center": "^5.1.5",
@@ -5798,7 +5704,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
       "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/clone": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5811,7 +5717,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
       "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/distance": "^5.1.5",
         "@turf/helpers": "^5.1.5",
@@ -5823,7 +5729,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
       "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/meta": "^5.1.5"
@@ -5833,7 +5739,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
       "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/along": "5.1.x",
         "@turf/area": "5.1.x",
@@ -5941,7 +5847,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
       "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "turf-jsts": "*"
@@ -5951,7 +5857,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
       "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/area": "^5.1.5",
         "@turf/boolean-point-in-polygon": "^5.1.5",
@@ -5964,13 +5870,13 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
           "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
-          "dev": true
+          "peer": true
         },
         "rbush": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
           "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "quickselect": "^1.0.1"
           }
@@ -5981,7 +5887,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
       "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
@@ -5992,13 +5898,13 @@
       "version": "4.14.170",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
       "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
-      "dev": true
+      "peer": true
     },
     "@types/loglevel": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha512-v2YWQQgqtNXAzybOT9qV3CIJqSeoaMUwmBfIMTQdvhsWUybYic/zNGccKH494naWKJ7zUm+VTgFepJfTrbCCJQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loglevel": "*"
       }
@@ -6007,31 +5913,31 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
-      "dev": true
+      "peer": true
     },
     "@types/url-search-params": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/url-search-params/-/url-search-params-1.1.0.tgz",
       "integrity": "sha512-MAiEDfjOmuZLSx2rrRj3rR2729wygQbq5mdQsEW4gMRFRDoW93lUU3n0ablmbAIL9pzharzhmcEjrO2zW0JSKg==",
-      "dev": true
+      "peer": true
     },
     "@types/validator": {
       "version": "13.1.4",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.4.tgz",
       "integrity": "sha512-19C02B8mr53HufY7S+HO/EHBD7a/R22IwEwyqiHaR19iwL37dN3o0M8RianVInfSSqP7InVSg/o0mUATM4JWsQ==",
-      "dev": true
+      "peer": true
     },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "peer": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -6040,7 +5946,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
       "peer": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -6051,27 +5956,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "peer": true
     },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "peer": true
     },
     "bootstrap": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
       "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
-      "dev": true,
+      "peer": true,
       "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6081,7 +5985,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "peer": true,
       "requires": {
         "fill-range": "^7.0.1"
@@ -6091,7 +5994,6 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
       "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
-      "dev": true,
       "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001259",
@@ -6105,7 +6007,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -6115,7 +6017,6 @@
       "version": "1.0.30001260",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
       "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
-      "dev": true,
       "peer": true,
       "requires": {
         "nanocolors": "^0.1.0"
@@ -6125,14 +6026,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
       "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
-      "dev": true,
       "peer": true
     },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -6143,7 +6043,6 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "dev": true,
       "peer": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -6160,7 +6059,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -6171,7 +6070,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -6180,25 +6079,25 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "peer": true
     },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "peer": true
     },
     "concaveman": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.0.tgz",
       "integrity": "sha512-OcqechF2/kubbffomKqjGEkb0ndlYhEbmyg/fxIGqdfYp5AZjD2Kl5hc97Hh3ngEuHU2314Z4KDbxL7qXGWrQQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "point-in-polygon": "^1.0.1",
         "rbush": "^3.0.0",
@@ -6210,7 +6109,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -6219,19 +6118,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
-      "dev": true
+      "peer": true
     },
     "d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "dev": true
+      "peer": true
     },
     "d3-geo": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
       "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "d3-array": "1"
       }
@@ -6240,19 +6139,19 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
       "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=",
-      "dev": true
+      "peer": true
     },
     "dayjs": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
       "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
-      "dev": true
+      "peer": true
     },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -6261,13 +6160,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "peer": true
     },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -6281,13 +6180,13 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "peer": true
     },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -6296,57 +6195,54 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
       "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU=",
-      "dev": true
+      "peer": true
     },
     "dependency-graph": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "dev": true,
       "peer": true
     },
     "earcut": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
       "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==",
-      "dev": true
+      "peer": true
     },
     "electron-to-chromium": {
       "version": "1.3.849",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz",
       "integrity": "sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==",
-      "dev": true,
       "peer": true
     },
     "emitter-component": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
-      "dev": true
+      "peer": true
     },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "peer": true
     },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "peer": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "peer": true
     },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "peer": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -6356,39 +6252,31 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "dev": true
+      "peer": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true,
       "peer": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "peer": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "peer": true
     },
     "geojson-equality": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
       "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "deep-equal": "^1.0.0"
       }
@@ -6397,7 +6285,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
       "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@turf/helpers": "*",
         "@turf/meta": "*",
@@ -6408,7 +6296,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-2.3.1.tgz",
       "integrity": "sha512-gV0brwiPkNka6uqHNvzE5gZC4YmYXgddK3lodj3cF03P+FEFP70hRkCpvK75CnmHC6slFlFphIGJcJCWNaQVmQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@terrestris/ol-util": "^4.0.1",
         "geostyler-style": "^4.0.0",
@@ -6419,7 +6307,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-2.3.0.tgz",
       "integrity": "sha512-2uEHhOQDxPJaWlguPr8y5DdHxNMJyyN89I5Wxn6owe5G5IaD6y00xbQAk4o9nUDwnubCk7Z7IJ9JuwnjHDR+1Q==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "geostyler-style": "^4.0.1",
         "lodash": "^4.17.21",
@@ -6433,7 +6321,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-4.0.3.tgz",
       "integrity": "sha512-51esHVZz86HFoSvKRA/Kfqd2Mytek88zgHSSt8ZZg30o4dqyZuQluxwIjqkSLp5hdvmA0nwCAyqxHy6aMyJ5lQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/lodash": "^4.14.168",
         "lodash": "^4.17.21"
@@ -6443,19 +6331,19 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "peer": true
     },
     "get-closest": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
       "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8=",
-      "dev": true
+      "peer": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -6466,7 +6354,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6480,7 +6368,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "peer": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -6490,13 +6377,13 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "peer": true
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6505,19 +6392,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "peer": true
     },
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "peer": true
     },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -6526,19 +6413,19 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "peer": true
     },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "peer": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6548,13 +6435,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "peer": true
     },
     "is-arguments": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
       "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -6563,7 +6450,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "peer": true,
       "requires": {
         "binary-extensions": "^2.0.0"
@@ -6573,7 +6459,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
       "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -6582,26 +6468,24 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
       "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
-      "dev": true
+      "peer": true
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
       "peer": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "peer": true
     },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "peer": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -6611,14 +6495,13 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "peer": true
     },
     "is-regex": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
       "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.2"
@@ -6628,25 +6511,25 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "peer": true
     },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "peer": true
     },
     "json-stringify-pretty-compact": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
       "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
+      "peer": true
     },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -6655,7 +6538,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
       "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "pako": "~1.0.2"
       }
@@ -6664,7 +6547,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -6673,31 +6556,30 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
       "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM=",
-      "dev": true
+      "peer": true
     },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "peer": true
     },
     "loglevel": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
-      "dev": true
+      "peer": true
     },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
+      "peer": true
     },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "peer": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
@@ -6707,25 +6589,25 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
-      "dev": true
+      "peer": true
     },
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "dev": true
+      "peer": true
     },
     "mgrs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
       "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk=",
-      "dev": true
+      "peer": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -6734,26 +6616,25 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "peer": true
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "peer": true
     },
     "nanocolors": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
       "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
-      "dev": true,
       "peer": true
     },
     "ngx-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ngx-color/-/ngx-color-7.2.0.tgz",
       "integrity": "sha512-bX7xelfMDTMtr8oL5eUrz+j70CwPhzoqthIg2aHYwaAHBUZk+T/xGB1RXlRfUSV3oZua8OZ7qUtQ1Wo2Zc+suQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@ctrl/tinycolor": "^3.4.0",
         "material-colors": "^1.2.6",
@@ -6764,7 +6645,7 @@
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-12.0.3.tgz",
       "integrity": "sha512-F5xJBTrrreI2DERGOrO6U+L7s031HxTER+3Z4gDCwxdTl4AXmtWddMxxQVw7KflOLZ4InYEs6FjQsXmKU4HsJg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -6773,27 +6654,25 @@
       "version": "1.1.76",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
       "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
-      "dev": true,
       "peer": true
     },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "peer": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "peer": true
     },
     "object-is": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -6803,13 +6682,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "peer": true
     },
     "ol": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
       "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
@@ -6820,7 +6699,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
       "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
@@ -6831,14 +6710,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
       "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw==",
-      "dev": true,
+      "peer": true,
       "requires": {}
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6847,20 +6726,20 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "peer": true
     },
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "parsedbf": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.1.1.tgz",
       "integrity": "sha512-jndFmhcrzSAGCMccM4za+3bIRxqV6L2doQjYN8Xgz0kZUpyBT5I8Gs6Y6hL5GcO2rih9OBkPcLlx2uBoLi8R8Q==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "iconv-lite": "^0.4.15",
         "text-encoding-polyfill": "^0.6.7"
@@ -6870,19 +6749,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "peer": true
     },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "peer": true
     },
     "pbf": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -6892,20 +6771,19 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
       "peer": true
     },
     "point-in-polygon": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "dev": true
+      "peer": true
     },
     "proj4": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.2.tgz",
       "integrity": "sha512-x/EboBmIq48a9FED0Z9zWCXkd8VIpXHLsyEXljGtsnzeztC41bFjPjJ0S//wBbNLDnDYRe0e6c3FSSiqMCebDA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.2.4"
@@ -6915,13 +6793,13 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
       "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw==",
-      "dev": true
+      "peer": true
     },
     "query-string": {
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
       "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -6933,13 +6811,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "peer": true
     },
     "queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "inherits": "~2.0.3"
       }
@@ -6948,13 +6826,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "peer": true
     },
     "rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "quickselect": "^2.0.0"
       }
@@ -6963,7 +6841,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "peer": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -6973,14 +6850,13 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true,
       "peer": true
     },
     "regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
       "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -6990,19 +6866,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "peer": true
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "peer": true
     },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -7012,7 +6888,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -7021,24 +6897,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resumablejs/-/resumablejs-1.1.0.tgz",
       "integrity": "sha512-gUTWTtJ2aheRb5svHDGHMtQsBkGxTILpZApT11ODoxEe5D75GhYL7Nc/WYgCcJXY+5RVmm2BEsp2qriCkKWRRg==",
-      "dev": true
+      "peer": true
     },
     "robust-predicates": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
       "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
-      "dev": true
+      "peer": true
     },
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
+      "peer": true
     },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       },
@@ -7046,7 +6923,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },
@@ -7054,37 +6932,37 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "peer": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "peer": true
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "peer": true
     },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "peer": true
     },
     "share-api-polyfill": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/share-api-polyfill/-/share-api-polyfill-1.0.20.tgz",
       "integrity": "sha512-yEPJmckdBz38E+cu966MVRAeRwVIbEtnhG6Ox4d0+Q0P5BVQtulzzA7LaFmDFNKGFp8LDhsuESnPZmWxE0hWPw==",
-      "dev": true
+      "peer": true
     },
     "shpjs": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
       "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "jszip": "^2.4.0",
         "lie": "^3.0.1",
@@ -7097,25 +6975,25 @@
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
       "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
-      "dev": true
+      "peer": true
     },
     "sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
       "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true
+      "peer": true
     },
     "sort-desc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
       "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true
+      "peer": true
     },
     "sort-object": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -7125,26 +7003,25 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "peer": true
     },
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true,
       "peer": true
     },
     "split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
+      "peer": true
     },
     "stream": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
-      "dev": true,
+      "peer": true,
       "requires": {
         "emitter-component": "^1.1.1"
       }
@@ -7153,13 +7030,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "dev": true
+      "peer": true
     },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7170,7 +7047,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -7179,7 +7056,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -7188,31 +7065,30 @@
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
       "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==",
-      "dev": true
+      "peer": true
     },
     "timers": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/timers/-/timers-0.1.1.tgz",
       "integrity": "sha1-hqxceMHuQZaU81pY3k/UGDz7nB4=",
-      "dev": true
+      "peer": true
     },
     "tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "dev": true
+      "peer": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "peer": true
     },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "peer": true,
       "requires": {
         "is-number": "^7.0.0"
@@ -7222,7 +7098,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "commander": "2"
       }
@@ -7231,7 +7107,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
       "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "commander": "2"
       }
@@ -7245,20 +7121,19 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==",
-      "dev": true
+      "peer": true
     },
     "typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
       "peer": true
     },
     "url-parse": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
       "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -7268,31 +7143,31 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-1.1.0.tgz",
       "integrity": "sha512-XiO5GLAxmlZgdLob/RmKZRc2INHrssMbpwD6O46JkB1aEJO4fkV3x3mR6+CDX01ijfEUwvfwCiUQZrKqfm1ILw==",
-      "dev": true
+      "peer": true
     },
     "validator": {
       "version": "13.6.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
       "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
-      "dev": true
+      "peer": true
     },
     "webfont-matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
       "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
-      "dev": true
+      "peer": true
     },
     "wkt-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.4.tgz",
       "integrity": "sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg==",
-      "dev": true
+      "peer": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7303,7 +7178,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -7312,7 +7187,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
+          "peer": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -7321,7 +7196,7 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "peer": true
         }
       }
     },
@@ -7329,13 +7204,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "peer": true
     },
     "xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
       "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "sax": "^1.2.4"
       }
@@ -7344,7 +7219,7 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -7354,32 +7229,31 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
+      "peer": true
     },
     "xmldom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
       "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "dev": true
+      "peer": true
     },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "peer": true
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "peer": true
     },
     "yargs": {
       "version": "17.1.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
       "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -7394,7 +7268,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true
+      "peer": true
     },
     "zone.js": {
       "version": "0.11.4",

--- a/projects/hslayers/package.json
+++ b/projects/hslayers/package.json
@@ -22,7 +22,7 @@
     "geostyler-sld-parser": "^2.0.0",
     "geostyler-style": "^4.0.0",
     "ngx-cookie-service": "^12.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.7.0",
     "ol-popup": "^4.0.0",
     "proj4": "^2.6.0",
     "queue": "^6.0.0",

--- a/projects/hslayers/package.json
+++ b/projects/hslayers/package.json
@@ -32,33 +32,6 @@
     "zone.js": "^0.10.2 || ^0.11.3",
     "resumablejs": "^1.1.0"
   },
-  "devDependencies": {
-    "@angular/cdk": "^12.2.7",
-    "@angular/common": "^12.2.7",
-    "@angular/compiler": "^12.2.7",
-    "@angular/core": "^12.2.7",
-    "@angular/forms": "^12.2.7",
-    "@angular/localize": "^12.2.7",
-    "@ng-bootstrap/ng-bootstrap": "^10.0.0",
-    "@ngx-translate/core": "^12.1.2",
-    "@ngx-translate/http-loader": "^6.0.0",
-    "bootstrap": ">=4.6.0",
-    "dayjs": "^1.10.4",
-    "deepmerge": "^4.2.2",
-    "geostyler-openlayers-parser": "^2.3.0",
-    "geostyler-sld-parser": "^2.3.0",
-    "geostyler-style": "^4.0.2",
-    "ngx-color": "^7.2.0",
-    "ngx-cookie-service": "^12.0.0",
-    "ol": "^6.6.0",
-    "ol-popup": "^4.0.0",
-    "proj4": "^2.7.2",
-    "queue": "^6.0.2",
-    "resumablejs": "^1.1.0",
-    "rxjs": "^6.6.7",
-    "share-api-polyfill": "^1.0.18",
-    "xml-js": "^1.6.11"
-  },
   "dependencies": {
     "tslib": "^2.0.0"
   }


### PR DESCRIPTION
## Description

Remove devDependecies lists in our monorepo subprojects, because with npm 7 they are installed anyway
Upgrade to OL 6.7

## Related issues or pull requests

https://github.com/hslayers/hslayers-ng/pull/2143

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
