### PR TITLE
feat: Add QML support for layer styles when loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "deepmerge": "^4.2.2",
         "geostyler-legend": "^2.1.1",
         "geostyler-openlayers-parser": "^3.0.0",
+        "geostyler-qgis-parser": "^1.0.0",
         "geostyler-sld-parser": "^3.0.1",
         "geostyler-style": "^5.0.0",
         "geotiff": "^1.0.8",
@@ -3960,6 +3961,85 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@jest/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
@@ -6018,6 +6098,27 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/jasmine": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.2.tgz",
@@ -6031,6 +6132,15 @@
       "dev": true,
       "dependencies": {
         "@types/jasmine": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "dependencies": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -6074,8 +6184,7 @@
     "node_modules/@types/node": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.0.tgz",
-      "integrity": "sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg==",
-      "dev": true
+      "integrity": "sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6150,6 +6259,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
+      "integrity": "sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.9.2",
@@ -8857,6 +8987,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -8869,6 +9008,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/color-string": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -11385,6 +11533,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+      "engines": {
+        "node": ">= 10.14.2"
       }
     },
     "node_modules/dir-glob": {
@@ -14631,6 +14787,20 @@
         "rbush": "*"
       }
     },
+    "node_modules/geostyler-cql-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-cql-parser/-/geostyler-cql-parser-1.0.0.tgz",
+      "integrity": "sha512-iqnIrAJ7n6qfZFnvoX/XTEQM/I1nUthmNmQX4Jxg9UAbz0ZJuP03IQN0sC7AbWIii8Jn16ijSZuqZb2jI+Ca5Q==",
+      "dependencies": {
+        "geostyler-style": "^2.0.3",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/geostyler-cql-parser/node_modules/geostyler-style": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.2.0.tgz",
+      "integrity": "sha512-kAksOmPsuVFuQNLVT2phIDMW/XhO2Idg8PxKmzYnHqajLM+AQH6cPSa9J8TRUmMt+nKNgIkcT1bhkVIwY/Ufrw=="
+    },
     "node_modules/geostyler-legend": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/geostyler-legend/-/geostyler-legend-2.1.1.tgz",
@@ -14678,6 +14848,29 @@
       "peerDependencies": {
         "ol": "~6.5"
       }
+    },
+    "node_modules/geostyler-qgis-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-qgis-parser/-/geostyler-qgis-parser-1.0.0.tgz",
+      "integrity": "sha512-P+T2hWIk7pOV4AS8IqCgYQ13jAGXhRgDjIUoTJc8loKnpF8ovAWlDtYjJ/pagPKwHZE9J1xOypMkPpGBJNkssQ==",
+      "dependencies": {
+        "@babel/core": "^7.10.2",
+        "@types/jest": "^26.0.23",
+        "@types/lodash": "^4.14.155",
+        "@types/node": "^14.0.11",
+        "@types/xml2js": "^0.4.5",
+        "color": "^3.1.2",
+        "geostyler-cql-parser": "^1.0.0",
+        "geostyler-style": "^5.0.0",
+        "lodash": "^4.17.15",
+        "xml2js": "^0.4.23",
+        "xmldom": "^0.6.0"
+      }
+    },
+    "node_modules/geostyler-qgis-parser/node_modules/@types/node": {
+      "version": "14.17.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+      "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
     },
     "node_modules/geostyler-sld-parser": {
       "version": "3.0.1",
@@ -17307,6 +17500,92 @@
       "dev": true,
       "engines": {
         "node": ">= 6.9.x"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+      "engines": {
+        "node": ">= 10.14.2"
       }
     },
     "node_modules/jest-worker": {
@@ -22959,6 +23238,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "dependencies": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -23696,6 +24019,11 @@
       "dependencies": {
         "quickselect": "^2.0.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -25148,6 +25476,19 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
       "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/skmeans": {
       "version": "0.9.7",
@@ -32921,6 +33262,63 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz",
@@ -34824,6 +35222,27 @@
         "@types/node": "*"
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/jasmine": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.2.tgz",
@@ -34837,6 +35256,15 @@
       "dev": true,
       "requires": {
         "@types/jasmine": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "@types/json-schema": {
@@ -34879,8 +35307,7 @@
     "@types/node": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.0.tgz",
-      "integrity": "sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg==",
-      "dev": true
+      "integrity": "sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -34954,6 +35381,27 @@
           "dev": true
         }
       }
+    },
+    "@types/xml2js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
+      "integrity": "sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/yargs": {
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "@types/yauzl": {
       "version": "2.9.2",
@@ -37101,6 +37549,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -37113,6 +37570,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -39132,6 +39598,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
+    },
+    "diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -41658,6 +42129,22 @@
         "rbush": "*"
       }
     },
+    "geostyler-cql-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-cql-parser/-/geostyler-cql-parser-1.0.0.tgz",
+      "integrity": "sha512-iqnIrAJ7n6qfZFnvoX/XTEQM/I1nUthmNmQX4Jxg9UAbz0ZJuP03IQN0sC7AbWIii8Jn16ijSZuqZb2jI+Ca5Q==",
+      "requires": {
+        "geostyler-style": "^2.0.3",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "geostyler-style": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-2.2.0.tgz",
+          "integrity": "sha512-kAksOmPsuVFuQNLVT2phIDMW/XhO2Idg8PxKmzYnHqajLM+AQH6cPSa9J8TRUmMt+nKNgIkcT1bhkVIwY/Ufrw=="
+        }
+      }
+    },
     "geostyler-legend": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/geostyler-legend/-/geostyler-legend-2.1.1.tgz",
@@ -41689,6 +42176,31 @@
             "proj4": "^2.7.0",
             "shpjs": "^3.6.3"
           }
+        }
+      }
+    },
+    "geostyler-qgis-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-qgis-parser/-/geostyler-qgis-parser-1.0.0.tgz",
+      "integrity": "sha512-P+T2hWIk7pOV4AS8IqCgYQ13jAGXhRgDjIUoTJc8loKnpF8ovAWlDtYjJ/pagPKwHZE9J1xOypMkPpGBJNkssQ==",
+      "requires": {
+        "@babel/core": "^7.10.2",
+        "@types/jest": "^26.0.23",
+        "@types/lodash": "^4.14.155",
+        "@types/node": "^14.0.11",
+        "@types/xml2js": "^0.4.5",
+        "color": "^3.1.2",
+        "geostyler-cql-parser": "^1.0.0",
+        "geostyler-style": "^5.0.0",
+        "lodash": "^4.17.15",
+        "xml2js": "^0.4.23",
+        "xmldom": "^0.6.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.17.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+          "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g=="
         }
       }
     },
@@ -43735,6 +44247,67 @@
       "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-2.2.0.tgz",
       "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
       "dev": true
+    },
+    "jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
     },
     "jest-worker": {
       "version": "27.3.1",
@@ -48082,6 +48655,40 @@
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
     },
+    "pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -48662,6 +49269,11 @@
       "requires": {
         "quickselect": "^2.0.0"
       }
+    },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "read-cache": {
       "version": "1.0.0",
@@ -49815,6 +50427,21 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
       "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
     },
     "skmeans": {
       "version": "0.9.7",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "deepmerge": "^4.2.2",
     "geostyler-legend": "^2.1.1",
     "geostyler-openlayers-parser": "^3.0.0",
+    "geostyler-qgis-parser": "^1.0.0",
     "geostyler-sld-parser": "^3.0.1",
     "geostyler-style": "^5.0.0",
     "geotiff": "^1.0.8",

--- a/projects/hslayers-server/package-lock.json
+++ b/projects/hslayers-server/package-lock.json
@@ -4234,9 +4234,9 @@
       }
     },
     "uid2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
-      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/projects/hslayers/README.md
+++ b/projects/hslayers/README.md
@@ -36,7 +36,7 @@ It will install hslayers-ng for the default application specified in your angula
 `ng add hslayers-ng --project myProject`
 
 Add peer dependencies:
-`npm i bootstrap@^5.0.0 ol@^6.0.0 @angular/cdk@^12 @angular/common@^12 @angular/core@^12 @angular/forms@^12.0.0 @ngx-translate/core@^13 @ngx-translate/http-loader@^6.0.0 deepmerge@^4.0.0 dayjs@^1.0.0 @ng-bootstrap/ng-bootstrap@^10.0.0 ol-popup@^4.0.0 proj4@^2.6.0 share-api-polyfill@^1.0.0 @angular/compiler@^12.0.0 @angular/platform-browser@^12.0.0 @angular/platform-browser-dynamic@^12.0.0 @angular/localize@^12.0.0 rxjs@^6.0.0 zone.js@^0.11.3 xml-js@^1.0.0 ngx-cookie-service@^12.0.0 geostyler-style@^5 geostyler-sld-parser@^3 geostyler-openlayers-parser@^3 geostyler-legend@>=3 ngx-color@^7 queue resumablejs d3 geotiff@^1.0.8`
+`npm i bootstrap@^5.0.0 ol@^6.0.0 @angular/cdk@^12 @angular/common@^12 @angular/core@^12 @angular/forms@^12.0.0 @ngx-translate/core@^13 @ngx-translate/http-loader@^6.0.0 deepmerge@^4.0.0 dayjs@^1.0.0 @ng-bootstrap/ng-bootstrap@^10.0.0 ol-popup@^4.0.0 proj4@^2.6.0 share-api-polyfill@^1.0.0 @angular/compiler@^12.0.0 @angular/platform-browser@^12.0.0 @angular/platform-browser-dynamic@^12.0.0 @angular/localize@^12.0.0 rxjs@^6.0.0 zone.js@^0.11.3 xml-js@^1.0.0 ngx-cookie-service@^12.0.0 geostyler-style@^5 geostyler-sld-parser@^3 geostyler-openlayers-parser@^3 geostyler-legend@>=3 ngx-color@^7 queue resumablejs d3 geotiff@^1.0.8 geostyler-qgis-parser@^1`
 
 For using hslayers-ng prebuilt bundle including angular, bootstrap etc. dependencies by loading it through `<script>` tags see: [Hslayers-ng application](https://github.com/hslayers/hslayers-ng/tree/develop/projects/hslayers-app)
 

--- a/projects/hslayers/package.json
+++ b/projects/hslayers/package.json
@@ -21,6 +21,7 @@
     "dayjs": "^1.0.0",
     "geostyler-openlayers-parser": "^3.0.0",
     "geostyler-sld-parser": "^3.0.0",
+    "geostyler-qgis-parser": "^1.0.0",
     "geostyler-style": "^5.0.0",
     "geostyler-legend": "^2.1.0",
     "geotiff": "^1.0.8",

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -43,6 +43,7 @@ const QUERY_FILTER = 'queryFilter';
 const REMOVABLE = 'removable';
 const SHOW_IN_LAYER_MANAGER = 'showInLayerManager';
 const HS_SLD = 'sld';
+const HS_QML = 'qml';
 const THUMBNAIL = 'thumbnail';
 const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
 const LEGENDS = 'legends';
@@ -347,6 +348,10 @@ export function getFeatureInfoTarget(layer: Layer<Source>): string {
 
 export function getSld(layer: Layer<Source>): string {
   return layer.get(HS_SLD);
+}
+
+export function getQml(layer: Layer<Source>): string {
+  return layer.get(HS_QML);
 }
 
 export function setSld(layer: Layer<Source>, sld: string): void {

--- a/projects/hslayers/src/components/add-data/add-data.service.ts
+++ b/projects/hslayers/src/components/add-data/add-data.service.ts
@@ -18,7 +18,6 @@ export type DatasetType = 'url' | 'catalogue' | 'file' | 'OWS';
   providedIn: 'root',
 })
 export class HsAddDataService {
-  isAuthorized = false;
   typeSelected: DatasetType;
   //Holds reference to data.url.component type selected
   urlType: AddDataUrlType;
@@ -33,18 +32,7 @@ export class HsAddDataService {
     public hsConfig: HsConfig,
     public hsCommonEndpointsService: HsCommonEndpointsService,
     public hsCommonLaymanService: HsCommonLaymanService
-  ) {
-    const layman = this.hsCommonEndpointsService.endpoints.filter(
-      (ep) => ep.type == 'layman'
-    )[0];
-    if (layman) {
-      this.hsCommonLaymanService.authChange.subscribe((endpoint: any) => {
-        this.isAuthorized = endpoint.authenticated;
-      });
-      this.isAuthorized =
-        layman.user !== 'anonymous' && layman.user !== 'browser';
-    }
-  }
+  ) {}
 
   addLayer(layer: Layer<Source>, underLayer?: Layer<Source>): void {
     if (underLayer) {

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -68,7 +68,6 @@
                 <div class="btn-group btn-group-toggle h-100 pe-2 align-items-center" data-toggle="buttons">
                     <label class="btn btn-sm btn-outline-secondary" *ngFor="let type of whatToAddTypes"
                         style="width:6em" (click)="selectTypeAndAdd(type,$event)">
-                        <input type="radio" name="options" />
                         {{type}}
                     </label>
                 </div>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
@@ -33,7 +33,7 @@ type WhatToAddDescriptor = {
   extractStyles?;
   editable?: boolean;
   workspace?: string;
-  sld?: string;
+  style?: string;
 };
 
 @Injectable({
@@ -429,7 +429,7 @@ export class HsAddDataCatalogueService {
             {
               extractStyles: whatToAdd.extractStyles,
               workspace: whatToAdd.workspace,
-              sld: whatToAdd.sld,
+              style: whatToAdd.style,
             }
           );
           this.hsAddDataVectorService.fitExtent(layer);
@@ -439,7 +439,7 @@ export class HsAddDataCatalogueService {
             this.hsEventBusService.owsFilling.next({
               type: 'wfs',
               uri: whatToAdd.link.replace('_wms/ows', '/wfs'),
-              sld: whatToAdd.sld,
+              style: whatToAdd.style,
               layer: `${whatToAdd.workspace}:${whatToAdd.name}`,
             });
           });

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
@@ -414,6 +414,7 @@ export class HsAddDataCatalogueService {
             type: whatToAdd.type.toLowerCase(),
             uri: decodeURIComponent(whatToAdd.link),
             layer: undefined, //layer.title || layer.name ||
+            style: whatToAdd.style,
           });
         });
       } else {

--- a/projects/hslayers/src/components/add-data/catalogue/layer-descriptor.model.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layer-descriptor.model.ts
@@ -15,8 +15,9 @@ export interface HsAddDataLayerDescriptor {
   id?;
   workspace?: string;
   editable?: boolean;
-  sld?: {
+  style?: {
     url: string;
+    type: string;
   };
   featureId?: string;
   highlighted?: boolean;

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -278,23 +278,34 @@ export class HsLaymanBrowserService {
     layer: HsAddDataLayerDescriptor
   ): Promise<any> {
     const lyr = await this.fillLayerMetadata(ds, layer);
-    let sld: string = undefined;
-    if (lyr.sld?.url) {
-      sld = await this.http
-        .get(lyr.sld?.url, {
-          headers: new HttpHeaders().set('Content-Type', 'text'),
-          responseType: 'text',
-        })
-        .toPromise();
-      if (!sld?.includes('StyledLayerDescriptor')) {
-        sld = undefined;
+    let style: string = undefined;
+    if (lyr.style?.url) {
+      try {
+        style = await (this.http
+          .get(lyr.style?.url, {
+            headers: new HttpHeaders().set('Content-Type', 'text'),
+            responseType: 'text',
+          })
+          .toPromise());
+      } catch (ex) {
+        console.error(ex);
+      }
+    }
+    if (lyr.style.type == 'sld') {
+      if (!style?.includes('StyledLayerDescriptor')) {
+        style = undefined;
+      }
+    }
+    if (lyr.style.type == 'qml') {
+      if (!style?.includes('<qgis')) {
+        style = undefined;
       }
     }
     if (lyr.wms.url) {
       return {
         type: lyr.type,
         link: lyr.wms.url,
-        sld,
+        style,
         layer: lyr.name,
         name: lyr.name,
         title: lyr.title,

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -281,13 +281,13 @@ export class HsLaymanBrowserService {
     let style: string = undefined;
     if (lyr.style?.url) {
       try {
-        style = await (this.http
+        style = await this.http
           .get(lyr.style?.url, {
             headers: new HttpHeaders().set('Content-Type', 'text'),
             responseType: 'text',
-            withCredentials: true
+            withCredentials: true,
           })
-          .toPromise());
+          .toPromise();
       } catch (ex) {
         console.error(ex);
       }

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -285,6 +285,7 @@ export class HsLaymanBrowserService {
           .get(lyr.style?.url, {
             headers: new HttpHeaders().set('Content-Type', 'text'),
             responseType: 'text',
+            withCredentials: true
           })
           .toPromise());
       } catch (ex) {

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -315,6 +315,6 @@ export class HsAddDataCommonFileService {
   }
 
   isAuthorized(): boolean {
-    return this.hsAddDataService.isAuthorized;
+    return this.hsLaymanService.getLaymanEndpoint().authenticated;
   }
 }

--- a/projects/hslayers/src/components/add-data/url/add-data-url-base.component.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-url-base.component.ts
@@ -54,15 +54,15 @@ export class HsAddDataUrlBaseComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.hsEventBusService.owsConnecting
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(({type, uri, layer}) => {
+      .subscribe(({type, uri, layer, style}) => {
         if (type === this.baseDataType) {
           this.hsAddDataCommonService.layerToSelect = layer;
-          this.setUrlAndConnect(uri, layer);
+          this.setUrlAndConnect(uri, style);
         }
       });
   }
 
-  async connect(layerToSelect?: string): Promise<void> {
+  async connect(style?: string): Promise<void> {
     const url = this.hsAddDataCommonService.url;
     if (!url || url === '') {
       return;
@@ -74,12 +74,11 @@ export class HsAddDataUrlBaseComponent implements OnInit, OnDestroy {
     this.hsAddDataUrlService.hasAnyChecked = false;
     this.hsHistoryListService.addSourceHistory(this.baseDataType, url);
     Object.assign(this.hsAddDataCommonService, {
-      layerToSelect,
       loadingInfo: true,
       showDetails: true,
     });
     const wrapper = await this.typeCapabilitiesService.request(url);
-    this.typeService.addLayerFromCapabilities(wrapper);
+    this.typeService.addLayerFromCapabilities(wrapper, style);
   }
 
   /**
@@ -88,9 +87,9 @@ export class HsAddDataUrlBaseComponent implements OnInit, OnDestroy {
    * @param layer - Optional layer to select, when
    * getCapabilities arrives
    */
-  setUrlAndConnect(url: string, layer: string): void {
+  setUrlAndConnect(url: string, style?: string): void {
     this.hsAddDataCommonService.updateUrl(url);
-    this.connect(layer);
+    this.connect(style);
   }
 
   changed(data: urlDataObject): void {

--- a/projects/hslayers/src/components/add-data/url/add-data-url.component.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-url.component.ts
@@ -39,13 +39,13 @@ export class HsAddDataUrlComponent implements OnDestroy {
     }
 
     this.owsFillingSubscription = this.hsEventBusService.owsFilling.subscribe(
-      ({type, uri, layer, sld}) => {
+      ({type, uri, layer, style}) => {
         this.typeSelected = type.toLowerCase();
         this.hsEventBusService.owsConnecting.next({
           type,
           uri,
           layer,
-          sld,
+          style,
         });
       }
     );
@@ -75,7 +75,7 @@ export class HsAddDataUrlComponent implements OnDestroy {
           type,
           uri: url,
           layer,
-          sld: undefined,
+          style: undefined,
         });
       }
     } else {

--- a/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
+++ b/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
@@ -13,7 +13,7 @@ export interface HsUrlTypeServiceModel {
     wrapper: CapabilitiesResponseWrapper,
     sld?: string
   ): Promise<void>;
-  addLayers(checkedOnly: boolean, sld?: string): void;
+  addLayers(checkedOnly: boolean, style?: string): void;
   addLayer(layer: any, options: addLayerOptions): void;
   addLayersRecursively(layer: any, options: addLayersRecursivelyOptions): void;
   addService?(

--- a/projects/hslayers/src/components/add-data/url/types/layer-options.type.ts
+++ b/projects/hslayers/src/components/add-data/url/types/layer-options.type.ts
@@ -7,6 +7,7 @@ export type addLayerOptions = {
   path?: string;
   queryFormat?: string;
   sld?: string;
+  qml?: string;
   subLayers?: any[];
   tileSize?;
 };

--- a/projects/hslayers/src/components/add-data/url/types/recursive-options.type.ts
+++ b/projects/hslayers/src/components/add-data/url/types/recursive-options.type.ts
@@ -1,4 +1,4 @@
 export type addLayersRecursivelyOptions = {
   checkedOnly?: boolean;
-  sld?: string;
+  style?: string;
 };

--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
@@ -123,7 +123,9 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
       // this.description = addAnchors(caps.ServiceIdentification.Abstract);
       this.data.version = caps.ServiceIdentification.ServiceTypeVersion;
       const layer = Array.isArray(caps.FeatureTypeList.FeatureType)
-        ? caps.FeatureTypeList.FeatureType[0]
+        ? caps.FeatureTypeList.FeatureType.find(
+            (layer) => layer.Name == this.hsAddDataCommonService.layerToSelect
+          )
         : caps.FeatureTypeList.FeatureType;
       this.data.layers = Array.isArray(caps.FeatureTypeList.FeatureType)
         ? caps.FeatureTypeList.FeatureType

--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
@@ -71,7 +71,7 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
 
   async addLayerFromCapabilities(
     wrapper: CapabilitiesResponseWrapper,
-    sld?: string
+    style?: string
   ): Promise<void> {
     if (!wrapper.response && !wrapper.error) {
       return;
@@ -95,7 +95,7 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
             layer.checked = true;
           }
         }
-        this.addLayers(true, sld);
+        this.addLayers(true, style);
         this.hsAddDataCommonService.layerToSelect = null;
         this.zoomToBBox(bbox);
       }
@@ -288,10 +288,10 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
    * First step in adding layers to the map. Lops through the list of layers and calls addLayer.
    * @param checkedOnly - Add all available layers or only checked ones. Checked=false=all
    */
-  addLayers(checkedOnly: boolean, sld: string): void {
+  addLayers(checkedOnly: boolean, style: string): void {
     this.data.add_all = checkedOnly;
     for (const layer of this.data.services) {
-      this.addLayersRecursively(layer, {sld});
+      this.addLayersRecursively(layer, {style});
     }
   }
 
@@ -301,12 +301,15 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
         layerName: layer.Name,
         folder: this.hsUtilsService.undefineEmptyString(this.data.folder_name),
         crs: this.data.srs,
-        sld: options.sld,
+        sld: options.style?.includes('StyledLayerDescriptor')
+          ? options.style
+          : undefined,
+        qml: options.style?.includes('qgis') ? options.style : undefined,
       });
     }
     if (layer.Layer) {
       for (const sublayer of layer.Layer) {
-        this.addLayersRecursively(sublayer, {sld: options.sld});
+        this.addLayersRecursively(sublayer, {style: options.style});
       }
     }
   }
@@ -326,6 +329,7 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
         path: options.folder,
         removable: true,
         sld: options.sld,
+        qml: options.qml,
         wfsUrl: this.hsWfsGetCapabilitiesService.service_url.split('?')[0],
       },
       source: new WfsSource(this.hsUtilsService, this.http, {

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
@@ -9,7 +9,6 @@ import {
 
 import {Cluster} from 'ol/source';
 
-import {HsAddDataService} from '../../add-data.service';
 import {HsAddDataVectorService} from '../vector.service';
 import {HsCommonEndpointsService} from '../../../../common/endpoints/endpoints.service';
 import {HsLanguageService} from '../../../language/language.service';
@@ -44,8 +43,7 @@ export class HsAddDataVectorFileComponent implements OnInit, AfterViewInit {
     public hsLayerManagerService: HsLayerManagerService,
     public hsLayerUtilsService: HsLayerUtilsService,
     public hsLayoutService: HsLayoutService,
-    public hsUtilsService: HsUtilsService,
-    public hsAddDataService: HsAddDataService
+    public hsUtilsService: HsUtilsService
   ) {}
   ngAfterViewInit(): void {
     this.vectorFileInput = this.hsUploadComponent.getVectorFileInput();
@@ -139,7 +137,10 @@ export class HsAddDataVectorFileComponent implements OnInit, AfterViewInit {
           this.data.saveAvailable = false;
         } else {
           this.data.saveAvailable = true;
-          this.data.saveToLayman = this.hsAddDataService.isAuthorized;
+          this.data.saveToLayman =
+            this.hsCommonEndpointsService.endpoints.filter(
+              (ep) => ep.type == 'layman'
+            )[0].authenticated;
         }
         //add layman endpoint url as url to allow sync
         if (this.data.url == '' && this.data.saveToLayman) {

--- a/projects/hslayers/src/components/core/event-bus.service.ts
+++ b/projects/hslayers/src/components/core/event-bus.service.ts
@@ -150,7 +150,7 @@ export class HsEventBusService {
   /**
    * replaces 'ows.filling'
    */
-  owsFilling: Subject<{type: any; uri: any; layer: any; sld?: string}> =
+  owsFilling: Subject<{type: any; uri: any; layer: any; style?: string}> =
     new Subject();
   /**
    * replaces `ows.${type}_connecting`
@@ -159,7 +159,7 @@ export class HsEventBusService {
     type: AddDataUrlType;
     uri: string;
     layer?: any;
-    sld?: string;
+    style?: string;
   }> = new BehaviorSubject({type: undefined, uri: '', layer: null});
   /**
    * Fires when layerSelected parameter is found in the URL

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -267,8 +267,11 @@ export class HsStylerService {
       this.layer = layer;
       this.layerTitle = getTitle(layer);
       const sld = getSld(layer);
+      const qml = getQml(layer);
       if (sld != undefined) {
         this.styleObject = await this.sldToJson(sld);
+      } else if (qml != undefined) {
+        this.styleObject = await this.qmlToJson(qml);
       } else {
         this.styleObject = {name: 'untitled style', rules: []};
       }


### PR DESCRIPTION
## Description

Layman layers having QGIS style instead of SLD should still load the style using
geostyler-qgis-parser



BREAKING CHANGE: Add geostyler-qgis-parser peerdependency: `npm i geostyler-qgis-parser`

## Related issues or pull requests

fix #2361


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
