### PR TITLE
Broadcast event when user layman session has expired

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@angular-eslint/template-parser": "^12.6.1",
         "@angular/cli": "~12.2.13",
         "@angular/compiler-cli": "~12.2.12",
-        "@commitlint/cli": "^14.1.0",
+        "@commitlint/cli": "^15.0.0",
         "@commitlint/config-conventional": "^15.0.0",
         "@compodoc/compodoc": "^1.1.15",
         "@types/jasmine": "~3.10.2",
@@ -2815,16 +2815,16 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-14.1.0.tgz",
-      "integrity": "sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
+      "integrity": "sha512-Y5xmDCweytqzo4N4lOI2YRiuX35xTjcs8n5hUceBH8eyK0YbwtgWX50BJOH2XbkwEmII9blNhlBog6AdQsqicg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^14.1.0",
-        "@commitlint/lint": "^14.1.0",
-        "@commitlint/load": "^14.1.0",
-        "@commitlint/read": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/format": "^15.0.0",
+        "@commitlint/lint": "^15.0.0",
+        "@commitlint/load": "^15.0.0",
+        "@commitlint/read": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
@@ -2850,12 +2850,12 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-14.1.0.tgz",
-      "integrity": "sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-15.0.0.tgz",
+      "integrity": "sha512-7DV4iNIald3vycwaWBNGk5FbonaNzOlU8nBe5m5AgU2dIeNKuXwLm+zzJzG27j0Ho56rgz//3F6RIvmsoxY9ZA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19"
       },
       "engines": {
@@ -2863,21 +2863,21 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz",
-      "integrity": "sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-15.0.0.tgz",
+      "integrity": "sha512-pyE4ApxjbWhb1TXz5vRiGwI2ssdMMgZbaaheZq1/7WC0xRnqnIhE1yUC1D2q20qPtvkZPstTYvMiRVtF+DvjUg==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-14.1.0.tgz",
-      "integrity": "sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-15.0.0.tgz",
+      "integrity": "sha512-bPhAfqwRhPk92WiuY0ktEJNpRRHSCd+Eg1MdhGyL9Bl3U25E5zvuInA+dNctnzZiOBSH/37ZaD0eOKCpQE6acg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "chalk": "^4.0.0"
       },
       "engines": {
@@ -2955,12 +2955,12 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz",
-      "integrity": "sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-15.0.0.tgz",
+      "integrity": "sha512-edtnkf2QZ/7e/YCJDgn1WDw9wfF1WfOitW5YEoSOb4SxjJEb/oE87kxNPZ2j8mnDMuunspcMfGHeg6fRlwaEWg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "semver": "7.3.5"
       },
       "engines": {
@@ -2968,29 +2968,29 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-14.1.0.tgz",
-      "integrity": "sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
+      "integrity": "sha512-hUi2+Im/2dJ5FBvWnodypTkg+5haCgsDzB0fyMApWLUA1IucYUAqRCQCW5em1Mhk9Crw1pd5YzFNikhIclkqCw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^14.0.0",
-        "@commitlint/parse": "^14.0.0",
-        "@commitlint/rules": "^14.1.0",
-        "@commitlint/types": "^14.0.0"
+        "@commitlint/is-ignored": "^15.0.0",
+        "@commitlint/parse": "^15.0.0",
+        "@commitlint/rules": "^15.0.0",
+        "@commitlint/types": "^15.0.0"
       },
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-14.1.0.tgz",
-      "integrity": "sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-15.0.0.tgz",
+      "integrity": "sha512-Ak1YPeOhvxmY3ioe0o6m1yLGvUAYb4BdfGgShU8jiTCmU3Mnmms0Xh/kfQz8AybhezCC3AmVTyBLaBZxOHR8kg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/execute-rule": "^14.0.0",
-        "@commitlint/resolve-extends": "^14.1.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/execute-rule": "^15.0.0",
+        "@commitlint/resolve-extends": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
@@ -3086,21 +3086,21 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-14.0.0.tgz",
-      "integrity": "sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-15.0.0.tgz",
+      "integrity": "sha512-L8euabzboKavPuDJsdIYAY2wx97LbiGEYsckMo6NmV8pOun50c8hQx6ouXFSAx4pp+mX9yUGmMiVqfrk2LKDJQ==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-14.0.0.tgz",
-      "integrity": "sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-15.0.0.tgz",
+      "integrity": "sha512-7fweM67tZfBNS7zw1KTuuT5K2u9nGytUJqFqT/1Ln3Na9cBCsoAqR47mfsNOTlRCgGwakm4xiQ7BpS2gN0OGuw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       },
@@ -3109,13 +3109,13 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-14.0.0.tgz",
-      "integrity": "sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-15.0.0.tgz",
+      "integrity": "sha512-5yI1o2HKZFVe7RTjL7IhuhHMKar/MDNY34vEHqqz9gMI7BK/rdP8uVb4Di1efl2V0UPnwID0nPKWESjQ8Ti0gw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/top-level": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       },
@@ -3124,9 +3124,9 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz",
-      "integrity": "sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-15.0.0.tgz",
+      "integrity": "sha512-7apfRJjgJsKja7lHsPfEFixKjA/fk/UeD3owkOw1174yYu4u8xBDLSeU3IinGPdMuF9m245eX8wo7vLUy+EBSg==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.0.0",
@@ -3139,15 +3139,15 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-14.1.0.tgz",
-      "integrity": "sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-15.0.0.tgz",
+      "integrity": "sha512-SqXfp6QUlwBS+0IZm4FEA/NmmAwcFQIkG3B05BtemOVWXQdZ8j1vV6hDwvA9oMPCmUSrrGpHOtZK7HaHhng2yA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^14.1.0",
-        "@commitlint/message": "^14.0.0",
-        "@commitlint/to-lines": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/ensure": "^15.0.0",
+        "@commitlint/message": "^15.0.0",
+        "@commitlint/to-lines": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "execa": "^5.0.0"
       },
       "engines": {
@@ -3155,18 +3155,18 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-14.0.0.tgz",
-      "integrity": "sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-15.0.0.tgz",
+      "integrity": "sha512-mY3MNA9ujPqVpiJjTYG9MDsYCobue5PJFO0MfcIzS1mCVvngH8ZFTPAh1fT5t+t1h876boS88+9WgqjRvbYItw==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-14.0.0.tgz",
-      "integrity": "sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-15.0.0.tgz",
+      "integrity": "sha512-7Gz3t7xcuuUw1d1Nou6YLaztzp2Em+qZ6YdCzrqYc+aquca3Vt0O696nuiBDU/oE+tls4Hx2CNpAbWhTgEwB5A==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0"
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-14.0.0.tgz",
-      "integrity": "sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-15.0.0.tgz",
+      "integrity": "sha512-OMSLX+QJnyNoTwws54ULv9sOvuw9GdVezln76oyUd4YbMMJyaav62aSXDuCdWyL2sm9hTkSzyEi52PNaIj/vqw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0"
@@ -32022,16 +32022,16 @@
       }
     },
     "@commitlint/cli": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-14.1.0.tgz",
-      "integrity": "sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
+      "integrity": "sha512-Y5xmDCweytqzo4N4lOI2YRiuX35xTjcs8n5hUceBH8eyK0YbwtgWX50BJOH2XbkwEmII9blNhlBog6AdQsqicg==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^14.1.0",
-        "@commitlint/lint": "^14.1.0",
-        "@commitlint/load": "^14.1.0",
-        "@commitlint/read": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/format": "^15.0.0",
+        "@commitlint/lint": "^15.0.0",
+        "@commitlint/load": "^15.0.0",
+        "@commitlint/read": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
@@ -32048,28 +32048,28 @@
       }
     },
     "@commitlint/ensure": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-14.1.0.tgz",
-      "integrity": "sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-15.0.0.tgz",
+      "integrity": "sha512-7DV4iNIald3vycwaWBNGk5FbonaNzOlU8nBe5m5AgU2dIeNKuXwLm+zzJzG27j0Ho56rgz//3F6RIvmsoxY9ZA==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19"
       }
     },
     "@commitlint/execute-rule": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz",
-      "integrity": "sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-15.0.0.tgz",
+      "integrity": "sha512-pyE4ApxjbWhb1TXz5vRiGwI2ssdMMgZbaaheZq1/7WC0xRnqnIhE1yUC1D2q20qPtvkZPstTYvMiRVtF+DvjUg==",
       "dev": true
     },
     "@commitlint/format": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-14.1.0.tgz",
-      "integrity": "sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-15.0.0.tgz",
+      "integrity": "sha512-bPhAfqwRhPk92WiuY0ktEJNpRRHSCd+Eg1MdhGyL9Bl3U25E5zvuInA+dNctnzZiOBSH/37ZaD0eOKCpQE6acg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "chalk": "^4.0.0"
       },
       "dependencies": {
@@ -32125,36 +32125,36 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz",
-      "integrity": "sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-15.0.0.tgz",
+      "integrity": "sha512-edtnkf2QZ/7e/YCJDgn1WDw9wfF1WfOitW5YEoSOb4SxjJEb/oE87kxNPZ2j8mnDMuunspcMfGHeg6fRlwaEWg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "semver": "7.3.5"
       }
     },
     "@commitlint/lint": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-14.1.0.tgz",
-      "integrity": "sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
+      "integrity": "sha512-hUi2+Im/2dJ5FBvWnodypTkg+5haCgsDzB0fyMApWLUA1IucYUAqRCQCW5em1Mhk9Crw1pd5YzFNikhIclkqCw==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^14.0.0",
-        "@commitlint/parse": "^14.0.0",
-        "@commitlint/rules": "^14.1.0",
-        "@commitlint/types": "^14.0.0"
+        "@commitlint/is-ignored": "^15.0.0",
+        "@commitlint/parse": "^15.0.0",
+        "@commitlint/rules": "^15.0.0",
+        "@commitlint/types": "^15.0.0"
       }
     },
     "@commitlint/load": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-14.1.0.tgz",
-      "integrity": "sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-15.0.0.tgz",
+      "integrity": "sha512-Ak1YPeOhvxmY3ioe0o6m1yLGvUAYb4BdfGgShU8jiTCmU3Mnmms0Xh/kfQz8AybhezCC3AmVTyBLaBZxOHR8kg==",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "^14.0.0",
-        "@commitlint/resolve-extends": "^14.1.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/execute-rule": "^15.0.0",
+        "@commitlint/resolve-extends": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
@@ -32221,38 +32221,38 @@
       }
     },
     "@commitlint/message": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-14.0.0.tgz",
-      "integrity": "sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-15.0.0.tgz",
+      "integrity": "sha512-L8euabzboKavPuDJsdIYAY2wx97LbiGEYsckMo6NmV8pOun50c8hQx6ouXFSAx4pp+mX9yUGmMiVqfrk2LKDJQ==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-14.0.0.tgz",
-      "integrity": "sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-15.0.0.tgz",
+      "integrity": "sha512-7fweM67tZfBNS7zw1KTuuT5K2u9nGytUJqFqT/1Ln3Na9cBCsoAqR47mfsNOTlRCgGwakm4xiQ7BpS2gN0OGuw==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       }
     },
     "@commitlint/read": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-14.0.0.tgz",
-      "integrity": "sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-15.0.0.tgz",
+      "integrity": "sha512-5yI1o2HKZFVe7RTjL7IhuhHMKar/MDNY34vEHqqz9gMI7BK/rdP8uVb4Di1efl2V0UPnwID0nPKWESjQ8Ti0gw==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/top-level": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz",
-      "integrity": "sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-15.0.0.tgz",
+      "integrity": "sha512-7apfRJjgJsKja7lHsPfEFixKjA/fk/UeD3owkOw1174yYu4u8xBDLSeU3IinGPdMuF9m245eX8wo7vLUy+EBSg==",
       "dev": true,
       "requires": {
         "import-fresh": "^3.0.0",
@@ -32262,37 +32262,37 @@
       }
     },
     "@commitlint/rules": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-14.1.0.tgz",
-      "integrity": "sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-15.0.0.tgz",
+      "integrity": "sha512-SqXfp6QUlwBS+0IZm4FEA/NmmAwcFQIkG3B05BtemOVWXQdZ8j1vV6hDwvA9oMPCmUSrrGpHOtZK7HaHhng2yA==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^14.1.0",
-        "@commitlint/message": "^14.0.0",
-        "@commitlint/to-lines": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/ensure": "^15.0.0",
+        "@commitlint/message": "^15.0.0",
+        "@commitlint/to-lines": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "execa": "^5.0.0"
       }
     },
     "@commitlint/to-lines": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-14.0.0.tgz",
-      "integrity": "sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-15.0.0.tgz",
+      "integrity": "sha512-mY3MNA9ujPqVpiJjTYG9MDsYCobue5PJFO0MfcIzS1mCVvngH8ZFTPAh1fT5t+t1h876boS88+9WgqjRvbYItw==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-14.0.0.tgz",
-      "integrity": "sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-15.0.0.tgz",
+      "integrity": "sha512-7Gz3t7xcuuUw1d1Nou6YLaztzp2Em+qZ6YdCzrqYc+aquca3Vt0O696nuiBDU/oE+tls4Hx2CNpAbWhTgEwB5A==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
       }
     },
     "@commitlint/types": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-14.0.0.tgz",
-      "integrity": "sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-15.0.0.tgz",
+      "integrity": "sha512-OMSLX+QJnyNoTwws54ULv9sOvuw9GdVezln76oyUd4YbMMJyaav62aSXDuCdWyL2sm9hTkSzyEi52PNaIj/vqw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "share-api-polyfill": "^1.0.21",
         "tslib": "^2.3.0",
         "vega": "5.21.0",
-        "vega-embed": "6.20.1",
+        "vega-embed": "6.20.2",
         "vega-lite": "~5.0.0",
         "xml-js": "^1.6.11",
         "zone.js": "~0.11.4"
@@ -27875,9 +27875,9 @@
       }
     },
     "node_modules/vega-embed": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.20.1.tgz",
-      "integrity": "sha512-79Scx9HdcoaxaqiDeoK22BS9er3vMI/9jJHCbbhD8wZlWcQ3tGlVay/TOk3JagtJJq/Zut+ZbB1dkj8Y07AQcQ==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.20.2.tgz",
+      "integrity": "sha512-U31UrhCOB1FRtxNh98AMFNvNneS17wavtE3WRU8W2BT/XWC99pCzKWzfMyszCdSMuXTAZaCuLZuGF/ebZ9v2Gg==",
       "dependencies": {
         "fast-json-patch": "^3.1.0",
         "json-stringify-pretty-compact": "^3.0.0",
@@ -51992,9 +51992,9 @@
       }
     },
     "vega-embed": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.20.1.tgz",
-      "integrity": "sha512-79Scx9HdcoaxaqiDeoK22BS9er3vMI/9jJHCbbhD8wZlWcQ3tGlVay/TOk3JagtJJq/Zut+ZbB1dkj8Y07AQcQ==",
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.20.2.tgz",
+      "integrity": "sha512-U31UrhCOB1FRtxNh98AMFNvNneS17wavtE3WRU8W2BT/XWC99pCzKWzfMyszCdSMuXTAZaCuLZuGF/ebZ9v2Gg==",
       "requires": {
         "fast-json-patch": "^3.1.0",
         "json-stringify-pretty-compact": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "geotiff": "^1.0.8",
         "jasmine-core": "~3.10.1",
         "jasmine-spec-reporter": "~7.0.0",
-        "karma": "~6.3.8",
+        "karma": "~6.3.9",
         "karma-chrome-launcher": "~3.1.0",
         "karma-jasmine": "~4.0.1",
         "karma-jasmine-html-reporter": "^1.7.0",
@@ -17565,9 +17565,9 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.8.tgz",
-      "integrity": "sha512-10wBBU9S0lBHhbCNfmmbWQaY5C1bXlKdnvzN2QKThujCI/+DKaezrI08l6bfTlpJ92VsEboq3zYKpXwK6DOi3A==",
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.9.tgz",
+      "integrity": "sha512-E/MqdLM9uVIhfuyVnrhlGBu4miafBdXEAEqCmwdEMh3n17C7UWC/8Kvm3AYKr91gc7scutekZ0xv6rxRaUCtnw==",
       "dev": true,
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -43952,9 +43952,9 @@
       }
     },
     "karma": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.8.tgz",
-      "integrity": "sha512-10wBBU9S0lBHhbCNfmmbWQaY5C1bXlKdnvzN2QKThujCI/+DKaezrI08l6bfTlpJ92VsEboq3zYKpXwK6DOi3A==",
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.9.tgz",
+      "integrity": "sha512-E/MqdLM9uVIhfuyVnrhlGBu4miafBdXEAEqCmwdEMh3n17C7UWC/8Kvm3AYKr91gc7scutekZ0xv6rxRaUCtnw==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@angular/cli": "~12.2.13",
         "@angular/compiler-cli": "~12.2.12",
         "@commitlint/cli": "^14.1.0",
-        "@commitlint/config-conventional": "^14.1.0",
+        "@commitlint/config-conventional": "^15.0.0",
         "@compodoc/compodoc": "^1.1.15",
         "@types/jasmine": "~3.10.2",
         "@types/jasminewd2": "~2.0.10",
@@ -2838,9 +2838,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz",
-      "integrity": "sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
+      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^4.3.1"
@@ -32039,9 +32039,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz",
-      "integrity": "sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
+      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@angular-eslint/template-parser": "^12.6.1",
     "@angular/cli": "~12.2.13",
     "@angular/compiler-cli": "~12.2.12",
-    "@commitlint/cli": "^14.1.0",
+    "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
     "@compodoc/compodoc": "^1.1.15",
     "@types/jasmine": "~3.10.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "share-api-polyfill": "^1.0.21",
     "tslib": "^2.3.0",
     "vega": "5.21.0",
-    "vega-embed": "6.20.1",
+    "vega-embed": "6.20.2",
     "vega-lite": "~5.0.0",
     "xml-js": "^1.6.11",
     "zone.js": "~0.11.4"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "geotiff": "^1.0.8",
     "jasmine-core": "~3.10.1",
     "jasmine-spec-reporter": "~7.0.0",
-    "karma": "~6.3.8",
+    "karma": "~6.3.9",
     "karma-chrome-launcher": "~3.1.0",
     "karma-jasmine": "~4.0.1",
     "karma-jasmine-html-reporter": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@angular/cli": "~12.2.13",
     "@angular/compiler-cli": "~12.2.12",
     "@commitlint/cli": "^14.1.0",
-    "@commitlint/config-conventional": "^14.1.0",
+    "@commitlint/config-conventional": "^15.0.0",
     "@compodoc/compodoc": "^1.1.15",
     "@types/jasmine": "~3.10.2",
     "@types/jasminewd2": "~2.0.10",

--- a/projects/hslayers/src/common/layman/layman.service.ts
+++ b/projects/hslayers/src/common/layman/layman.service.ts
@@ -12,6 +12,7 @@ import {HsToastService} from '../../components/layout/toast/toast.service';
 })
 export class HsCommonLaymanService {
   authChange: Subject<HsEndpoint> = new Subject();
+  sessionExpired: Subject<void> = new Subject();
   constructor(
     private $http: HttpClient,
     public hsToastService: HsToastService,
@@ -35,6 +36,7 @@ export class HsCommonLaymanService {
       if (res.code === 32) {
         endpoint.authenticated = false;
         endpoint.user = endpoint.originalConfiguredUser;
+        this.sessionExpired.next();
       }
       if (res.username) {
         if (endpoint.user != res.username) {

--- a/projects/hslayers/src/components/add-data/add-data.service.ts
+++ b/projects/hslayers/src/components/add-data/add-data.service.ts
@@ -41,6 +41,9 @@ export class HsAddDataService {
       this.hsCommonLaymanService.authChange.subscribe((endpoint: any) => {
         this.isAuthorized = endpoint.authenticated;
       });
+      this.hsCommonLaymanService.sessionExpired.subscribe(() => {
+        this.isAuthorized = false;
+      });
       this.isAuthorized =
         layman.user !== 'anonymous' && layman.user !== 'browser';
     }

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.spec.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.spec.ts
@@ -38,6 +38,7 @@ class HsConfigMock {
 class HsCommonLaymanServiceMock {
   constructor() {}
   authChange: Subject<any> = new Subject();
+  sessionExpired: Subject<void> = new Subject();
 }
 
 class CommonEndpointsServiceMock {

--- a/projects/hslayers/src/components/draw/draw.service.ts
+++ b/projects/hslayers/src/components/draw/draw.service.ts
@@ -185,6 +185,10 @@ export class HsDrawService {
       }
     });
 
+    this.HsCommonLaymanService.sessionExpired.subscribe(() => {
+      this.fillDrawableLayers();
+    });
+
     this.HsEventBusService.LayerManagerLayerVisibilityChanges.subscribe(
       (event) => {
         if (this.draw && event.layer == this.selectedLayer) {

--- a/projects/hslayers/src/components/draw/draw.spec.ts
+++ b/projects/hslayers/src/components/draw/draw.spec.ts
@@ -5,12 +5,13 @@ import {
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {TranslateModule} from '@ngx-translate/core';
-import {of} from 'rxjs';
 
 import VectorLayer from 'ol/layer/Vector';
+import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {Polygon} from 'ol/geom';
+import {TranslateModule} from '@ngx-translate/core';
 import {Vector as VectorSource} from 'ol/source';
+import {of} from 'rxjs';
 
 import {HsAddDataVectorService} from '../add-data/vector/vector.service';
 import {HsCommonLaymanService} from '../../common/layman/layman.service';
@@ -29,7 +30,6 @@ import {HsQueryVectorService} from '../query/query-vector.service';
 import {HsUtilsService} from '../utils/utils.service';
 import {HsUtilsServiceMock} from '../utils/utils.service.mock';
 import {mockLayerUtilsService} from '../utils/layer-utils.service.mock';
-import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 
 class emptyMock {
   constructor() {}
@@ -99,6 +99,7 @@ describe('HsDraw', () => {
           provide: HsCommonLaymanService,
           useValue: {
             authChange: of('endpoint'),
+            sessionExpired: of(),
           },
         },
       ],

--- a/projects/hslayers/src/components/save-map/layman.spec.ts
+++ b/projects/hslayers/src/components/save-map/layman.spec.ts
@@ -6,10 +6,11 @@ import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
+
+import VectorLayer from 'ol/layer/Vector';
 import {Subject} from 'rxjs';
 import {TranslateModule} from '@ngx-translate/core';
 
-import VectorLayer from 'ol/layer/Vector';
 import {HsCommonEndpointsService} from '../../common/endpoints/endpoints.service';
 import {HsCommonLaymanService} from '../../common/layman/layman.service';
 import {HsConfig} from '../../config.service';
@@ -39,6 +40,7 @@ class HsSaveMapManagerServiceMock {
 class HsCommonLaymanServiceMock {
   constructor() {}
   authChange: Subject<any> = new Subject();
+  sessionExpired: Subject<void> = new Subject();
 }
 
 class HsEventBusServiceMock {

--- a/projects/hslayers/src/components/save-map/save-map.component.ts
+++ b/projects/hslayers/src/components/save-map/save-map.component.ts
@@ -19,7 +19,8 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsSaveMapComponent
   extends HsPanelBaseComponent
-  implements OnDestroy {
+  implements OnDestroy
+{
   endpoint = null;
   isAuthorized = false;
   advancedForm: boolean;
@@ -103,6 +104,13 @@ export class HsSaveMapComponent
         this.isAuthorized =
           endpoint.user !== 'anonymous' && endpoint.user !== 'browser';
         this.HsSaveMapManagerService.currentUser = endpoint.user;
+      });
+
+    this.HsCommonLaymanService.sessionExpired
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(() => {
+        this.isAuthorized = false;
+        this.HsSaveMapManagerService.currentUser = false;
       });
   }
   ngOnDestroy(): void {


### PR DESCRIPTION
## Description

This is needed for components to update the ui and also data, when LAyman responds with code 32: token not active. 
This might not be the best solution, byut using authChage triggers somekind of loop, that I couldn't fix. Feel free to comment or replace this PR.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
