### PR TITLE
Update close-button style to Bs5

### DIFF
--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.html
@@ -7,7 +7,7 @@
                 <h4 class="modal-title">
                     {{'SENSORS.sensorUnit' | translate}} {{HsSensorsUnitDialogService.unit.description}}
                 </h4>
-                <button type="button" class="btn-close" (click)="close()" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" class="btn-close" (click)="close()" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}"></button>
             </div>
             <div class="modal-body" style="max-height: 260px; overflow-y: auto">
                 <div class="container-fluid">

--- a/projects/hslayers/src/common/confirm/confirm-dialog.html
+++ b/projects/hslayers/src/common/confirm/confirm-dialog.html
@@ -5,7 +5,7 @@
                 <h4 class="modal-title">
                     {{data.title}}
                 </h4>
-                <button type="button" (click)="no()" class="btn-close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="no()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}"></button>
             </div>
             <div class="modal-body" style="overflow-y:auto">
                 <p class="fw-bold h6">{{data.message}}</p>
@@ -13,7 +13,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" (click)="yes()" [title]="'COMMON.yes' | translate" data-dismiss="modal">{{'COMMON.yes' | translate}}</button>
-                <button type="button" class="btn btn-secondary compositions-btn-cancel" [title]="'COMMON.no' | translate" (click)="no()" data-dismiss="modal">{{'COMMON.no' | translate}}</button>      
+                <button type="button" class="btn btn-secondary compositions-btn-cancel" [title]="'COMMON.no' | translate" (click)="no()" data-dismiss="modal">{{'COMMON.no' | translate}}</button>
             </div>
         </div>
     </div>

--- a/projects/hslayers/src/common/layman/layman-login.html
+++ b/projects/hslayers/src/common/layman/layman-login.html
@@ -5,7 +5,7 @@
                 <h4 class="modal-title">
                     {{'COMMON.Login' | translate }}
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate }}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}"></button>
             </div>
             <div class="modal-body" style="max-height:600px; height: 35em; overflow-y:auto">
                 <iframe [src]="url" style="width:100%; height:100%;border:0"></iframe>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
@@ -5,10 +5,7 @@
                 <h4 class="modal-title">
                     {{'DATASOURCE_SELECTOR.metadataFor' | translate}} {{ selectedLayer.title}}
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span>
-                    <span class="visually-hidden">{{'COMMON.close' | translate}}</span>
-                </button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}"></button>
             </div>
             <div class="modal-body" style="max-height:400px; overflow-y:auto">
                 <ng-container *ngFor="let key of selectedLayerKeys">

--- a/projects/hslayers/src/components/add-data/common/capabilities-error-dialog/capabilities-error-dialog.component.html
+++ b/projects/hslayers/src/components/add-data/common/capabilities-error-dialog/capabilities-error-dialog.component.html
@@ -5,7 +5,7 @@
                 <h4 class="modal-title text-uppercase">
                     {{'ADDLAYERS.capabilitiesParsingProblem' | translate}}
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}"></button>
             </div>
             <div class="modal-body" style="max-height:600px; overflow-y:auto">
                 <p>{{'ADDLAYERS.ERROR.thereWasErrorWhile' | translate}}</p>

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_delete.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_delete.html
@@ -5,9 +5,9 @@
                 <h4 class="modal-title">
                     {{'COMMON.confirm' | translate}}
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true">&times;</span><span
-                        class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
+                    attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height: 600px; overflow-y: auto">
                 <span>{{'COMPOSITIONS.dialogDelete.doYouWantToDeleteMap' | translate}}</span>

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_info.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_info.html
@@ -5,9 +5,9 @@
                 <h4 class="modal-title">
                     {{data.info.title}} <span>{{'COMPOSITIONS.dialogInfo.details' | translate}}</span>
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' |
-                        translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
+                    attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height: 600px; overflow-y: auto">
                 <div class="row" style="text-align: justify; text-justify: inter-word;">

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_overwriteconfirm.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_overwriteconfirm.html
@@ -3,8 +3,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h4 class="modal-title">{{'COMPOSITIONS.dialogoverwriteConfirm.overwriteExistingMap' | translate}}</h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
+                    attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height: 600px; overflow-y: auto">
                 {{'COMPOSITIONS.dialogoverwriteConfirm.youAreOpeningMap' | translate}}

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_share.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_share.html
@@ -5,9 +5,9 @@
                 <h4 class="modal-title">
                     <span>{{'COMPOSITIONS.dialogShare.shareMap' | translate}}</span> {{data.title}}
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true">&times;</span><span
-                        class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
+                    attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height: 600px; overflow-y: auto">
                 <div class="row">

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_warning.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_warning.html
@@ -3,8 +3,9 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h4 class="modal-title">{{'COMMON.warning' | translate}}</h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
+                    attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height: 600px; overflow-y: auto">
                 <br>{{'COMMON.name' | translate}}: <b>{{data.composition_title}}</b>

--- a/projects/hslayers/src/components/draw/draw-layer-metadata/draw-layer-metadata.html
+++ b/projects/hslayers/src/components/draw/draw-layer-metadata/draw-layer-metadata.html
@@ -6,9 +6,9 @@
                     <h4 class="modal-title">
                         {{'COMMON.newDrawingLayer' | translate}}
                     </h4>
-                    <button type="button" (click)="cancel()" class="btn-close" data-dismiss="modal"><span
-                            aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' |
-                            translate}}</span></button>
+                    <button type="button" (click)="cancel()" class="btn-close" data-dismiss="modal"
+                        attr.aria-label="{{'COMMON.close' | translate}}">
+                    </button>
                 </div>
                 <p class="m-0 p-0" style="font-size: small; color: red;">
                     {{'DRAW.drawLayerMetadata.layerWillBeAdded' | translate}}</p>

--- a/projects/hslayers/src/components/layermanager/dialogs/dialog_remove_layer.html
+++ b/projects/hslayers/src/components/layermanager/dialogs/dialog_remove_layer.html
@@ -5,8 +5,8 @@
         <h4 class="modal-title">
           {{'PANEL_HEADER.LM' | translate}}
         </h4>
-        <button (click)="close()" class="btn-close" data-dismiss="modal"><span aria-hidden="true"></span><span
-            class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+        <button (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}">
+        </button>
       </div>
       <div class="modal-body" style="max-height:600px; overflow-y:auto">
         {{'LAYERMANAGER.dialogRemoveLayer.dialogMessage' | translate}}</div>

--- a/projects/hslayers/src/components/layermanager/dialogs/dialog_removeall.html
+++ b/projects/hslayers/src/components/layermanager/dialogs/dialog_removeall.html
@@ -5,8 +5,8 @@
                 <h4 class="modal-title">
                     {{'PANEL_HEADER.LM' | translate}}
                 </h4>
-                <button (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true"></span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height:600px; overflow-y:auto">
                 {{'LAYERMANAGER.dialogRemoveAll.dialogMessage' | translate}}</div>

--- a/projects/hslayers/src/components/save-map/partials/dialog_result.html
+++ b/projects/hslayers/src/components/save-map/partials/dialog_result.html
@@ -5,9 +5,8 @@
                 <h4 class="modal-title">
                     {{'SAVECOMPOSITION.dialogResult.savingCompositionStatus' | translate}}
                 </h4>
-              <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true">&times;</span><span
-                        class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}">
+                </button>
             </div>
             <div class="modal-body" style="max-height:600px; overflow-y:auto">
                 <div class="alert alert-status" [hidden]="!HsSaveMapManagerService.statusData.status">

--- a/projects/hslayers/src/components/save-map/partials/dialog_save.html
+++ b/projects/hslayers/src/components/save-map/partials/dialog_save.html
@@ -5,8 +5,7 @@
                 <h4 class="modal-title">
                     {{'SAVECOMPOSITION.dialogSave.saveComposition' | translate}}
                 </h4>
-                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"><span
-                        aria-hidden="true"></span><span class="visually-hidden">{{'COMMON.close' | translate}}</span></button>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}"></button>
             </div>
             <div class="modal-body" style="max-height: 600px; overflow-y: auto; text-align: center; font-size: 16px">
                 <div>

--- a/projects/hslayers/src/components/styles/styler.component.html
+++ b/projects/hslayers/src/components/styles/styler.component.html
@@ -4,9 +4,8 @@
       {{'LAYERMANAGER.layerEditor.styleLayer' | translate}}
       {{hsStylerService.layerTitle}}
     </span>
-    <button type="button" class="btn-close" (click)="layermanager()" [title]="'COMMON.close' | translate">
-      <span aria-hidden="true">×</span>
-      <span class="visually-hidden">{{'COMMON.close' | translate}}</span>
+    <button type="button" class="btn-close" (click)="layermanager()" [title]="'COMMON.close' | translate"
+      attr.aria-label="{{'COMMON.close' | translate}}">
     </button>
   </div>
   <div class="card-body">

--- a/projects/hslayers/src/components/styles/symbolizers/select-icon-dialog/select-icon-dialog.component.html
+++ b/projects/hslayers/src/components/styles/symbolizers/select-icon-dialog/select-icon-dialog.component.html
@@ -4,8 +4,7 @@
       <div class="modal-header d-flex flex-column">
         <div class="d-flex w-100 align-items-center">
           <h4 class="modal-title">{{'STYLER.selectIcon' | translate}}</h4>
-          <button type="button" (click)="cancel()" class="btn-close" data-dismiss="modal">
-            <span aria-hidden="true">&times;</span><span class="visually-hidden">{{'COMMON.close' | translate}}</span>
+          <button type="button" (click)="cancel()" class="btn-close" data-dismiss="modal" attr.aria-label="{{'COMMON.close' | translate}}">
           </button>
         </div>
       </div>


### PR DESCRIPTION
------------

## Description

Updates styling of close buttons to Bootstrap 5. The issue persists in the toasts, but this must be addressed on the side of @ng-bootstrap (see https://github.com/ng-bootstrap/ng-bootstrap/issues/3899).

## Related issues or pull requests

#2424 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
