### PR TITLE
fix(legend): Show correct legend when switching layer editors

### DIFF
--- a/projects/hslayers/src/components/legend/legend-layer-vector/legend-layer-vector.component.html
+++ b/projects/hslayers/src/components/legend/legend-layer-vector/legend-layer-vector.component.html
@@ -1,1 +1,1 @@
-<div [innerHtml]="svg"></div>
+<div [innerHtml]="hsLegendService.svg"></div>

--- a/projects/hslayers/src/components/legend/legend-layer-vector/legend-layer-vector.component.ts
+++ b/projects/hslayers/src/components/legend/legend-layer-vector/legend-layer-vector.component.ts
@@ -1,11 +1,11 @@
-import {Component, Input} from '@angular/core';
+import {Component} from '@angular/core';
+
+import {HsLegendService} from '../legend.service';
 
 @Component({
   selector: 'hs-legend-vector-layer',
   templateUrl: './legend-layer-vector.component.html',
 })
 export class HsLegendLayerVectorComponent {
-  @Input() svg: string;
-
-  constructor() {}
+  constructor(public hsLegendService: HsLegendService) {}
 }

--- a/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.html
+++ b/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.html
@@ -1,5 +1,5 @@
 <div>
-    <hs-legend-vector-layer *ngIf="layer.type === 'vector' && layer.autoLegend" [svg]="svg">
+    <hs-legend-vector-layer *ngIf="layer.type === 'vector' && layer.autoLegend">
     </hs-legend-vector-layer>
     <div *ngIf="layer.type === 'wms'">
         <img *ngFor="let sublayer of layer.subLayerLegends" [src]="sublayer"

--- a/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.ts
+++ b/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
+import {SafeHtml} from '@angular/platform-browser';
 
 import VectorLayer from 'ol/layer/Vector';
 import {Subject} from 'rxjs';
@@ -15,21 +15,17 @@ import {HsUtilsService} from '../../utils/utils.service';
 })
 export class HsLegendLayerComponent implements OnInit, OnDestroy {
   @Input() layer: any;
-  svg: SafeHtml;
   private ngUnsubscribe = new Subject();
   constructor(
     public hsUtilsService: HsUtilsService,
     public hsLegendService: HsLegendService,
-    public hsStylerService: HsStylerService,
-    private sanitizer: DomSanitizer
+    public hsStylerService: HsStylerService
   ) {
     this.hsStylerService.onSet
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(async (layer) => {
         if (this.layer.lyr == layer) {
-          this.svg = this.sanitizer.bypassSecurityTrustHtml(
-            await this.hsLegendService.getVectorLayerLegendSvg(this.layer.lyr)
-          );
+          this.hsLegendService.setSvg(layer);
         }
       });
   }
@@ -41,9 +37,7 @@ export class HsLegendLayerComponent implements OnInit, OnDestroy {
 
   async initLayer(olLayer: any): Promise<void> {
     if (this.hsUtilsService.instOf(olLayer, VectorLayer)) {
-      this.svg = this.sanitizer.bypassSecurityTrustHtml(
-        await this.hsLegendService.getVectorLayerLegendSvg(olLayer)
-      );
+      this.hsLegendService.setSvg(olLayer);
     }
   }
 

--- a/projects/hslayers/src/components/legend/legend.service.ts
+++ b/projects/hslayers/src/components/legend/legend.service.ts
@@ -37,14 +37,26 @@ declare type StyleLike = Style | Array<Style> | StyleFunction;
   providedIn: 'root',
 })
 export class HsLegendService {
+  svg: SafeHtml;
+
   constructor(
     public hsUtilsService: HsUtilsService,
     private hsLayerUtilsService: HsLayerUtilsService,
-    public hsLayerSelectorService: HsLayerSelectorService
+    public hsLayerSelectorService: HsLayerSelectorService,
+    private sanitizer: DomSanitizer
   ) {
     this.hsLayerSelectorService.layerSelected.subscribe((layer) => {
       this.getLayerLegendDescriptor(layer.layer);
+      if (this.hsLayerUtilsService.isLayerVectorLayer(layer.layer)) {
+        this.setSvg(layer.layer as VectorLayer<VectorSource<Geometry>>);
+      }
     });
+  }
+
+  async setSvg(layer: VectorLayer<VectorSource<Geometry>>): Promise<void> {
+    this.svg = this.sanitizer.bypassSecurityTrustHtml(
+      await this.getVectorLayerLegendSvg(layer)
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

When toggling layer editors without closing previous, the auto legend does not dispaly correct legend.
This PR fixes it.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
