### PR TITLE
fix: Successfully saved map composition doesnt return 'saved' property

### DIFF
--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -132,7 +132,8 @@ export class HsLaymanService implements HsSaverService {
           formdata,
           options
         ).toPromise();
-        if (response.saved) {
+        //Unsuccessfull request response contains code,detail and message properties
+        if (!response.code) {
           success = true;
         } else {
           if (amendmentsApplied) {


### PR DESCRIPTION
## Description

Conditin response.saved was never met which resulted in two attempts to save the same composition thus error.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
