### PR TITLE
fix: Hover popup without enabled info panel

### DIFF
--- a/projects/decoupling-test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/decoupling-test-app/src/hslayers-app/hslayers-app.component.ts
@@ -10,6 +10,7 @@ import {Vector as VectorLayer} from 'ol/layer';
 import {HsConfig} from '../../../hslayers/src/config.service';
 import {HsEventBusService} from 'hslayers-ng/src/components/core/event-bus.service';
 import {HsLayoutService} from 'hslayers-ng/src/components/layout/public-api';
+import {HsQueryFeaturePopupComponent} from 'hslayers-ng/src/components/query/feature-popup.component';
 //import {HsQueryComponent} from '../../../hslayers/src/components/query/query.component';
 //import {HsToolbarPanelContainerService} from 'hslayers-ng/src/components/toolbar/toolbar-panel-container.service';
 
@@ -340,7 +341,7 @@ export class HslayersAppComponent {
     //hsToolbarPanelContainerService.create(HsSearchToolbarComponent, {});
     //hsToolbarPanelContainerService.create(HsDrawToolbarComponent, {});
     //hsToolbarPanelContainerService.create(HsMeasureToolbarComponent, {});
-    //hsLayoutService.createOverlay(HsInfoComponent, {});
+    hsLayoutService.createOverlay(HsQueryFeaturePopupComponent, {});
     //hsLayoutService.createOverlay(HsGeolocationComponent, {});
   }
   title = 'hslayers-workspace';

--- a/projects/decoupling-test-app/src/hslayers-app/hslayers-app.module.ts
+++ b/projects/decoupling-test-app/src/hslayers-app/hslayers-app.module.ts
@@ -10,7 +10,7 @@ import {HsCoreModule} from '../../../hslayers/src/components/core/core.module';
 import {HsLayoutModule} from '../../../hslayers/src/components/layout/layout.module';
 //import {HsMeasureModule} from 'hslayers-ng/src/components/measure/public-api';
 //import {HsDrawModule} from 'hslayers-ng/src/components/draw/public-api';
-//import {HsQueryModule} from 'hslayers-ng/src/components/query/query.module';
+import {HsQueryModule} from 'hslayers-ng/src/components/query/query.module';
 import {HslayersAppComponent} from './hslayers-app.component';
 import {TranslateModule} from '@ngx-translate/core';
 
@@ -26,7 +26,7 @@ import {TranslateModule} from '@ngx-translate/core';
     //HsSearchModule,
     //HsInfoModule,
     //HsGeolocationModule,
-    //HsQueryModule,
+    HsQueryModule,
   ],
   providers: [],
   bootstrap: [HslayersAppComponent],

--- a/projects/hslayers/src/components/query/query.component.ts
+++ b/projects/hslayers/src/components/query/query.component.ts
@@ -15,7 +15,6 @@ import {HsLayoutService} from '../layout/layout.service';
 import {HsMapService} from '../map/map.service';
 import {HsPanelBaseComponent} from '../layout/panels/panel-base.component';
 import {HsQueryBaseService} from './query-base.service';
-import {HsQueryFeaturePopupComponent} from './feature-popup.component';
 import {HsQueryVectorService} from './query-vector.service';
 import {HsQueryWmsService} from './query-wms.service';
 import {HsSidebarService} from '../sidebar/sidebar.service';
@@ -60,8 +59,6 @@ export class HsQueryComponent
     this.HsMapService.loaded().then((map) => {
       map.addOverlay(this.popup);
     });
-
-    this.HsDialogContainerService.create(HsQueryFeaturePopupComponent, {});
 
     //add current panel queryable - activate/deactivate
     this.HsEventBusService.mainPanelChanges

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -27,6 +27,7 @@ import {HsStylerComponent} from './components/styles/styler.component';
 import {HsToolbarComponent} from './components/toolbar/toolbar.component';
 import {HsToolbarPanelContainerService} from './components/toolbar/toolbar-panel-container.service';
 import {HsTripPlannerComponent} from './components/trip-planner/trip-planner.component';
+import {HsQueryFeaturePopupComponent} from './components/query/feature-popup.component';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'hslayers',
@@ -90,6 +91,7 @@ export class HslayersComponent implements OnInit {
       this.hsLayoutService.createOverlay(HsInfoComponent, {});
       this.hsLayoutService.createOverlay(HsLayerManagerGalleryComponent, {});
       this.hsLayoutService.createOverlay(HsToolbarComponent, {});
+      this.hsLayoutService.createOverlay(HsQueryFeaturePopupComponent, {});
       this.hsLayoutService.initializedOnce = true;
     }
   }


### PR DESCRIPTION
## Description

This fixes a bug where hover popups element was not added to the DOM if query panel was not enabled. Now it will be added by hslayers root component by default and to overlays service instead of dialog service.

## Related issues or pull requests


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
