### PR TITLE
Issue 2243/cluster style override

### DIFF
--- a/projects/hslayers/src/components/layermanager/layer-editor-vector-layer.service.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor-vector-layer.service.ts
@@ -13,6 +13,7 @@ import {HsUtilsService} from '../utils/utils.service';
   providedIn: 'root',
 })
 export class HsLayerEditorVectorLayerService {
+  layersClusteredFromStart = [];
   constructor(
     public HsMapService: HsMapService,
     public HsUtilsService: HsUtilsService,
@@ -30,14 +31,17 @@ export class HsLayerEditorVectorLayerService {
   async cluster(
     newValue: boolean,
     layer: Layer<Source>,
-    distance: number
+    distance: number,
+    generateStyle: boolean
   ): Promise<void> {
     if (newValue == true) {
       if (!this.HsUtilsService.instOf(layer.getSource(), Cluster)) {
         layer.setSource(this.createClusteredSource(layer, distance));
-        await this.HsStylerService.styleClusteredLayer(
-          layer as VectorLayer<Cluster>
-        );
+        if (generateStyle) {
+          await this.HsStylerService.styleClusteredLayer(
+            layer as VectorLayer<Cluster>
+          );
+        }
         this.updateFeatureTableLayers(layer);
       }
     } else if (this.HsUtilsService.instOf(layer.getSource(), Cluster)) {

--- a/projects/hslayers/src/components/layermanager/layer-editor.service.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor.service.ts
@@ -111,7 +111,14 @@ export class HsLayerEditorService {
     }
     if (newValue != undefined) {
       setCluster(layer, newValue);
-      this.HsLayerEditorVectorLayerService.cluster(newValue, layer, distance);
+      this.HsLayerEditorVectorLayerService.cluster(
+        newValue,
+        layer,
+        distance,
+        !this.HsLayerEditorVectorLayerService.layersClusteredFromStart.includes(
+          layer
+        )
+      );
       this.HsEventBusService.compositionEdits.next();
     } else {
       return getCluster(layer);

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -188,10 +188,12 @@ export class HsLayerManagerService {
       this.HsLayerUtilsService.isLayerVectorLayer(layer) &&
       getCluster(layer)
     ) {
+      this.HsLayerEditorVectorLayerService.layersClusteredFromStart.push(layer);
       await this.HsLayerEditorVectorLayerService.cluster(
         true,
         layer,
-        this.HsConfig.clusteringDistance || 40
+        this.HsConfig.clusteringDistance || 40,
+        false
       );
     }
     /**
@@ -540,18 +542,29 @@ export class HsLayerManagerService {
         this.data.layers.splice(i, 1);
       }
     }
-
     for (let i = 0; i < this.data.baselayers.length; i++) {
       if (this.data.baselayers[i].layer == e.element) {
         this.data.baselayers.splice(i, 1);
       }
     }
+    this.removeFromArray(
+      this.HsLayerEditorVectorLayerService.layersClusteredFromStart,
+      e.element
+    );
     this.HsEventBusService.layerManagerUpdates.next(e.element);
     this.HsEventBusService.layerRemovals.next(e.element);
     this.HsEventBusService.compositionEdits.next();
     const layers = this.HsMapService.map.getLayers().getArray();
     if (this.zIndexValue > layers.length) {
       this.zIndexValue--;
+    }
+  }
+
+  removeFromArray(arrayToSearch: Layer<Source>[], layer: Layer<Source>) {
+    for (let i = 0; i < arrayToSearch.length; i++) {
+      if (arrayToSearch[i] == layer) {
+        arrayToSearch.splice(i, 1);
+      }
     }
   }
 

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -3,6 +3,7 @@ import {Component} from '@angular/core';
 import Feature from 'ol/Feature';
 import GeoJSON from 'ol/format/GeoJSON';
 import Point from 'ol/geom/Point';
+import {Circle, Fill, Stroke, Style} from 'ol/style';
 import {OSM, Vector as VectorSource, XYZ} from 'ol/source';
 import {Tile} from 'ol/layer';
 import {Vector as VectorLayer} from 'ol/layer';
@@ -258,6 +259,32 @@ export class HslayersAppComponent {
             `,
             path: 'User generated',
           },
+          source: new VectorSource({features}),
+        }),
+        new VectorLayer({
+          properties: {
+            title: 'Clusters without SLD',
+            synchronize: false,
+            cluster: true,
+            inlineLegend: true,
+            popUp: {
+              attributes: ['name', 'population'],
+            },
+            editor: {editable: false},
+            path: 'User generated',
+          },
+          style: new Style({
+            image: new Circle({
+              fill: new Fill({
+                color: 'rgba(0, 157, 87, 0.5)',
+              }),
+              stroke: new Stroke({
+                color: 'rgb(0, 157, 87)',
+                width: 2,
+              }),
+              radius: 5,
+            }),
+          }),
           source: new VectorSource({features}),
         }),
         new VectorLayer({


### PR DESCRIPTION
## Description

If the layer is clustered at the start of loading application, dont try to invent a style for clustered features, but use the provided one.

## Related issues or pull requests

#2243 
## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
