### PR TITLE
Fix accidentaly added layers (issue 2418)

### DIFF
--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
@@ -434,6 +434,7 @@ export class HsAddDataCatalogueService {
             }
           );
           this.hsAddDataVectorService.fitExtent(layer);
+          this.hsAddDataService.typeSelected = 'catalogue';
         } else {
           //Layman layers without write access
           setTimeout(() => {

--- a/projects/hslayers/src/components/add-data/common/common.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common.service.ts
@@ -3,6 +3,7 @@ import {Injectable} from '@angular/core';
 import {HsAddDataService} from '../add-data.service';
 import {HsAddDataUrlService} from '../url/add-data-url.service';
 import {HsDimensionService} from '../../../common/get-capabilities/dimension.service';
+import {HsEventBusService} from '../../core/event-bus.service';
 import {HsMapService} from '../../map/map.service';
 import {HsToastService} from '../../layout/toast/toast.service';
 
@@ -20,7 +21,8 @@ export class HsAddDataCommonService {
     public hsAddDataUrlService: HsAddDataUrlService,
     public hsToastService: HsToastService,
     public hsAddDataService: HsAddDataService,
-    public hsDimensionService: HsDimensionService
+    public hsDimensionService: HsDimensionService,
+    public hsEventBusService: HsEventBusService
   ) {
     this.hsAddDataService.cancelUrlRequest.subscribe(() => {
       this.clearParams();
@@ -31,6 +33,15 @@ export class HsAddDataCommonService {
     this.loadingInfo = false;
     this.showDetails = false;
     this.url = '';
+    this.hsEventBusService.owsConnecting.next({
+      type: undefined,
+      uri: '',
+      layer: null,
+    });
+  }
+
+  setPanelToCatalogue(): void {
+    this.hsAddDataService.typeSelected = 'catalogue';
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
+++ b/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
@@ -60,7 +60,6 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
       if (this.hsAddDataCommonService.layerToSelect) {
         this.hsAddDataCommonService.checkTheSelectedLayer(this.data.services);
         this.addLayers(true);
-        this.hsAddDataCommonService.layerToSelect = null;
       }
     } catch (e) {
       this.hsAddDataCommonService.throwParsingError(e);
@@ -147,6 +146,9 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
     }
     this.data.base = false;
     this.hsLayoutService.setMainPanel('layermanager');
+    this.hsAddDataCommonService.clearParams();
+    this.setDataToDefault();
+    this.hsAddDataCommonService.setPanelToCatalogue();
   }
 
   addLayersRecursively(

--- a/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
+++ b/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
@@ -23,4 +23,5 @@ export interface HsUrlTypeServiceModel {
     addUnder?: Layer<Source>,
     path?: string
   ): Promise<void>;
+  setDataToDefault(): void;
 }

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -91,7 +91,6 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
       if (this.hsAddDataCommonService.layerToSelect) {
         this.hsAddDataCommonService.checkTheSelectedLayer(this.data.services);
         this.addLayers(true);
-        this.hsAddDataCommonService.layerToSelect = null;
       }
     } catch (e) {
       this.hsAddDataCommonService.throwParsingError(e);
@@ -359,6 +358,9 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
     }
     this.data.base = false;
     this.hsLayoutService.setMainPanel('layermanager');
+    this.hsAddDataCommonService.clearParams();
+    this.setDataToDefault();
+    this.hsAddDataCommonService.setPanelToCatalogue();
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/url/wmts/wmts-service.ts
+++ b/projects/hslayers/src/components/add-data/url/wmts/wmts-service.ts
@@ -55,7 +55,6 @@ export class HsUrlWmtsService implements HsUrlTypeServiceModel {
       if (this.hsAddDataCommonService.layerToSelect) {
         this.hsAddDataCommonService.checkTheSelectedLayer(this.data.services);
         this.addLayers(true);
-        this.hsAddDataCommonService.layerToSelect = null;
       }
     } catch (e) {
       this.hsAddDataCommonService.throwParsingError(e);
@@ -100,6 +99,9 @@ export class HsUrlWmtsService implements HsUrlTypeServiceModel {
       this.addLayersRecursively(layer);
     }
     this.hsLayoutService.setMainPanel('layermanager');
+    this.hsAddDataCommonService.clearParams();
+    this.setDataToDefault();
+    this.hsAddDataCommonService.setPanelToCatalogue();
     //FIX ME: to implement
     // this.zoomToLayers();
   }


### PR DESCRIPTION
## Description

Layers from add data are no longer getting loaded by accident. Made some fixes for wfs layer loading as well.

Add data panel gets reset to catalogue view after layers are added.

## Related issues or pull requests

Closes #2418 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
