### PR TITLE
 Use layer max/minResolution and service scaleDenominators properly

### DIFF
--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.html
@@ -90,7 +90,7 @@
   </ng-container>
   <hr />
   <ng-container *ngIf="type === 'wms'; else simpleTable">
-    <table class="table table-sm table-striped table-bordered">
+    <table class="table table-sm table-striped table-bordered hs-url-table">
       <thead class="bg-secondary text-light">
         <th style="width:1.5em">&nbsp;</th>
         <th>{{'COMMON.title' | translate}}</th>
@@ -155,7 +155,8 @@
         [translate]="'ADDDATA.CATALOGUE.showingSubset'"
         [translateParams]="{limitShown: limitShown, total: data.services.length}"></span>
       <div class="btn-group ms-2">
-        <button type="button" class="btn btn-sm btn-light  btn-outline-secondary" (click)="limitShown = limitShown + 100">
+        <button type="button" class="btn btn-sm btn-light  btn-outline-secondary"
+          (click)="limitShown = limitShown + 100">
           {{'ADDDATA.CATALOGUE.showNext100' | translate}}
         </button>
         <button type="button" class="btn btn-sm btn-light  btn-outline-secondary"
@@ -165,7 +166,6 @@
       </div>
     </div>
   </ng-container>
-  <hs-url-add class="w-100" [injectedService]="injectedService"
-    [layers]="data.services">
+  <hs-url-add class="w-100" [injectedService]="injectedService" [layers]="data.services">
   </hs-url-add>
 </div>

--- a/projects/hslayers/src/components/add-data/common/url/nested-layers-table/nested-layers-table.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/nested-layers-table/nested-layers-table.component.html
@@ -1,14 +1,16 @@
-<table class="table table-sm table-striped table-bordered" style="width: 100%">
+<table class="table table-sm table-striped table-bordered hs-url-table" style="width: 100%">
     <tbody *ngFor="let sub_layer of layers; trackBy:( 'Name' | trackByProperty )">
         <tr>
-            <td  style="width: 1em"><input type="checkbox" [(ngModel)]="sub_layer.checked" (change)="checked(sub_layer)"
+            <td style="width: 1em"><input type="checkbox" [(ngModel)]="sub_layer.checked" (change)="checked(sub_layer)"
                     [ngModelOptions]="{standalone: true}" /></td>
             <td hsWmsLayerHighlight class="text-truncate" style="max-width: 12em;" id="hs-add-layer-{{sub_layer.Name}}"
-            [title]="'Title: ' + sub_layer.Title  + '\nName: ' + sub_layer.Name" (click)="hsUrlWmsService.expandTableRow($event)">{{sub_layer.Title}}
+                [title]="'Title: ' + sub_layer.Title  + '\nName: ' + sub_layer.Name"
+                (click)="hsUrlWmsService.expandTableRow($event)">{{sub_layer.Title}}
             </td>
             <!-- <td class="text-truncate" id="hs-add-layer-{{sub_layer.Name}}" style="width: 30%; padding-left: 1em">{{sub_layer.Name}}</td> -->
-            <td hsWmsLayerHighlight class="text-truncate" style="max-width: 10.875em;width: 30%;" [title]="sub_layer.Abstract"
-                (click)="hsUrlWmsService.expandTableRow($event)">{{sub_layer.Abstract}}</td>
+            <td hsWmsLayerHighlight class="text-truncate" style="max-width: 10.875em;width: 30%;"
+                [title]="sub_layer.Abstract" (click)="hsUrlWmsService.expandTableRow($event)">{{sub_layer.Abstract}}
+            </td>
         </tr>
         <tr *ngIf="sub_layer.Style?.length > 1 && sub_layer.checked">
             <td colspan="3">
@@ -30,13 +32,15 @@
                         <ng-container *ngIf="isArray(dimension.values); else unsupported_dim_format">
                             <label class="control-label">{{dimension.name}}:</label>
                             <div>
-                                <select class="form-control form-select" [(ngModel)]="dimension.value" [ngModelOptions]="{standalone: true}">
+                                <select class="form-control form-select" [(ngModel)]="dimension.value"
+                                    [ngModelOptions]="{standalone: true}">
                                     <option [value]="dimension_value" *ngFor="let dimension_value of dimension.values">
                                         {{dimension_value}}</option>
                                 </select>
                             </div>
                         </ng-container>
-                        <ng-template #unsupported_dim_format><span class="text-muted">{{'ADDLAYERS.unknownDimesion'| translate}}: {{dimension.name}}</span></ng-template>
+                        <ng-template #unsupported_dim_format><span class="text-muted">{{'ADDLAYERS.unknownDimesion'|
+                                translate}}: {{dimension.name}}</span></ng-template>
                     </div>
                 </form>
             </td>

--- a/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
+++ b/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
@@ -8,6 +8,7 @@ import {CapabilitiesResponseWrapper} from '../../../../common/get-capabilities/c
 import {HsAddDataCommonService} from '../../common/common.service';
 import {HsAddDataUrlService} from '../add-data-url.service';
 import {HsArcgisGetCapabilitiesService} from '../../../../common/get-capabilities/arcgis-get-capabilities.service';
+import {HsLayerUtilsService} from '../../../utils/layer-utils.service';
 import {HsLayoutService} from '../../../layout/layout.service';
 import {HsMapService} from '../../../map/map.service';
 import {HsUrlTypeServiceModel} from '../models/url-type-service.model';
@@ -28,7 +29,8 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
     public hsMapService: HsMapService,
     public hsUtilsService: HsUtilsService,
     public hsAddDataUrlService: HsAddDataUrlService,
-    public hsAddDataCommonService: HsAddDataCommonService
+    public hsAddDataCommonService: HsAddDataCommonService,
+    public hsLayerUtilsService: HsLayerUtilsService
   ) {
     this.data = {
       map_projection: '',
@@ -242,7 +244,12 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
         dimensions,
       },
       source,
-      maxResolution: layer.minScale > 0 ? layer.minScale : undefined,
+      maxResolution:
+        layer.minScale > 0
+          ? this.hsLayerUtilsService.calculateResolutionFromScale(
+              layer.minScale
+            )
+          : undefined,
     });
     //OlMap.proxifyLayerLoader(new_layer, me.data.use_tiles);
     this.hsMapService.map.addLayer(new_layer);

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -18,6 +18,7 @@ import {HsAddDataUrlService} from '../add-data-url.service';
 import {HsConfig} from '../../../../config.service';
 import {HsDimensionService} from '../../../../common/get-capabilities/dimension.service';
 import {HsEventBusService} from '../../../core/event-bus.service';
+import {HsLayerUtilsService} from '../../../utils/layer-utils.service';
 import {HsLayoutService} from '../../../layout/layout.service';
 import {HsMapService} from '../../../map/map.service';
 import {HsUrlTypeServiceModel} from '../models/url-type-service.model';
@@ -47,7 +48,8 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
     public hsAddDataService: HsAddDataService,
     public hsEventBusService: HsEventBusService,
     public hsAddDataUrlService: HsAddDataUrlService,
-    public hsAddDataCommonService: HsAddDataCommonService
+    public hsAddDataCommonService: HsAddDataCommonService,
+    public HsLayerUtilsService: HsLayerUtilsService
   ) {
     this.data = {
       add_under: null,
@@ -436,8 +438,12 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
       title: options.layerName,
       name: options.layerName,
       source,
-      minResolution: layer.MinScaleDenominator,
-      maxResolution: layer.MaxScaleDenominator,
+      minResolution: this.HsLayerUtilsService.calculateResolutionFromScale(
+        layer.MinScaleDenominator
+      ),
+      maxResolution: this.HsLayerUtilsService.calculateResolutionFromScale(
+        layer.MaxScaleDenominatorview
+      ),
       removable: true,
       abstract: layer.Abstract,
       metadata,

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -165,10 +165,10 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
       this.data.exceptions = caps.Capability.Exception;
       this.data.srss = [];
       this.fillProjections(caps, response);
-      //TODO: WHY?
-      if (this.data.srss.includes('CRS:84')) {
-        this.data.srss.splice(this.data.srss.indexOf('CRS:84'), 1);
-      }
+      // //TODO: WHY?
+      // if (this.data.srss.includes('CRS:84')) {
+      //   this.data.srss.splice(this.data.srss.indexOf('CRS:84'), 1);
+      // }
       if (
         this.hsAddDataCommonService.currentProjectionSupported(this.data.srss)
       ) {

--- a/projects/hslayers/src/components/layermanager/editor/sub-layer-checkboxes.html
+++ b/projects/hslayers/src/components/layermanager/editor/sub-layer-checkboxes.html
@@ -9,10 +9,12 @@
     <div *ngIf="!subLayerIsString(subLayer)" class="w-100">
         <div class="d-flex">
             <div class="p-0 form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" [(ngModel)]="checkedSubLayers[subLayer.Name]" [ngModelOptions]="{standalone: true}"
+                <input class="form-check-input" type="checkbox" [(ngModel)]="checkedSubLayers[subLayer.Name]"
+                    [ngModelOptions]="{standalone: true}"
                     (change)="subLayerSelected(subLayer,checkedSubLayers[subLayer.Name])"
                     [attr.id]="'hs-sublayers-'+subLayer.Name" *ngIf="!subLayer.Layer">
-                <input class="form-check-input" type="checkbox" [(ngModel)]="withChildren[subLayer.Name]" [ngModelOptions]="{standalone: true}"
+                <input class="form-check-input" type="checkbox" [(ngModel)]="withChildren[subLayer.Name]"
+                    [ngModelOptions]="{standalone: true}"
                     (change)="subLayerSelected(subLayer, withChildren[subLayer.Name])"
                     [attr.id]="'hs-sublayers-'+subLayer.Name" *ngIf="subLayer.Layer">
 
@@ -20,7 +22,8 @@
                     <label class="form-check-label m-0"
                         [ngClass]="{'hs-checkmark':withChildren[subLayer.Name],'hs-uncheckmark':!withChildren[subLayer.Name]}"
                         [attr.for]="'hs-sublayers-'+subLayer.Name"></label>
-                    <div (click)="toggleExpanded()" [ngStyle]="{'cursor':'pointer'}" [ngClass]="{'grayed': HsLayerManagerService.currentResolution >= subLayer.maxResolution}">
+                    <div (click)="toggleExpanded()" [ngStyle]="{'cursor':'pointer'}"
+                        [ngClass]="{'grayed': HsLayerManagerService.currentResolution >= subLayer.maxResolution}">
                         {{subLayer.Title || subLayer.Name}}
                         <button type="button" class="btn btn-sm p-0" [ngStyle]="{'font-size':'x-small'}">
                             <i [ngClass]="{'icon-chevron-down': expanded, 'icon-chevron-right': !expanded}"></i>
@@ -34,7 +37,7 @@
                 </div>
             </div>
         </div>
-        <div *ngIf="subLayer.Layer" class="collapse ms-4" [hidden]="!expanded">
+        <div *ngIf="subLayer.Layer" class="ms-4" [hidden]="!expanded">
             <div *ngFor="let subLayer of subLayer.Layer">
                 <div *ngIf="subLayerIsString(subLayer)">
                     <input class="form-check-input" type="checkbox" [(ngModel)]="checkedSubLayers[subLayer]"

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -885,17 +885,7 @@ export class HsLayerManagerService {
    * @param lyr - Selected layer
    */
   isLayerInResolutionInterval(lyr: Layer<Source>): boolean {
-    let cur_res;
-    if (this.isWms(lyr)) {
-      const view = this.HsMapService.map.getView();
-      const resolution = view.getResolution();
-      const units = view.getProjection().getUnits();
-      const dpi = 25.4 / 0.28;
-      const mpu = METERS_PER_UNIT[units];
-      cur_res = resolution * mpu * 39.37 * dpi;
-    } else {
-      cur_res = this.HsMapService.map.getView().getResolution();
-    }
+    const cur_res = this.HsMapService.map.getView().getResolution();
     this.currentResolution = cur_res;
     return (
       lyr.getMinResolution() <= cur_res && cur_res <= lyr.getMaxResolution()

--- a/projects/hslayers/src/components/utils/layer-utils.service.ts
+++ b/projects/hslayers/src/components/utils/layer-utils.service.ts
@@ -20,7 +20,9 @@ import {isEmpty} from 'ol/extent';
 
 import {HsLanguageService} from '../language/language.service';
 import {HsLayerDescriptor} from '../layermanager/layer-descriptor.interface';
+import {HsMapService} from '../map/map.service';
 import {HsUtilsService} from './utils.service';
+import {METERS_PER_UNIT} from 'ol/proj';
 import {WmsLayer} from '../../common/get-capabilities/wms-get-capabilities-response.interface';
 import {
   getCluster,
@@ -35,6 +37,7 @@ export class HsLayerUtilsService {
   constructor(
     public HsUtilsService: HsUtilsService,
     public HsLanguageService: HsLanguageService,
+    public hsMapService: HsMapService,
     private zone: NgZone
   ) {}
 
@@ -433,5 +436,16 @@ export class HsLayerUtilsService {
    */
   layerInvalid(layer: HsLayerDescriptor): boolean {
     return layer.loadProgress?.error;
+  }
+
+  calculateResolutionFromScale(denominator: number) {
+    if (!denominator) {
+      return denominator;
+    }
+    const view = this.hsMapService.map.getView();
+    const units = view.getProjection().getUnits();
+    const dpi = 25.4 / 0.28;
+    const mpu = METERS_PER_UNIT[units];
+    return denominator / (mpu * 39.37 * dpi);
   }
 }

--- a/projects/hslayers/src/components/utils/layer-utils.spec.ts
+++ b/projects/hslayers/src/components/utils/layer-utils.spec.ts
@@ -10,6 +10,8 @@ import {Image as ImageLayer, Tile, Vector as VectorLayer} from 'ol/layer';
 
 import {HsLanguageService} from '../language/language.service';
 import {HsLayerUtilsService} from './layer-utils.service';
+import {HsMapService} from '../map/map.service';
+import {HsMapServiceMock} from '../map/map.service.mock';
 import {HsUtilsService} from './utils.service';
 import {HsUtilsServiceMock} from './utils.service.mock';
 import {
@@ -69,6 +71,7 @@ describe('HsLayerUtilsService', () => {
     TestBed.configureTestingModule({
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
+        {provide: HsMapService, useValue: new HsMapServiceMock()},
         HsLayerUtilsService,
         {
           provide: HsUtilsService,

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -71,6 +71,7 @@ $list-group-item-padding-x: 1.25rem;
   .navbar-expand .nav-item {
     align-items: flex-start;
   }
+
   .basemapGallery .dropdown-menu {
     overflow: visible;
   }
@@ -80,6 +81,11 @@ $list-group-item-padding-x: 1.25rem;
   .list-group-item+.list-group-item{
     border-top-width: 0px;
   }
+  
+  .hs-url-table tr td {
+    display: table-cell;
+  }
+
 
   /* app css stylesheet */
   .icon-spin {

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -82,8 +82,12 @@ $list-group-item-padding-x: 1.25rem;
     border-top-width: 0px;
   }
   
-  .hs-url-table tr td {
-    display: table-cell;
+  .hs-url-table {
+    tr td { display: table-cell;}
+
+    .text-light th {
+      color: $light;
+   }
   }
 
 

--- a/projects/hslayers/src/css/hslayers-colors.scss
+++ b/projects/hslayers/src/css/hslayers-colors.scss
@@ -4,6 +4,11 @@
 $table-group-separator-color: white;
 
 .hsl {
+
+  .hs-url-table .text-light th {
+     color: $light;
+  }
+
   div.hs-info-area {
     background-color: hsla(214, 50%, 37%, 0.4);
     color: hsl(0, 0%, 100%);

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -43,8 +43,12 @@ $list-group-item-padding-x: 1.25rem;
   .list-group-item+.list-group-item{
     border-top-width: 0px;
   }
-  .hs-url-table tr td {
-    display: table-cell;
+  .hs-url-table {
+    tr td { display: table-cell;}
+
+    .text-light th {
+      color: $light;
+   }
   }
 
   /* app css stylesheet */

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -43,6 +43,9 @@ $list-group-item-padding-x: 1.25rem;
   .list-group-item+.list-group-item{
     border-top-width: 0px;
   }
+  .hs-url-table tr td {
+    display: table-cell;
+  }
 
   /* app css stylesheet */
   .icon-spin {

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -10,7 +10,7 @@ import {Vector as VectorLayer} from 'ol/layer';
 
 import {HsConfig} from 'hslayers-ng/src/config.service';
 import {HsEventBusService} from 'hslayers-ng/src/components/core/event-bus.service';
-import { View } from 'ol';
+import {View} from 'ol';
 
 @Component({
   selector: 'hslayers-app',
@@ -141,11 +141,11 @@ export class HslayersAppComponent {
           liferayProtocol: 'https',
         },
         {
-          title: "Micka",
-          url: "https://hub.sieusoil.eu/cat/csw",
+          title: 'Micka',
+          url: 'https://hub.sieusoil.eu/cat/csw',
           language: 'eng',
-          type: "micka"
-        }
+          type: 'micka',
+        },
       ],
       proxyPrefix: window.location.hostname.includes('localhost')
         ? `${window.location.protocol}//${window.location.hostname}:8085/`
@@ -154,14 +154,8 @@ export class HslayersAppComponent {
         tripPlanner: true,
       },
       componentsEnabled: {
-        basemapGallery: true
+        basemapGallery: true,
       },
-      default_view: new View({
-        projection: 'CRS:84',
-        center: [15.628, 49.864249],
-        multiWorld: false,
-        zoom: 8,
-      }),
       assetsPath: 'assets',
       symbolizerIcons: [
         {name: 'bag', url: '/assets/icons/bag1.svg'},

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -10,6 +10,7 @@ import {Vector as VectorLayer} from 'ol/layer';
 
 import {HsConfig} from 'hslayers-ng/src/config.service';
 import {HsEventBusService} from 'hslayers-ng/src/components/core/event-bus.service';
+import { View } from 'ol';
 
 @Component({
   selector: 'hslayers-app',
@@ -139,6 +140,12 @@ export class HslayersAppComponent {
           type: 'layman',
           liferayProtocol: 'https',
         },
+        {
+          title: "Micka",
+          url: "https://hub.sieusoil.eu/cat/csw",
+          language: 'eng',
+          type: "micka"
+        }
       ],
       proxyPrefix: window.location.hostname.includes('localhost')
         ? `${window.location.protocol}//${window.location.hostname}:8085/`
@@ -149,6 +156,12 @@ export class HslayersAppComponent {
       componentsEnabled: {
         basemapGallery: true
       },
+      default_view: new View({
+        projection: 'CRS:84',
+        center: [15.628, 49.864249],
+        multiWorld: false,
+        zoom: 8,
+      }),
       assetsPath: 'assets',
       symbolizerIcons: [
         {name: 'bag', url: '/assets/icons/bag1.svg'},


### PR DESCRIPTION
## Description

Up until now we were incorrectly assigning web service scale denominators to layer resolution parameters which were causing service layers to not render correctly (in relation to map scale). Wrong values were also stored to layer composition object. 

+few smaller changes to UI that gets vroken by liefary css
+consider crs-84 a valid CRS...@fzadrazil  wanted to use it on hub.sieusoil. Any ideas why we were filtering it out?

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
