### PR TITLE
Issue 2224/translations from assets

### DIFF
--- a/projects/hslayers/src/components/core/core.module.ts
+++ b/projects/hslayers/src/components/core/core.module.ts
@@ -10,6 +10,7 @@ import {
 import {map} from 'rxjs/operators';
 
 import * as merge from 'deepmerge';
+import en from '../../assets/locales/en.json';
 
 import {HsCommonEndpointsModule} from '../../common/endpoints/endpoints.module';
 import {HsConfig} from '../../config.service';
@@ -28,13 +29,12 @@ export class WebpackTranslateLoader implements TranslateLoader {
     const hsConfig = this.HsConfig;
     //Idea taken from https://github.com/denniske/ngx-translate-multi-http-loader/blob/master/projects/ngx-translate/multi-http-loader/src/lib/multi-http-loader.ts
     const requests: Observable<any>[] = [
+      //these translations are loaded as promises in order, where next one overwrites previous loaders values
+      from(new Promise((resolve) => resolve(en))),
       from(
-        new Promise(async (resolve) => {
-          const res = await this.HttpClient.get(
-            `${this.HsConfig.assetsPath}/locales/${lang}.json`
-            ).toPromise();
-          resolve(res);
-        })
+        this.HttpClient.get(
+          `${this.HsConfig.assetsPath}/locales/${lang}.json`
+          ).toPromise()
       ),
       from(
         new Promise((resolve) => {


### PR DESCRIPTION
## Description

Load translations from assets/locales directory. HsConfig.assetPath needs to be set. This way we can provide more than just the 4 included languages, but no locale gets bundled with hslayers by default - thus bundle size is reduced.

## Related issues or pull requests

#2224 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
