### PR TITLE
Widget to generate popup content dynamically

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -83,6 +83,7 @@ export type popUpAttribute = {
 export type popUp = {
   attributes?: Array<popUpAttribute | string>;
   widgets?: string[];
+  displayFunction?: any;
 };
 
 export function getAccessRights(layer: Layer<Source>): accessRightsModel {

--- a/projects/hslayers/src/components/query/public-api.ts
+++ b/projects/hslayers/src/components/query/public-api.ts
@@ -17,6 +17,7 @@ export * from './query-popup-widget-base.component';
 export * from './widgets/feature-info.component';
 export * from './query-popup-widget-container.service';
 export * from './widgets/clear-layer.component';
-export * from './widgets/widgets.type';
+export * from './widgets/dynamic-text.component';
 export * from './widgets/layer-name.component';
+export * from './widgets/widgets.type';
 export * from './widgets/widget-item.type';

--- a/projects/hslayers/src/components/query/query-popup-base.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-base.service.ts
@@ -41,13 +41,15 @@ export class HsQueryPopupBaseService {
           'title'
         );
         this.featureLayersUnderMouse = layersFound.map((l) => {
+          const needSpecialWidgets =
+            getPopUp(l)?.widgets || getPopUp(l).displayFunction;
           const layer = {
             title: getTitle(l),
             layer: l,
             features: this.featuresUnderMouse.filter(
               (f) => this.hsMapService.getLayerForFeature(f) == l
             ),
-            panelObserver: getPopUp(l)?.widgets
+            panelObserver: needSpecialWidgets
               ? new ReplaySubject<HsPanelItem>()
               : undefined,
           };
@@ -55,8 +57,13 @@ export class HsQueryPopupBaseService {
         });
         for (const layer of this.featureLayersUnderMouse) {
           if (layer.panelObserver) {
+            const popupDef = getPopUp(layer.layer);
+            let widgets = popupDef?.widgets;
+            if (popupDef.displayFunction) {
+              widgets = ['dynamic-text'];
+            }
             this.hsQueryPopupWidgetContainerService.initWidgets(
-              getPopUp(layer.layer)?.widgets,
+              widgets,
               layer.panelObserver
             );
           }

--- a/projects/hslayers/src/components/query/query-popup-widget-container.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-widget-container.service.ts
@@ -3,6 +3,7 @@ import {ReplaySubject} from 'rxjs';
 
 import {HsClearLayerComponent} from './widgets/clear-layer.component';
 import {HsConfig} from '../../config.service';
+import {HsDynamicTextComponent} from './widgets/dynamic-text.component';
 import {HsFeatureInfoComponent} from './widgets/feature-info.component';
 import {HsLayerNameComponent} from './widgets/layer-name.component';
 import {HsPanelContainerService} from '../layout/panels/panel-container.service';
@@ -17,6 +18,7 @@ export class HsQueryPopupWidgetContainerService extends HsPanelContainerService 
     {name: 'layer-name', component: HsLayerNameComponent},
     {name: 'feature-info', component: HsFeatureInfoComponent},
     {name: 'clear-layer', component: HsClearLayerComponent},
+    {name: 'dynamic-text', component: HsDynamicTextComponent},
   ];
 
   constructor(private hsConfig: HsConfig) {

--- a/projects/hslayers/src/components/query/query-popup/query-popup.component.html
+++ b/projects/hslayers/src/components/query/query-popup/query-popup.component.html
@@ -5,9 +5,9 @@
             <i class="icon-remove-circle"></i>
         </a>
         <div *ngFor="let layerDesc of data.service.featureLayersUnderMouse; let i = index" class="hs-popup-layer">
-                <hs-panel-container [service]="hsQueryPopupWidgetContainerService" [panelObserver]="layerDesc.panelObserver"
-                    [data]="{layerDescriptor: layerDesc, attributesForHover: attributesForHover, service: data.service}">
-                </hs-panel-container>
+            <hs-panel-container [service]="hsQueryPopupWidgetContainerService" [panelObserver]="layerDesc.panelObserver"
+                [data]="{layerDescriptor: layerDesc, attributesForHover: attributesForHover, service: data.service}">
+            </hs-panel-container>
         </div>
     </div>
 </div>

--- a/projects/hslayers/src/components/query/query-popup/query-popup.component.html
+++ b/projects/hslayers/src/components/query/query-popup/query-popup.component.html
@@ -1,10 +1,10 @@
 <div [ngStyle]="popupVisible()" class="hs-hover-popup">
-    <div class="card" style="padding: 5px;">
-        <div *ngFor="let layerDesc of data.service.featureLayersUnderMouse; let i = index" style="line-height: 1.2">
-            <a class="p-1" (click)="data.service.closePopup()" data-toggle="tooltip" [hidden]="i !== 0"
-                [title]="'QUERY.featurePopup.closePopup' | translate">
-                <i class="icon-remove-circle" style="color: rgb(73, 80, 87)"></i>
-            </a>
+    <div class="card">
+        <a class="p-1" (click)="data.service.closePopup()" data-toggle="tooltip"
+            [title]="'QUERY.featurePopup.closePopup' | translate">
+            <i class="icon-remove-circle"></i>
+        </a>
+        <div *ngFor="let layerDesc of data.service.featureLayersUnderMouse; let i = index" class="hs-popup-layer">
                 <hs-panel-container [service]="hsQueryPopupWidgetContainerService" [panelObserver]="layerDesc.panelObserver"
                     [data]="{layerDescriptor: layerDesc, attributesForHover: attributesForHover, service: data.service}">
                 </hs-panel-container>

--- a/projects/hslayers/src/components/query/query.module.ts
+++ b/projects/hslayers/src/components/query/query.module.ts
@@ -7,6 +7,7 @@ import {TranslateModule} from '@ngx-translate/core';
 
 import {HsClearLayerComponent} from './widgets/clear-layer.component';
 import {HsDownloadModule} from '../../common/download/download.module';
+import {HsDynamicTextComponent} from './widgets/dynamic-text.component';
 import {HsFeatureInfoComponent} from './widgets/feature-info.component';
 import {HsLayerNameComponent} from './widgets/layer-name.component';
 import {HsPanelHelpersModule} from '../layout/panels/panel-helpers.module';
@@ -31,6 +32,7 @@ import {HsQueryPopupWidgetBaseComponent} from './query-popup-widget-base.compone
     HsQueryPopupWidgetBaseComponent,
     HsFeatureInfoComponent,
     HsLayerNameComponent,
+    HsDynamicTextComponent,
   ],
   imports: [
     CommonModule,
@@ -49,6 +51,7 @@ import {HsQueryPopupWidgetBaseComponent} from './query-popup-widget-base.compone
     HsQueryPopupWidgetBaseComponent,
     HsFeatureInfoComponent,
     HsLayerNameComponent,
+    HsDynamicTextComponent,
   ],
   entryComponents: [HsQueryComponent, HsQueryPopupComponent],
 })

--- a/projects/hslayers/src/components/query/widgets/dynamic-text.component.html
+++ b/projects/hslayers/src/components/query/widgets/dynamic-text.component.html
@@ -1,0 +1,3 @@
+<ng-container *ngFor="let feature of layerDescriptor.features">
+    <div [innerHtml]="generateContent(feature)"></div>
+</ng-container>

--- a/projects/hslayers/src/components/query/widgets/dynamic-text.component.ts
+++ b/projects/hslayers/src/components/query/widgets/dynamic-text.component.ts
@@ -1,0 +1,42 @@
+import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+
+import {Feature} from 'ol';
+import {Geometry} from 'ol/geom';
+
+import {HsLayerUtilsService} from '../../utils/layer-utils.service';
+import {HsQueryPopupWidgetBaseComponent} from '../query-popup-widget-base.component';
+import {getPopUp} from '../../../common/layer-extensions';
+
+@Component({
+  selector: 'hs-dynamic-text',
+  templateUrl: './dynamic-text.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HsDynamicTextComponent
+  extends HsQueryPopupWidgetBaseComponent
+  implements OnInit {
+  layerDescriptor: any;
+  name = 'dynamic-text';
+
+  @Input() data: {
+    layerDescriptor: any;
+  };
+
+  constructor(
+    public hsLayerUtilsService: HsLayerUtilsService,
+    private sanitizer: DomSanitizer
+  ) {
+    super();
+  }
+  ngOnInit(): void {
+    this.layerDescriptor = this.data.layerDescriptor;
+  }
+  generateContent(feature: Feature<Geometry>) {
+    const displayFunction = getPopUp(
+      this.layerDescriptor.layer
+    ).displayFunction;
+    const content = displayFunction(feature);
+    return this.sanitizer.bypassSecurityTrustHtml(content);
+  }
+}

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -643,7 +643,7 @@ $list-group-item-padding-x: 1.25rem;
     max-height: 20em;
     min-width: 10em;
     max-width: 40em;
-    overflow-y: scroll;
+    overflow-y: auto;
     visibility: visible;
     background: white;
   }
@@ -748,6 +748,17 @@ $list-group-item-padding-x: 1.25rem;
 
   .hs-endpoint-item-active {
     background-color: hsla(0, 0%, 0%, 0.2);
+  }
+
+  .hs-popup-layer {
+    line-height: 1.2; border-top: 1px solid rgba(200, 200, 200, 0.5)
+  }
+
+  .hs-hover-popup .icon-remove-circle {color: rgb(73, 80, 87); float: right}
+
+  .hs-hover-popup .card {
+    padding: 5px;
+    overflow-y: auto;
   }
 
   @import "../components/layout/partials/layout.component.scss";

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -61,6 +61,10 @@ export class HslayersAppComponent {
               ],
             ],
           },
+          'properties': {
+            'name': 'Poly 3',
+            'population': Math.floor(Math.random() * 100000),
+          },
         },
         {
           'type': 'Feature',
@@ -75,6 +79,10 @@ export class HslayersAppComponent {
                 [-2e6, 6e6],
               ],
             ],
+          },
+          'properties': {
+            'name': 'Poly 2',
+            'population': Math.floor(Math.random() * 100000),
           },
         },
         {
@@ -91,6 +99,10 @@ export class HslayersAppComponent {
               ],
             ],
           },
+          'properties': {
+            'name': 'Poly 4',
+            'population': Math.floor(Math.random() * 100000),
+          },
         },
         {
           'type': 'Feature',
@@ -104,6 +116,10 @@ export class HslayersAppComponent {
                 [-2e6, -1e6],
               ],
             ],
+          },
+          'properties': {
+            'name': 'Poly 1',
+            'population': Math.floor(Math.random() * 100000),
           },
         },
       ],
@@ -133,6 +149,30 @@ export class HslayersAppComponent {
       visible: false,
       opacity: 1,
     });
+    const polygonSld = `<?xml version="1.0" encoding="ISO-8859-1"?>
+            <StyledLayerDescriptor version="1.0.0" 
+                xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+                xmlns="http://www.opengis.net/sld" 
+                xmlns:ogc="http://www.opengis.net/ogc" 
+                xmlns:xlink="http://www.w3.org/1999/xlink" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <NamedLayer>
+                <Name>Simple point with stroke</Name>
+                <UserStyle>
+                  <Title>Default</Title>
+                  <FeatureTypeStyle>
+                    <Rule>
+                    <PolygonSymbolizer>
+                    <Fill>
+                      <CssParameter name="fill">#000080</CssParameter>
+                    </Fill>
+                  </PolygonSymbolizer>
+                    </Rule>
+                  </FeatureTypeStyle>
+                </UserStyle>
+              </NamedLayer>
+            </StyledLayerDescriptor>
+            `;
     this.HsConfig.update({
       queryPopupWidgets: ['layer-name', 'feature-info', 'clear-layer'],
       datasources: [
@@ -317,30 +357,36 @@ export class HslayersAppComponent {
                 description: 'none',
               },
             },
-            sld: `<?xml version="1.0" encoding="ISO-8859-1"?>
-            <StyledLayerDescriptor version="1.0.0" 
-                xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-                xmlns="http://www.opengis.net/sld" 
-                xmlns:ogc="http://www.opengis.net/ogc" 
-                xmlns:xlink="http://www.w3.org/1999/xlink" 
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-              <NamedLayer>
-                <Name>Simple point with stroke</Name>
-                <UserStyle>
-                  <Title>Default</Title>
-                  <FeatureTypeStyle>
-                    <Rule>
-                    <PolygonSymbolizer>
-                    <Fill>
-                      <CssParameter name="fill">#000080</CssParameter>
-                    </Fill>
-                  </PolygonSymbolizer>
-                    </Rule>
-                  </FeatureTypeStyle>
-                </UserStyle>
-              </NamedLayer>
-            </StyledLayerDescriptor>
-            `,
+            sld: polygonSld,
+            path: 'User generated',
+          },
+          source: new VectorSource({
+            features: new GeoJSON().readFeatures(geojsonObject),
+          }),
+        }),
+        new VectorLayer({
+          properties: {
+            title: 'Polygons with display f-n',
+            synchronize: false,
+            cluster: false,
+            inlineLegend: true,
+            popUp: {
+              attributes: ['name'],
+              widgets: ['layer-name', 'clear-layer'], //Will be ignored due to display function
+              displayFunction: function (feature) {
+                return `<a>${feature.get(
+                  'name'
+                )} with population of ${feature.get('population')}</a>`;
+              },
+            },
+            editor: {
+              editable: true,
+              defaultAttributes: {
+                name: 'New polygon',
+                description: 'none',
+              },
+            },
+            sld: polygonSld,
             path: 'User generated',
           },
           source: new VectorSource({


### PR DESCRIPTION
## Description

Override the hover popups content (widgets) with a content generated by a function provided by user
in HsConfig layer definition. The function receives a feature object as a parameter.
![image](https://user-images.githubusercontent.com/395514/140911094-fe3e9615-4547-4e8a-8a85-bc89ed287c86.png)



## Related issues or pull requests

fix #2370

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
