### PR TITLE
Overridable popup widget list

### DIFF
--- a/projects/hslayers-cesium/src/query-popup.service.ts
+++ b/projects/hslayers-cesium/src/query-popup.service.ts
@@ -5,8 +5,10 @@ import {Geometry} from 'ol/geom';
 import {
   HsConfig,
   HsMapService,
+  HsQueryBaseService,
   HsQueryPopupBaseService,
   HsQueryPopupServiceModel,
+  HsQueryPopupWidgetContainerService,
   HsUtilsService,
 } from 'hslayers-ng';
 
@@ -25,9 +27,17 @@ export class HsCesiumQueryPopupService
     HsMapService: HsMapService,
     private HsConfig: HsConfig,
     HsUtilsService: HsUtilsService,
-    zone: NgZone
+    zone: NgZone,
+    private HsQueryBaseService: HsQueryBaseService,
+    hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService
   ) {
-    super(HsMapService, HsUtilsService, zone);
+    super(
+      HsMapService,
+      HsUtilsService,
+      zone,
+      HsConfig,
+      hsQueryPopupWidgetContainerService
+    );
   }
 
   registerPopup(nativeElement: any) {

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -82,6 +82,7 @@ export type popUpAttribute = {
 };
 export type popUp = {
   attributes?: Array<popUpAttribute | string>;
+  widgets?: string[];
 };
 
 export function getAccessRights(layer: Layer<Source>): accessRightsModel {

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -7,7 +7,7 @@ import {
   ViewChild,
 } from '@angular/core';
 
-import {Subject} from 'rxjs';
+import {ReplaySubject, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
 import {HsPanelComponent} from './panel-component.interface';
@@ -27,6 +27,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
   /** Miscellaneous data object to set to each of the panels inside this container.
    * This is used if undefined value is passed to the create functions data parameter. */
   @Input() data: any;
+  @Input() panelObserver?: ReplaySubject<HsPanelItem>;
   interval: any;
   private ngUnsubscribe = new Subject();
   constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
@@ -35,7 +36,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
   ngOnInit(): void {
-    this.service.panelObserver
+    (this.panelObserver ?? this.service.panelObserver)
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((item: HsPanelItem) => {
         this.loadPanel(item);
@@ -65,6 +66,5 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     const componentRefInstance = <HsPanelComponent>componentRef.instance;
     componentRefInstance.viewRef = componentRef.hostView;
     componentRefInstance.data = panelItem.data || this.data;
-    this.service.panels.push(componentRefInstance);
   }
 }

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
@@ -4,7 +4,6 @@ import {ReplaySubject, Subject} from 'rxjs';
 import {Type} from '@angular/core';
 
 export interface HsPanelContainerServiceInterface {
-  panels: HsPanelComponent[];
   panelObserver: ReplaySubject<HsPanelItem>;
   panelDestroyObserver: Subject<any>;
 

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.ts
@@ -10,7 +10,6 @@ import {ReplaySubject, Subject} from 'rxjs';
 export class HsPanelContainerService
   implements HsPanelContainerServiceInterface
 {
-  panels: Array<any> = [];
   panelObserver: ReplaySubject<HsPanelItem> = new ReplaySubject();
   panelDestroyObserver: Subject<any> = new Subject();
 
@@ -22,13 +21,19 @@ export class HsPanelContainerService
    * container component is even added to the dom.
    * @param component PanelComponent class
    * @param data Extra data to give the new panel
+   * @package panelObserver ReplaySubject to which you need to add the panel components. This is used when panels in this service are used only sometimes (for particular layers)
    */
-  create(component: Type<any>, data: any): void {
-    this.panelObserver.next(new HsPanelItem(component, data));
+  create(
+    component: Type<any>,
+    data: any,
+    panelObserver?: ReplaySubject<HsPanelItem>
+  ): void {
+    (panelObserver ?? this.panelObserver).next(
+      new HsPanelItem(component, data)
+    );
   }
 
   destroy(component: HsPanelComponent): void {
     this.panelDestroyObserver.next(component);
-    this.panels.splice(this.panels.indexOf(component), 1);
   }
 }

--- a/projects/hslayers/src/components/query/query-popup-base.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-base.service.ts
@@ -1,10 +1,19 @@
 import {Injectable, NgZone} from '@angular/core';
+import {ReplaySubject} from 'rxjs';
 
 import {Feature, Map} from 'ol';
 import {Geometry} from 'ol/geom';
 
+import {HsClearLayerComponent} from './widgets/clear-layer.component';
+import {HsConfig} from '../../config.service';
+import {HsFeatureInfoComponent} from './widgets/feature-info.component';
+import {HsFeatureLayer} from './query-popup.service.model';
+import {HsLayerNameComponent} from './widgets/layer-name.component';
 import {HsMapService} from '../map/map.service';
+import {HsPanelItem} from '../layout/panels/panel-item';
+import {HsQueryPopupWidgetContainerService} from './query-popup-widget-container.service';
 import {HsUtilsService} from '../utils/utils.service';
+import {WidgetItem} from './widgets/widget-item.type';
 import {getPopUp, getTitle} from '../../common/layer-extensions';
 
 @Injectable({
@@ -13,16 +22,26 @@ import {getPopUp, getTitle} from '../../common/layer-extensions';
 export class HsQueryPopupBaseService {
   map: Map;
   featuresUnderMouse: Feature<Geometry>[] = [];
-  featureLayersUnderMouse = [];
+  featureLayersUnderMouse: HsFeatureLayer[] = [];
   hoverPopup: any;
+  queryPopupWidgets: WidgetItem[] = [
+    {name: 'layer-name', component: HsLayerNameComponent},
+    {name: 'feature-info', component: HsFeatureInfoComponent},
+    {name: 'clear-layer', component: HsClearLayerComponent},
+  ];
 
   constructor(
     public hsMapService: HsMapService,
     public hsUtilsService: HsUtilsService,
-    public zone: NgZone
-  ) {}
+    public zone: NgZone,
+    public hsConfig: HsConfig,
+    public hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService
+  ) {
+    this.initWidgets(this.hsConfig.queryPopupWidgets);
+  }
 
   fillFeatures(features: Feature<Geometry>[]) {
+    //Zone is needed for performance reasons. Otherwise the popups dont get hidden soon enough
     this.zone.run(() => {
       this.featuresUnderMouse = features;
       if (this.featuresUnderMouse.length) {
@@ -39,13 +58,48 @@ export class HsQueryPopupBaseService {
             features: this.featuresUnderMouse.filter(
               (f) => this.hsMapService.getLayerForFeature(f) == l
             ),
+            panelObserver: getPopUp(l)?.widgets
+              ? new ReplaySubject<HsPanelItem>()
+              : undefined,
           };
           return layer;
         });
+        for (const layer of this.featureLayersUnderMouse) {
+          if (layer.panelObserver) {
+            this.initWidgets(
+              getPopUp(layer.layer)?.widgets,
+              layer.panelObserver
+            );
+          }
+        }
       } else {
         this.featuresUnderMouse = [];
       }
     });
+  }
+
+  initWidgets(
+    widgetNames: string[],
+    panelObserver?: ReplaySubject<HsPanelItem>
+  ) {
+    if (widgetNames?.length > 0) {
+      for (const widgetName of widgetNames) {
+        let widgetFound = this.queryPopupWidgets.find(
+          (widget) => widget.name == widgetName
+        );
+
+        if (!widgetFound && this.hsConfig.customQueryPopupWidgets?.length > 0) {
+          widgetFound = this.hsConfig.customQueryPopupWidgets.find(
+            (widget) => widget.name == widgetName
+          );
+        }
+        this.hsQueryPopupWidgetContainerService.create(
+          widgetFound.component,
+          undefined,
+          panelObserver
+        );
+      }
+    }
   }
 
   closePopup(): void {

--- a/projects/hslayers/src/components/query/query-popup-base.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-base.service.ts
@@ -4,16 +4,12 @@ import {ReplaySubject} from 'rxjs';
 import {Feature, Map} from 'ol';
 import {Geometry} from 'ol/geom';
 
-import {HsClearLayerComponent} from './widgets/clear-layer.component';
 import {HsConfig} from '../../config.service';
-import {HsFeatureInfoComponent} from './widgets/feature-info.component';
 import {HsFeatureLayer} from './query-popup.service.model';
-import {HsLayerNameComponent} from './widgets/layer-name.component';
 import {HsMapService} from '../map/map.service';
 import {HsPanelItem} from '../layout/panels/panel-item';
 import {HsQueryPopupWidgetContainerService} from './query-popup-widget-container.service';
 import {HsUtilsService} from '../utils/utils.service';
-import {WidgetItem} from './widgets/widget-item.type';
 import {getPopUp, getTitle} from '../../common/layer-extensions';
 
 @Injectable({
@@ -24,11 +20,6 @@ export class HsQueryPopupBaseService {
   featuresUnderMouse: Feature<Geometry>[] = [];
   featureLayersUnderMouse: HsFeatureLayer[] = [];
   hoverPopup: any;
-  queryPopupWidgets: WidgetItem[] = [
-    {name: 'layer-name', component: HsLayerNameComponent},
-    {name: 'feature-info', component: HsFeatureInfoComponent},
-    {name: 'clear-layer', component: HsClearLayerComponent},
-  ];
 
   constructor(
     public hsMapService: HsMapService,
@@ -36,9 +27,7 @@ export class HsQueryPopupBaseService {
     public zone: NgZone,
     public hsConfig: HsConfig,
     public hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService
-  ) {
-    this.initWidgets(this.hsConfig.queryPopupWidgets);
-  }
+  ) {}
 
   fillFeatures(features: Feature<Geometry>[]) {
     //Zone is needed for performance reasons. Otherwise the popups dont get hidden soon enough
@@ -66,7 +55,7 @@ export class HsQueryPopupBaseService {
         });
         for (const layer of this.featureLayersUnderMouse) {
           if (layer.panelObserver) {
-            this.initWidgets(
+            this.hsQueryPopupWidgetContainerService.initWidgets(
               getPopUp(layer.layer)?.widgets,
               layer.panelObserver
             );
@@ -76,30 +65,6 @@ export class HsQueryPopupBaseService {
         this.featuresUnderMouse = [];
       }
     });
-  }
-
-  initWidgets(
-    widgetNames: string[],
-    panelObserver?: ReplaySubject<HsPanelItem>
-  ) {
-    if (widgetNames?.length > 0) {
-      for (const widgetName of widgetNames) {
-        let widgetFound = this.queryPopupWidgets.find(
-          (widget) => widget.name == widgetName
-        );
-
-        if (!widgetFound && this.hsConfig.customQueryPopupWidgets?.length > 0) {
-          widgetFound = this.hsConfig.customQueryPopupWidgets.find(
-            (widget) => widget.name == widgetName
-          );
-        }
-        this.hsQueryPopupWidgetContainerService.create(
-          widgetFound.component,
-          undefined,
-          panelObserver
-        );
-      }
-    }
   }
 
   closePopup(): void {

--- a/projects/hslayers/src/components/query/query-popup-widget-container.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-widget-container.service.ts
@@ -1,12 +1,46 @@
 import {Injectable} from '@angular/core';
+import {ReplaySubject} from 'rxjs';
 
+import {HsClearLayerComponent} from './widgets/clear-layer.component';
+import {HsConfig} from '../../config.service';
+import {HsFeatureInfoComponent} from './widgets/feature-info.component';
+import {HsLayerNameComponent} from './widgets/layer-name.component';
 import {HsPanelContainerService} from '../layout/panels/panel-container.service';
+import {HsPanelItem} from '../layout/panels/panel-item';
+import {WidgetItem} from './widgets/widget-item.type';
 
 @Injectable({
   providedIn: 'root',
 })
 export class HsQueryPopupWidgetContainerService extends HsPanelContainerService {
-  constructor() {
+  queryPopupWidgets: WidgetItem[] = [
+    {name: 'layer-name', component: HsLayerNameComponent},
+    {name: 'feature-info', component: HsFeatureInfoComponent},
+    {name: 'clear-layer', component: HsClearLayerComponent},
+  ];
+
+  constructor(private hsConfig: HsConfig) {
     super();
+    this.initWidgets(this.hsConfig.queryPopupWidgets);
+  }
+
+  initWidgets(
+    widgetNames: string[],
+    panelObserver?: ReplaySubject<HsPanelItem>
+  ) {
+    if (widgetNames?.length > 0) {
+      for (const widgetName of widgetNames) {
+        let widgetFound = this.queryPopupWidgets.find(
+          (widget) => widget.name == widgetName
+        );
+
+        if (!widgetFound && this.hsConfig.customQueryPopupWidgets?.length > 0) {
+          widgetFound = this.hsConfig.customQueryPopupWidgets.find(
+            (widget) => widget.name == widgetName
+          );
+        }
+        this.create(widgetFound.component, undefined, panelObserver);
+      }
+    }
   }
 }

--- a/projects/hslayers/src/components/query/query-popup.service.model.ts
+++ b/projects/hslayers/src/components/query/query-popup.service.model.ts
@@ -2,11 +2,21 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
+import {ReplaySubject} from 'rxjs';
+
+import {HsPanelItem} from '../layout/panels/panel-item';
+
+export type HsFeatureLayer = {
+  title: string;
+  feature: Feature<Geometry>[];
+  layer: VectorLayer<VectorSource<Geometry>>;
+  panelObserver: ReplaySubject<HsPanelItem>;
+};
 
 export interface HsQueryPopupServiceModel {
   registerPopup(nativeElement: any);
   featuresUnderMouse: Feature<Geometry>[];
-  featureLayersUnderMouse: VectorLayer<VectorSource<Geometry>>[];
+  featureLayersUnderMouse: HsFeatureLayer[];
   hoverPopup: any;
 
   fillFeatures(features: Feature<Geometry>[]);
@@ -14,3 +24,4 @@ export interface HsQueryPopupServiceModel {
   closePopup(): void;
   serializeFeatureAttributes(feature: Feature<Geometry>): any[];
 }
+

--- a/projects/hslayers/src/components/query/query-popup.service.ts
+++ b/projects/hslayers/src/components/query/query-popup.service.ts
@@ -4,10 +4,12 @@ import {Feature, Map, Overlay} from 'ol';
 import {Geometry} from 'ol/geom';
 
 import {HsConfig} from '../../config.service';
+import {HsFeatureLayer} from './query-popup.service.model';
 import {HsMapService} from '../map/map.service';
 import {HsQueryBaseService} from './query-base.service';
 import {HsQueryPopupBaseService} from './query-popup-base.service';
 import {HsQueryPopupServiceModel} from './query-popup.service.model';
+import {HsQueryPopupWidgetContainerService} from './query-popup-widget-container.service';
 import {HsUtilsService} from '../utils/utils.service';
 
 @Injectable({
@@ -19,17 +21,24 @@ export class HsQueryPopupService
 {
   map: Map;
   featuresUnderMouse: Feature<Geometry>[] = [];
-  featureLayersUnderMouse = [];
+  featureLayersUnderMouse: HsFeatureLayer[] = [];
   hoverPopup: any;
 
   constructor(
     hsMapService: HsMapService,
-    private hsConfig: HsConfig,
+    public hsConfig: HsConfig,
     hsUtilsService: HsUtilsService,
     zone: NgZone,
-    private HsQueryBaseService: HsQueryBaseService
+    private HsQueryBaseService: HsQueryBaseService,
+    hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService
   ) {
-    super(hsMapService, hsUtilsService, zone);
+    super(
+      hsMapService,
+      hsUtilsService,
+      zone,
+      hsConfig,
+      hsQueryPopupWidgetContainerService
+    );
     this.hsMapService.loaded().then(() => this.init());
   }
 

--- a/projects/hslayers/src/components/query/query-popup/query-popup.component.html
+++ b/projects/hslayers/src/components/query/query-popup/query-popup.component.html
@@ -5,7 +5,7 @@
                 [title]="'QUERY.featurePopup.closePopup' | translate">
                 <i class="icon-remove-circle" style="color: rgb(73, 80, 87)"></i>
             </a>
-                <hs-panel-container [service]="hsQueryPopupWidgetContainerService"
+                <hs-panel-container [service]="hsQueryPopupWidgetContainerService" [panelObserver]="layerDesc.panelObserver"
                     [data]="{layerDescriptor: layerDesc, attributesForHover: attributesForHover, service: data.service}">
                 </hs-panel-container>
         </div>

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -107,7 +107,11 @@ export class HsConfig {
   /**
    * Configures query popup widgets, the order in which they are generated, and visibility
    */
-  queryPopupWidgets?: QueryPopupWidgetsType[] | string[];
+  queryPopupWidgets?: QueryPopupWidgetsType[] | string[] = [
+    'layer-name',
+    'feature-info',
+    'clear-layer',
+  ];
   /**
    * Allows the user to add custom widgets to query popup
    */

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -1,12 +1,10 @@
 import {Component, Input, OnInit, Type, ViewChild} from '@angular/core';
 
 import {HsAddDataComponent} from './components/add-data/add-data.component';
-import {HsClearLayerComponent} from './components/query/widgets/clear-layer.component';
 import {HsCompositionsComponent} from './components/compositions/compositions.component';
 import {HsConfig} from './config.service';
 import {HsDrawComponent} from './components/draw/draw.component';
 import {HsDrawToolbarComponent} from './components/draw/draw-toolbar.component';
-import {HsFeatureInfoComponent} from './components/query/widgets/feature-info.component';
 import {HsFeatureTableComponent} from './components/feature-table/feature-table.component';
 import {HsGeolocationComponent} from './components/geolocation/geolocation.component';
 import {HsInfoComponent} from './components/info/info.component';
@@ -14,7 +12,6 @@ import {HsLanguageComponent} from './components/language/language.component';
 import {HsLayerManagerComponent} from './components/layermanager/layermanager.component';
 import {HsLayerManagerGalleryComponent} from './components/layermanager/gallery/layermanager-gallery.component';
 import {HsLayerManagerService} from './components/layermanager/layermanager.service';
-import {HsLayerNameComponent} from './components/query/widgets/layer-name.component';
 import {HsLayoutComponent} from './components/layout/layout.component';
 import {HsLayoutService} from './components/layout/layout.service';
 import {HsLegendComponent} from './components/legend/legend.component';
@@ -33,7 +30,6 @@ import {HsStylerComponent} from './components/styles/styler.component';
 import {HsToolbarComponent} from './components/toolbar/toolbar.component';
 import {HsToolbarPanelContainerService} from './components/toolbar/toolbar-panel-container.service';
 import {HsTripPlannerComponent} from './components/trip-planner/trip-planner.component';
-import {WidgetItem} from './components/query/widgets/widget-item.type';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -44,11 +40,7 @@ import {WidgetItem} from './components/query/widgets/widget-item.type';
 export class HslayersComponent implements OnInit {
   @Input() config: HsConfig;
   @ViewChild(HsLayoutComponent) layout: HsLayoutComponent;
-  queryPopupWidgets: WidgetItem[] = [
-    {name: 'layer-name', component: HsLayerNameComponent},
-    {name: 'feature-info', component: HsFeatureInfoComponent},
-    {name: 'clear-layer', component: HsClearLayerComponent},
-  ];
+
   constructor(
     public hsConfig: HsConfig,
     private hsLayoutService: HsLayoutService,
@@ -108,28 +100,6 @@ export class HslayersComponent implements OnInit {
       this.hsLayoutService.createOverlay(HsQueryPopupComponent, {
         service: this.hsQueryPopupService,
       });
-
-      if (this.hsConfig.queryPopupWidgets?.length > 0) {
-        for (const widgetName of this.hsConfig.queryPopupWidgets) {
-          let widgetFound = this.queryPopupWidgets.find(
-            (widget) => widget.name == widgetName
-          );
-
-          if (
-            !widgetFound &&
-            this.hsConfig.customQueryPopupWidgets?.length > 0
-          ) {
-            widgetFound = this.hsConfig.customQueryPopupWidgets.find(
-              (widget) => widget.name == widgetName
-            );
-          } else {
-            this.hsQueryPopupWidgetContainerService.create(
-              widgetFound.component,
-              undefined
-            );
-          }
-        }
-      }
 
       this.hsLayoutService.initializedOnce = true;
     }

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -132,6 +132,7 @@ export class HslayersAppComponent {
       opacity: 1,
     });
     this.HsConfig.update({
+      queryPopupWidgets: ['layer-name', 'feature-info', 'clear-layer'],
       datasources: [
         {
           title: 'Layman',
@@ -305,6 +306,7 @@ export class HslayersAppComponent {
             inlineLegend: true,
             popUp: {
               attributes: ['name'],
+              widgets: ['layer-name', 'clear-layer'],
             },
             editor: {
               editable: true,


### PR DESCRIPTION
## Description

Make the HsConfig.queryPopupWidgets overridable by layers property  
```
popUp: {
              widgets: ['layer-name', 'clear-layer'],
            },
```
## Related issues or pull requests
#2336 


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
