### PR TITLE
fix: Parse style when loading WFS from compositions

### DIFF
--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -280,17 +280,7 @@ export class HsLaymanBrowserService {
     const lyr = await this.fillLayerMetadata(ds, layer);
     let style: string = undefined;
     if (lyr.style?.url) {
-      try {
-        style = await this.http
-          .get(lyr.style?.url, {
-            headers: new HttpHeaders().set('Content-Type', 'text'),
-            responseType: 'text',
-            withCredentials: true,
-          })
-          .toPromise();
-      } catch (ex) {
-        console.error(ex);
-      }
+      style = await this.getStyleFromUrl(lyr.style?.url);
     }
     if (lyr.style.type == 'sld') {
       if (!style?.includes('StyledLayerDescriptor')) {
@@ -323,6 +313,19 @@ export class HsLaymanBrowserService {
         {disableLocalization: true, serviceCalledFrom: 'HsLaymanBrowserService'}
       );
       return false;
+    }
+  }
+
+  async getStyleFromUrl(styleUrl: string): Promise<string> {
+    try {
+      const req = this.http.get(styleUrl, {
+        headers: new HttpHeaders().set('Content-Type', 'text'),
+        responseType: 'text',
+        withCredentials: true,
+      });
+      return await req.toPromise();
+    } catch (ex) {
+      console.error(ex);
     }
   }
 }

--- a/projects/hslayers/src/components/compositions/compositions.spec.ts
+++ b/projects/hslayers/src/components/compositions/compositions.spec.ts
@@ -20,6 +20,7 @@ import {HsCompositionsStatusManagerService} from './endpoints/compositions-statu
 import {HsConfig} from '../../config.service';
 import {HsEventBusServiceMock} from '../core/event-bus.service.mock';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
+import {HsLaymanBrowserService} from '../add-data/catalogue/layman/layman.service';
 import {HsLayoutService} from '../layout/layout.service';
 import {HsLayoutServiceMock} from '../layout/layout.service.mock';
 import {HsMapService} from '../map/map.service';
@@ -51,6 +52,59 @@ class HsCompositionsMickaServiceMock {
 
 class emptyMock {
   constructor() {}
+}
+
+class HsLaymanBrowserServiceMock {
+  constructor() {}
+  async getStyleFromUrl(styleUrl: string): Promise<string> {
+    return `<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0">
+    <sld:NamedLayer>
+      <sld:Name>Default Styler</sld:Name>
+      <sld:UserStyle>
+        <sld:Name>Default Styler</sld:Name>
+        <sld:Title>Default Styler</sld:Title>
+        <sld:FeatureTypeStyle>
+          <sld:Name>name</sld:Name>
+          <sld:Rule>
+            <sld:PointSymbolizer>
+              <sld:Graphic>
+                <sld:Mark>
+                  <sld:WellKnownName>triangle</sld:WellKnownName>
+                  <sld:Fill>
+                    <sld:CssParameter name="fill">#5171aa</sld:CssParameter>
+                  </sld:Fill>
+                  <sld:Stroke>
+                    <sld:CssParameter name="stroke">#3790cb</sld:CssParameter>
+                    <sld:CssParameter name="stroke-width">1.25</sld:CssParameter>
+                  </sld:Stroke>
+                </sld:Mark>
+                <sld:Opacity>0.45</sld:Opacity>
+                <sld:Size>70</sld:Size>
+              </sld:Graphic>
+            </sld:PointSymbolizer>
+            <sld:PolygonSymbolizer>
+              <sld:Fill>
+                <sld:CssParameter name="fill-opacity">0.45</sld:CssParameter>
+              </sld:Fill>
+              <sld:Stroke>
+                <sld:CssParameter name="stroke">rgba(0, 153, 255, 1)</sld:CssParameter>
+                <sld:CssParameter name="stroke-opacity">0.3</sld:CssParameter>
+                <sld:CssParameter name="stroke-width">1.25</sld:CssParameter>
+              </sld:Stroke>
+            </sld:PolygonSymbolizer>
+            <sld:LineSymbolizer>
+              <sld:Stroke>
+                <sld:CssParameter name="stroke">rgba(0, 153, 255, 1)</sld:CssParameter>
+                <sld:CssParameter name="stroke-width">1.25</sld:CssParameter>
+              </sld:Stroke>
+            </sld:LineSymbolizer>
+          </sld:Rule>
+        </sld:FeatureTypeStyle>
+      </sld:UserStyle>
+    </sld:NamedLayer>
+  </sld:StyledLayerDescriptor>
+  `;
+  }
 }
 
 let mockedMapService;
@@ -108,6 +162,10 @@ describe('compositions', () => {
         {provide: HsLayerUtilsService, useValue: layerUtilsMock},
         HsStylerService,
         HsCompositionsLayerParserService,
+        {
+          provide: HsLaymanBrowserService,
+          useValue: new HsLaymanBrowserServiceMock(),
+        },
         {
           provide: HsCompositionsStatusManagerService,
           useValue: {
@@ -215,5 +273,13 @@ describe('compositions', () => {
   it('if should parse composition layer style', async function () {
     await loadComposition(component);
     expect(mockedMapService.map.getLayers().item(2).getStyle()).toBeDefined();
+    expect(
+      mockedMapService.map
+        .getLayers()
+        .item(7)
+        .getStyle()[2]
+        .getStroke()
+        .getColor()
+    ).toBe('rgba(0, 153, 255, 1)');
   });
 });

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -62,7 +62,7 @@ export class HsCompositionsLayerParserService {
     const wrapper = await this.hsWfsGetCapabilitiesService.request(
       lyr_def.protocol.url
     );
-    this.HsUrlWfsService.addLayerFromCapabilities(wrapper);
+    this.HsUrlWfsService.addLayerFromCapabilities(wrapper, lyr_def.style);
   }
 
   /**

--- a/projects/hslayers/test/data/composition.ts
+++ b/projects/hslayers/test/data/composition.ts
@@ -95,6 +95,8 @@ export const compositionJson = {
       'maxResolution': null,
       'minResolution': 0,
       'projection': 'epsg:4326',
+      style:
+        'http://localhost:8087/rest/workspaces/raitisbe/layers/raitis_sld_test/style',
     },
   ],
   'current_base_layer': {'title': 'Open street map'},


### PR DESCRIPTION
## Description

Parse style from composition when loading WFS layers

## Related issues or pull requests

#2420 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
