### PR TITLE
fix: Clone compoData before unwrapping layer object when saving compo…

### DIFF
--- a/projects/hslayers/src/components/save-map/save-map-advanced-form.component.ts
+++ b/projects/hslayers/src/components/save-map/save-map-advanced-form.component.ts
@@ -72,7 +72,7 @@ export class HsSaveMapAdvancedFormComponent implements OnDestroy {
 
   saveCompoJson(): void {
     const compositionJSON =
-      this.HsSaveMapManagerService.generateCompositionJson(true);
+      this.HsSaveMapManagerService.generateCompositionJson();
     const file = new Blob([JSON.stringify(compositionJSON)], {
       type: 'application/json',
     });

--- a/projects/hslayers/src/components/save-map/save-map-manager.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map-manager.service.ts
@@ -174,19 +174,21 @@ export class HsSaveMapManagerService {
 
   save(saveAsNew, endpoint) {
     return new Promise((resolve, reject) => {
+      const tempCompoData: any = {};
+      Object.assign(tempCompoData, this.compoData);
       // Check whether layers were already formatted
-      if (this.compoData.layers[0].layer) {
-        this.compoData.layers = this.compoData.layers
+      if (tempCompoData.layers[0].layer) {
+        tempCompoData.layers = tempCompoData.layers
           .filter((l) => l.checked)
           .map((l) => l.layer);
       }
-      const compositionJson = this.generateCompositionJson();
+      const compositionJson = this.generateCompositionJson(tempCompoData);
       let saver: HsSaverService = this.HsStatusManagerService;
       if (endpoint.type == 'layman') {
         saver = this.HsLaymanService;
       }
       saver
-        .save(compositionJson, endpoint, this.compoData, saveAsNew)
+        .save(compositionJson, endpoint, tempCompoData, saveAsNew)
         .then((response) => {
           const compInfo: any = {};
           const j = response;
@@ -232,24 +234,24 @@ export class HsSaveMapManagerService {
   }
 
   /**
-   * @param download Used when generating json for download
+   * @param download Used when generating json for catalogue save
    * @returns composition JSON
    */
-  generateCompositionJson(download?): any {
+  generateCompositionJson(compoData?): any {
     /*TODO: REFACTOR
       Workaround for composition JSON generated for download. 
       Should be handled differently and generated only once. Task for upcoming component rework
     */
-    const compoData: any = {...this.compoData};
-    if (download) {
-      compoData.layers = compoData.layers
+    const tempCompoData: any = {...(compoData ?? this.compoData)};
+    if (!compoData) {
+      tempCompoData.layers = tempCompoData.layers
         .filter((l) => l.checked)
         .map((l) => l.layer);
     }
 
     return this.HsSaveMapService.map2json(
       this.HsMapService.map,
-      compoData,
+      tempCompoData,
       this.userData,
       this.statusData
     );


### PR DESCRIPTION
## Description

Clone composition data before unwrapping layer property to prevent manipulation of original object.


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
