### PR TITLE
fix: Parse SLD only when not qgis style provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ stats.json
 bundle
 *.d.ts
 hslayers-server.db
+projects/hslayers-server/data/hsl-share.db

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -260,6 +260,9 @@ export class HsLaymanBrowserService {
           responseType: 'text',
         })
         .toPromise();
+      if (!sld?.includes('StyledLayerDescriptor')) {
+        sld = undefined;
+      }
     }
     if (lyr.wms.url) {
       return {

--- a/projects/hslayers/src/components/add-data/url/wfs/add-data-url-wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/add-data-url-wfs.service.ts
@@ -286,6 +286,7 @@ export class HsAddDataWfsService implements HsAddDataUrlTypeServiceModel {
    * @param checkedOnly - Add all available layers or only checked ones. Checked=false=all
    */
   addLayers(checkedOnly: boolean, sld: string): void {
+    debugger;
     this.data.add_all = checkedOnly;
     for (const layer of this.data.services) {
       this.addLayersRecursively(layer, {sld});

--- a/projects/hslayers/src/components/add-data/url/wfs/add-data-url-wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/add-data-url-wfs.service.ts
@@ -286,7 +286,6 @@ export class HsAddDataWfsService implements HsAddDataUrlTypeServiceModel {
    * @param checkedOnly - Add all available layers or only checked ones. Checked=false=all
    */
   addLayers(checkedOnly: boolean, sld: string): void {
-    debugger;
     this.data.add_all = checkedOnly;
     for (const layer of this.data.services) {
       this.addLayersRecursively(layer, {sld});

--- a/projects/hslayers/src/components/layermanager/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor.component.ts
@@ -45,6 +45,7 @@ export class HsLayerEditorComponent {
   layer_renamer_visible = false;
   getAttribution = getAttribution;
   getBase = getBase;
+  tmpTitle: string = undefined;
   constructor(
     public HsLayerUtilsService: HsLayerUtilsService,
     public HsDimensionTimeService: HsDimensionTimeService,
@@ -326,18 +327,7 @@ export class HsLayerEditorComponent {
    * @param newTitle - New title to set
    */
   set title(newTitle: string) {
-    const newLayerTitle = newTitle.trim();
-    const layer = this.olLayer();
-    if (layer == undefined) {
-      return;
-    }
-    this.HsLayerEditorService.layerTitleChange.next({
-      newTitle: newLayerTitle,
-      oldTitle: getTitle(layer),
-      layer,
-    });
-    setTitle(layer, newLayerTitle);
-    this.HsEventBusService.layerManagerUpdates.next();
+    this.tmpTitle = newTitle.trim();
   }
 
   get title(): string {
@@ -345,7 +335,29 @@ export class HsLayerEditorComponent {
     if (layer == undefined) {
       return;
     }
-    return getTitle(layer);
+    if (this.tmpTitle == undefined) {
+      this.tmpTitle = getTitle(layer);
+    }
+    return this.tmpTitle;
+  }
+
+  saveTitle(): void {
+    const layer = this.olLayer();
+    if (layer == undefined) {
+      return;
+    }
+    this.HsLayerEditorService.layerTitleChange.next({
+      newTitle: this.tmpTitle,
+      oldTitle: getTitle(layer),
+      layer,
+    });
+    setTitle(layer, this.tmpTitle);
+    this.HsEventBusService.layerManagerUpdates.next();
+    this.toggleLayerRename();
+  }
+
+  titleUnsaved(): boolean {
+    return this.tmpTitle != getTitle(this.olLayer());
   }
 
   set abstract(newAbstract: string) {

--- a/projects/hslayers/src/components/layermanager/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/layer-editor.component.ts
@@ -38,7 +38,16 @@ import {
   templateUrl: './partials/layer-editor.html',
 })
 export class HsLayerEditorComponent {
-  @Input('current-layer') currentLayer: HsLayerDescriptor;
+  _currentLayer: HsLayerDescriptor;
+  @Input('current-layer') set currentLayer(value: HsLayerDescriptor) {
+    this._currentLayer = value;
+    this.tmpTitle = undefined;
+    this.layer_renamer_visible = false;
+  }
+
+  get currentLayer(): HsLayerDescriptor {
+    return this._currentLayer;
+  }
   distance = {
     value: 40,
   };
@@ -177,6 +186,7 @@ export class HsLayerEditorComponent {
    * Toogle layer rename control on panel (through layer rename variable)
    */
   toggleLayerRename(): void {
+    this.tmpTitle = undefined;
     this.layer_renamer_visible = !this.layer_renamer_visible;
   }
 

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -944,21 +944,25 @@ export class HsLayerManagerService {
     }
   }
 
-  setCurrentLayer(layer: HsLayerDescriptor): false {
-    this.currentLayer = layer;
-    this.updateGetParam(layer.title);
-    if (!layer.checkedSubLayers) {
-      layer.checkedSubLayers = {};
-      layer.withChildren = {};
-    }
-    this.HsLayerSelectorService.select(layer);
-    if (this.HsUtilsService.runningInBrowser()) {
-      const layerNode = document.getElementById(layer.idString());
-      if (layerNode && this.layerEditorElement) {
-        this.HsUtilsService.insertAfter(this.layerEditorElement, layerNode);
+  setCurrentLayer(layer: HsLayerDescriptor): boolean {
+    try {
+      this.currentLayer = layer;
+      this.updateGetParam(layer.title);
+      if (!layer.checkedSubLayers) {
+        layer.checkedSubLayers = {};
+        layer.withChildren = {};
       }
+      this.HsLayerSelectorService.select(layer);
+      if (this.HsUtilsService.runningInBrowser()) {
+        const layerNode = document.getElementById(layer.idString());
+        if (layerNode && this.layerEditorElement) {
+          this.HsUtilsService.insertAfter(this.layerEditorElement, layerNode);
+        }
+      }
+      return false;
+    } catch (ex) {
+      console.error(ex);
     }
-    return false;
   }
 
   private updateGetParam(title: string) {

--- a/projects/hslayers/src/components/layermanager/partials/layer-editor.html
+++ b/projects/hslayers/src/components/layermanager/partials/layer-editor.html
@@ -100,7 +100,14 @@
     <div class="card-footer" *ngIf="currentLayer?.settings">
         <div class="form-group" [hidden]="!layer_renamer_visible">
             <label>{{'COMMON.title' | translate}}</label>
-            <input type="text" class="form-control" [(ngModel)]="title" name="title">
+            <div class="input-group">
+                <input type="text" class="form-control" [(ngModel)]="title" name="title">
+                <div class="input-group-append" [hidden]="!titleUnsaved()" (click)="saveTitle()">
+                    <button class="btn btn-outline-secondary" type="button"><i class="icon-save-floppy"></i></button>
+                </div>
+            </div>
+
+            
             <div class="form">
                 <br>
                 <label>{{'COMMON.scale' | translate}}</label>

--- a/projects/hslayers/src/components/save-map/layer-synchronizer.service.ts
+++ b/projects/hslayers/src/components/save-map/layer-synchronizer.service.ts
@@ -109,7 +109,8 @@ export class HsLayerSynchronizerService {
       if (e.key == 'sld' || e.key == 'title') {
         this.HsLaymanService.upsertLayer(
           this.findLaymanForWfsLayer(layer),
-          layer
+          layer,
+          false
         );
       }
     });

--- a/projects/hslayers/src/components/save-map/layer-synchronizer.service.ts
+++ b/projects/hslayers/src/components/save-map/layer-synchronizer.service.ts
@@ -105,6 +105,14 @@ export class HsLayerSynchronizerService {
   ): Promise<boolean> {
     const layerSource = layer.getSource();
     await this.pull(layer, layerSource);
+    layer.on('propertychange', (e) => {
+      if (e.key == 'sld' || e.key == 'title') {
+        this.HsLaymanService.upsertLayer(
+          this.findLaymanForWfsLayer(layer),
+          layer
+        );
+      }
+    });
     layerSource.forEachFeature((f) => this.observeFeature(f));
     layerSource.on('addfeature', (e) => {
       this.sync(

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -570,7 +570,10 @@ export class HsLaymanService implements HsSaverService {
       if (response?.code == 15 || response?.code == 15 || wfsFailed(response)) {
         return null;
       }
-      if (wfsPendingOrStarting(response)) {
+      if (
+        wfsPendingOrStarting(response) ||
+        (response.wfs.status == 'SUCCESS' && response.wfs.url == undefined)
+      ) {
         if (!this.pendingLayers.includes(layerName)) {
           this.pendingLayers.push(layerName);
           this.laymanLayerPending.next(this.pendingLayers);

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -30,13 +30,12 @@ import {
 import {
   getAccessRights,
   getLaymanLayerDescriptor,
+  getSld,
   getTitle,
   getWorkspace,
   setHsLaymanSynchronizing,
   setLaymanLayerDescriptor,
 } from '../../common/layer-extensions';
-import {relative} from '@angular/compiler-cli/src/ngtsc/file_system';
-import { getSld } from 'hslayers-ng';
 
 export type WfsSyncParams = {
   /** Endpoint description */

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -333,8 +333,9 @@ export class HsStylerService {
           symbolizers: [
             {
               kind: 'Mark',
-              color: 'rgba(255, 255, 255, 0.41)',
-              strokeColor: 'rgba(0, 153, 255, 1)',
+              color: '#FFFFFF',
+              strokeOpacity: 0.41,
+              strokeColor: '#0099ff',
               strokeWidth: 2,
               wellKnownName: 'circle',
               radius: 10,

--- a/projects/hslayers/src/components/styles/styles.ts
+++ b/projects/hslayers/src/components/styles/styles.ts
@@ -15,10 +15,11 @@ export const defaultStyle = `<?xml version="1.0" encoding="UTF-8" standalone="ye
               <Mark>
                 <WellKnownName>circle</WellKnownName>
                 <Fill>
-                  <CssParameter name="fill">rgba(255, 255, 255, 0.41)</CssParameter>
+                  <CssParameter name="fill">#FFFFFF</CssParameter>
+                  <CssParameter name="fill-opacity">0.41</CssParameter>
                 </Fill>
                 <Stroke>
-                  <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
+                  <CssParameter name="stroke">#0099ff</CssParameter>
                   <CssParameter name="stroke-width">1.25</CssParameter>
                 </Stroke>
               </Mark>
@@ -30,14 +31,14 @@ export const defaultStyle = `<?xml version="1.0" encoding="UTF-8" standalone="ye
               <CssParameter name="fill-opacity">0.45</CssParameter>
             </Fill>
             <Stroke>
-              <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
+              <CssParameter name="stroke">#0099ff</CssParameter>
               <CssParameter name="stroke-width">1.25</CssParameter>
               <CssParameter name="stroke-opacity">0.3</CssParameter>
             </Stroke>
           </PolygonSymbolizer>
           <LineSymbolizer>
             <Stroke>
-              <CssParameter name="stroke">rgba(0, 153, 255, 1)</CssParameter>
+              <CssParameter name="stroke">#0099ff</CssParameter>
               <CssParameter name="stroke-width">1.25</CssParameter>
             </Stroke>
           </LineSymbolizer>


### PR DESCRIPTION
## Description

Check if style file returnerd by Layman contains StyledLayerDescriptor before trying to parse the SLD. The style might have been encoded in QML
## Related issues or pull requests

#2256 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
