### PR TITLE
fix(legend): Show correct legend for layer-editor window

### DIFF
--- a/projects/hslayers/src/components/layermanager/layer-editor.service.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor.service.ts
@@ -7,7 +7,6 @@ import {WMSCapabilities} from 'ol/format';
 import {transformExtent} from 'ol/proj';
 
 import {HsEventBusService} from '../core/event-bus.service';
-import {HsLayerDescriptor} from './layer-descriptor.interface';
 import {HsLayerEditorVectorLayerService} from './layer-editor-vector-layer.service';
 import {HsLayerManagerMetadataService} from './layermanager-metadata.service';
 import {HsLayerSelectorService} from './layer-selector.service';
@@ -44,10 +43,9 @@ export class HsLayerEditorService {
     public HsLayerSelectorService: HsLayerSelectorService,
     public HsLayerManagerMetadataService: HsLayerManagerMetadataService
   ) {
-    this.HsLayerSelectorService.layerSelected.subscribe((layer) => {
-      this.legendDescriptor = this.HsLegendService.getLayerLegendDescriptor(
-        layer.layer
-      );
+    this.HsLayerSelectorService.layerSelected.subscribe(async (layer) => {
+      this.legendDescriptor =
+        await this.HsLegendService.getLayerLegendDescriptor(layer.layer);
     });
   }
 

--- a/projects/hslayers/src/components/legend/legend-descriptor.interface.ts
+++ b/projects/hslayers/src/components/legend/legend-descriptor.interface.ts
@@ -1,4 +1,5 @@
 import {Layer} from 'ol/layer';
+import {SafeHtml} from '@angular/platform-browser';
 import {Source} from 'ol/source';
 
 export interface HsLegendDescriptor {
@@ -8,4 +9,5 @@ export interface HsLegendDescriptor {
   type: string;
   subLayerLegends?: Array<string>;
   visible: boolean;
+  svg?: SafeHtml;
 }

--- a/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.html
+++ b/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.html
@@ -1,5 +1,5 @@
 <div>
-    <hs-legend-vector-layer *ngIf="layer.type === 'vector' && layer.autoLegend" [svg]="svg">
+    <hs-legend-vector-layer *ngIf="layer.type === 'vector' && layer.autoLegend" [svg]="layer.svg">
     </hs-legend-vector-layer>
     <div *ngIf="layer.type === 'wms'">
         <img *ngFor="let sublayer of layer.subLayerLegends" [src]="sublayer"

--- a/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.ts
+++ b/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.ts
@@ -1,7 +1,6 @@
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
+import {SafeHtml} from '@angular/platform-browser';
 
-import VectorLayer from 'ol/layer/Vector';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -13,38 +12,22 @@ import {HsUtilsService} from '../../utils/utils.service';
   selector: 'hs-legend-layer-directive',
   templateUrl: './legend-layer.component.html',
 })
-export class HsLegendLayerComponent implements OnInit, OnDestroy {
+export class HsLegendLayerComponent implements OnDestroy {
   @Input() layer: any;
   svg: SafeHtml;
   private ngUnsubscribe = new Subject();
   constructor(
     public hsUtilsService: HsUtilsService,
     public hsLegendService: HsLegendService,
-    public hsStylerService: HsStylerService,
-    private sanitizer: DomSanitizer
+    public hsStylerService: HsStylerService
   ) {
     this.hsStylerService.onSet
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(async (layer) => {
         if (this.layer.lyr == layer) {
-          this.svg = this.sanitizer.bypassSecurityTrustHtml(
-            await this.hsLegendService.getVectorLayerLegendSvg(this.layer.lyr)
-          );
+          this.layer.svg = await this.hsLegendService.setSvg(layer);
         }
       });
-  }
-
-  ngOnInit(): void {
-    const olLayer = this.layer.lyr;
-    this.initLayer(olLayer);
-  }
-
-  async initLayer(olLayer: any): Promise<void> {
-    if (this.hsUtilsService.instOf(olLayer, VectorLayer)) {
-      this.svg = this.sanitizer.bypassSecurityTrustHtml(
-        await this.hsLegendService.getVectorLayerLegendSvg(olLayer)
-      );
-    }
   }
 
   ngOnDestroy(): void {

--- a/projects/hslayers/src/components/legend/legend-layer/legend-layer.spec.ts
+++ b/projects/hslayers/src/components/legend/legend-layer/legend-layer.spec.ts
@@ -82,7 +82,7 @@ describe('HsLegendLayerComponent', () => {
   it('should create', () => {
     expect(parentComponent).toBeTruthy();
   });
-  it('should generate vector layer', () => {
+  it('should generate vector layer', async () => {
     const count = 20;
     const features = new Array(count);
     const e = 4500000;
@@ -112,7 +112,7 @@ describe('HsLegendLayerComponent', () => {
       },
       source: new VectorSource({features}),
     });
-    parentComponent.addLayerToLegends(layer);
+    await parentComponent.addLayerToLegends(layer);
     expect(parentComponent.layerDescriptors.length).toBeDefined();
     expect(parentComponent.layerDescriptors[0].title).toBe('Bookmarks');
   });
@@ -146,7 +146,7 @@ describe('HsLegendLayerComponent', () => {
       },
       source: new VectorSource({features}),
     });
-    parentComponent.addLayerToLegends(layer);
+    await parentComponent.addLayerToLegends(layer);
     const expectedLayer = parentComponent.layerDescriptors[0];
     component.layer = expectedLayer;
     fixture.detectChanges();
@@ -183,7 +183,7 @@ describe('HsLegendLayerComponent', () => {
       },
       source: new VectorSource({features}),
     });
-    parentComponent.addLayerToLegends(layer);
+    await parentComponent.addLayerToLegends(layer);
     const expectedLayer = parentComponent.layerDescriptors[0];
     component.layer = expectedLayer;
     fixture.detectChanges();
@@ -203,7 +203,6 @@ describe('HsLegendLayerComponent', () => {
     });
     component.layer.lyr.setStyle(customStyle);
     fixture.detectChanges();
-    await component.initLayer(component.layer);
     const svg = await service.getVectorLayerLegendSvg(layer);
     expect(getCluster(component.layer.lyr)).toBeFalse();
     expect(svg).toContain(`<svg class="geostyler-legend-renderer" `);

--- a/projects/hslayers/src/components/legend/legend.spec.ts
+++ b/projects/hslayers/src/components/legend/legend.spec.ts
@@ -3,7 +3,12 @@ import {
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {Tile as TileLayer} from 'ol/layer';
 import {TileWMS} from 'ol/source';
@@ -74,7 +79,7 @@ describe('HsLegendComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should generate descriptor', () => {
+  it('should generate descriptor', async () => {
     const params = {
       LAYERS: '2017_yield_corn',
       FORMAT: 'image/png',
@@ -91,7 +96,7 @@ describe('HsLegendComponent', () => {
     layerUtilsMock.getLayerParams.and.returnValue(params);
     layerUtilsMock.getURL.and.returnValue('http://localhost/ows?');
 
-    component.addLayerToLegends(layer);
+    await component.addLayerToLegends(layer);
 
     expect(component.layerDescriptors.length).toBeDefined();
 
@@ -102,7 +107,7 @@ describe('HsLegendComponent', () => {
     ]);
   });
 
-  it('should follow wms source LAYERS change', () => {
+  it('should follow wms source LAYERS change', fakeAsync(async () => {
     const layer = new TileLayer({
       properties: {title: 'Crop stats', showInLayerManager: false},
       source: new TileWMS({
@@ -114,13 +119,14 @@ describe('HsLegendComponent', () => {
       }),
       visible: true,
     });
-    component.addLayerToLegends(layer);
+    await component.addLayerToLegends(layer);
     const layerParams = layer.getSource().getParams();
     layerParams.LAYERS = `2017_damage_tomato`;
     layerUtilsMock.getLayerParams.and.returnValue(layerParams);
     layer.getSource().updateParams(layerParams);
+    tick();
     expect(component.layerDescriptors[0].subLayerLegends).toEqual([
       '/proxy/http://localhost/ows?&version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=2017_damage_tomato&format=image%2Fpng',
     ]);
-  });
+  }));
 });


### PR DESCRIPTION
## Description

When toggling layer editors without closing previous, the auto legend does not dispaly correct legend.
This PR fixes it.

## Related issues or pull requests

closes #2232 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
