### PR TITLE
fix: Check if hslayers component, has initialized already

### DIFF
--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -85,7 +85,8 @@ export class HsLayoutService {
    */
   initializedOnce = false;
   /**
-   * Whether the app has been initialized already once.
+   * Whether the app has been initialized already once. 
+   * Need this to not add panels wtice when NgRouter is used
    * @public
    * @default false
    */

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -83,6 +83,12 @@ export class HsLayoutService {
    * @public
    * @default false
    */
+  initializedOnce = false;
+  /**
+   * Whether the app has been initialized already once.
+   * @public
+   * @default false
+   */
   minisidebar = false;
   contentWrapper: any;
   layoutElement: any;

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -57,32 +57,35 @@ export class HslayersComponent implements OnInit {
     if (this.config) {
       this.hsConfig.update(this.config);
     }
-    this.createPanel('tripPlanner', HsTripPlannerComponent);
-    this.createPanel('addData', HsAddDataComponent);
-    this.createPanel('draw', HsDrawComponent);
-    this.createPanel('search', HsSearchComponent);
-    this.createPanel('feature_table', HsFeatureTableComponent);
-    this.createPanel('saveMap', HsSaveMapComponent);
-    this.createPanel('language', HsLanguageComponent);
-    this.createPanel('info', HsQueryComponent);
-    this.createPanel('permalink', HsShareComponent);
-    this.createPanel('print', HsPrintComponent);
-    this.createPanel('measure', HsMeasureComponent);
-    this.createPanel('composition_browser', HsCompositionsComponent);
-    this.createPanel('legend', HsLegendComponent);
-    this.createPanel(
-      'layermanager',
-      HsLayerManagerComponent,
-      this.HsLayerManagerService.data
-    );
-    this.hsLayoutService.createPanel(HsStylerComponent, {});
-    this.hsToolbarPanelContainerService.create(HsSearchToolbarComponent, {});
-    this.hsToolbarPanelContainerService.create(HsDrawToolbarComponent, {});
-    this.hsToolbarPanelContainerService.create(HsMeasureToolbarComponent, {});
-    this.hsToolbarPanelContainerService.create(HsThemeToolbarComponent, {});
-    this.hsLayoutService.createOverlay(HsGeolocationComponent, {});
-    this.hsLayoutService.createOverlay(HsInfoComponent, {});
-    this.hsLayoutService.createOverlay(HsLayerManagerGalleryComponent, {});
-    this.hsLayoutService.createOverlay(HsToolbarComponent, {});
+    if (!this.hsLayoutService.initializedOnce) {
+      this.createPanel('tripPlanner', HsTripPlannerComponent);
+      this.createPanel('addData', HsAddDataComponent);
+      this.createPanel('draw', HsDrawComponent);
+      this.createPanel('search', HsSearchComponent);
+      this.createPanel('feature_table', HsFeatureTableComponent);
+      this.createPanel('saveMap', HsSaveMapComponent);
+      this.createPanel('language', HsLanguageComponent);
+      this.createPanel('info', HsQueryComponent);
+      this.createPanel('permalink', HsShareComponent);
+      this.createPanel('print', HsPrintComponent);
+      this.createPanel('measure', HsMeasureComponent);
+      this.createPanel('composition_browser', HsCompositionsComponent);
+      this.createPanel('legend', HsLegendComponent);
+      this.createPanel(
+        'layermanager',
+        HsLayerManagerComponent,
+        this.HsLayerManagerService.data
+      );
+      this.hsLayoutService.createPanel(HsStylerComponent, {});
+      this.hsToolbarPanelContainerService.create(HsSearchToolbarComponent, {});
+      this.hsToolbarPanelContainerService.create(HsDrawToolbarComponent, {});
+      this.hsToolbarPanelContainerService.create(HsMeasureToolbarComponent, {});
+      this.hsToolbarPanelContainerService.create(HsThemeToolbarComponent, {});
+      this.hsLayoutService.createOverlay(HsGeolocationComponent, {});
+      this.hsLayoutService.createOverlay(HsInfoComponent, {});
+      this.hsLayoutService.createOverlay(HsLayerManagerGalleryComponent, {});
+      this.hsLayoutService.createOverlay(HsToolbarComponent, {});
+      this.hsLayoutService.initializedOnce = true;
+    }
   }
 }


### PR DESCRIPTION
## Description

Check if hslayers component has already been initialized once, if this is not checked, for map-Whiteboard application, each time the user loads new map composition, all of the panels gets multiplied.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
