### PR TITLE
fix: Align layers style attribute to laymans schema

### DIFF
--- a/projects/hslayers/src/components/compositions/schema.json
+++ b/projects/hslayers/src/components/compositions/schema.json
@@ -497,7 +497,7 @@
                 }
               }
             ]
-          },,
+          },
           "dimensions": {
             "$id": "#/properties/layers/items/properties/dimensions",
             "type": "object",

--- a/projects/hslayers/src/components/compositions/schema.json
+++ b/projects/hslayers/src/components/compositions/schema.json
@@ -468,10 +468,15 @@
           },
           "style": {
             "$id": "#/properties/layers/items/properties/style",
-            "type": "object",
+            "type": [
+              "string",
+              "object"
+            ],
             "title": "Style of vector layer features",
-            "description": "",
+            "description": "The style can be specified using a string in SLD format, URL to SLD file or JSON object (old way for hslayers-ng@<5.0.0) which specifies fill/stroke/image attributes of the style",
             "examples": [
+              "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <StyledLayerDescriptor version=\"1.0.0\" xsi:schemaLocation=\"http://www.opengis.net/sld StyledLayerDescriptor.xsd\" xmlns=\"http://www.opengis.net/sld\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <NamedLayer> <Name>GeoServer SLD Cook Book: Simple point with stroke</Name> <UserStyle> <Name>GeoServer SLD Cook Book: Simple point with stroke</Name> <Title>GeoServer SLD Cook Book: Simple point with stroke</Title> <FeatureTypeStyle> <Rule> <Name/> <PointSymbolizer> <Graphic> <Mark> <WellKnownName>circle</WellKnownName> <Fill> <CssParameter name=\"fill\">#FF0000</CssParameter> </Fill> <Stroke> <CssParameter name=\"stroke\">#000000</CssParameter> <CssParameter name=\"stroke-width\">2</CssParameter> </Stroke> </Mark> <Size>18</Size> </Graphic> </PointSymbolizer> </Rule> </FeatureTypeStyle> </UserStyle> </NamedLayer> </StyledLayerDescriptor>",
+              "https://docs.geoserver.org/latest/en/user/_downloads/734cc880c145b4d96a3d17fc6eb9b0c8/point_simplepoint.sld",
               {
                 "stroke": {
                   "color": "rgba(238, 156, 150, 1)",
@@ -492,7 +497,7 @@
                 }
               }
             ]
-          },
+          },,
           "dimensions": {
             "$id": "#/properties/layers/items/properties/dimensions",
             "type": "object",


### PR DESCRIPTION
## Description

Layers style attribute should support string. It already does that de-facto, but schema didn't reflect it

## Related issues or pull requests

https://github.com/hslayers/hslayers-ng/pull/2422

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
