### PR TITLE
feat: Link feature actions to external element events

### DIFF
--- a/projects/hslayers/src/common/dom-feature-link.type.ts
+++ b/projects/hslayers/src/common/dom-feature-link.type.ts
@@ -9,7 +9,7 @@ export type DOMFeatureLink = {
     | string
     | Feature<Geometry>
     | ((layer: Layer<Source>, domElement: Element) => any);
-  eventInDom: string;
+  event: string;
   actions: [
     'zoomToExtent' | 'panToCenter' | 'showPopup',
     (

--- a/projects/hslayers/src/common/dom-feature-link.type.ts
+++ b/projects/hslayers/src/common/dom-feature-link.type.ts
@@ -1,0 +1,20 @@
+import Feature from 'ol/Feature';
+import {Geometry} from 'ol/geom';
+import {Layer} from 'ol/layer';
+import {Source} from 'ol/source';
+
+export type DOMFeatureLink = {
+  domSelector: string;
+  feature:
+    | string
+    | Feature<Geometry>
+    | ((layer: Layer<Source>, domElement: Element) => any);
+  eventInDom: string;
+  actions: [
+    'zoomToExtent' | 'panToCenter' | 'showPopup',
+    (
+      | 'hidePopup'
+      | ((feature: Feature<Geometry>, domElement: Element, event: any) => any)
+    )
+  ];
+};

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -1,6 +1,7 @@
 import Feature from 'ol/Feature';
 import {Group, Layer} from 'ol/layer';
 
+import {DOMFeatureLink} from './dom-feature-link.type';
 import {Geometry} from 'ol/geom';
 import {HsLaymanLayerDescriptor} from '../components/save-map/layman-layer-descriptor.interface';
 import {Source} from 'ol/source';
@@ -51,6 +52,7 @@ const TITLE = 'title';
 const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
 const WFS_URL = 'wfsUrl';
 const WORKSPACE = 'workspace';
+export const DOM_FEATURE_LINKS = 'domFeatureLinks';
 
 export type Attribution = {
   onlineResource?: string;
@@ -274,6 +276,17 @@ export function setDimension(
  */
 export function getDimension(layer: Layer<Source>, type: string): Dimension {
   return layer.get(DIMENSIONS) ? layer.get(DIMENSIONS)[type] : undefined;
+}
+
+export function setDomFeatureLinks(
+  layer: Layer<Source>,
+  domFeatureLinks: DOMFeatureLink[]
+): void {
+  layer.set(DOM_FEATURE_LINKS, domFeatureLinks);
+}
+
+export function getDomFeatureLinks(layer: Layer<Source>): DOMFeatureLink[] {
+  return layer.get(DOM_FEATURE_LINKS);
 }
 
 export function setEditor(layer: Layer<Source>, editor: Editor): void {
@@ -639,6 +652,8 @@ export const HsLayerExt = {
   getDefinition,
   setDimensions,
   getDimensions,
+  getDomFeatureLinks,
+  setDomFeatureLinks,
   setEditor,
   getEditor,
   setEnableProxy,

--- a/projects/hslayers/src/components/external/external.service.ts
+++ b/projects/hslayers/src/components/external/external.service.ts
@@ -16,6 +16,7 @@ import {
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
 import {HsMapService} from '../map/map.service';
 import {HsUtilsService} from '../utils/utils.service';
+import { HsQueryPopupService } from '../query/query-popup.service';
 
 export type FeatureDomEventLink = {
   handles: EventListenerOrEventListenerObject[];
@@ -36,7 +37,8 @@ export class HsExternalService {
   constructor(
     public hsMapService: HsMapService,
     public hsUtilsService: HsUtilsService,
-    private hsLayerUtilsService: HsLayerUtilsService
+    private hsLayerUtilsService: HsLayerUtilsService,
+    private hsQueryPopupService: HsQueryPopupService
   ) {
     this.hsMapService.loaded().then((map) => this.init(map));
   }
@@ -151,16 +153,19 @@ export class HsExternalService {
     domElement: Element,
     e: Event
   ) {
+    const center = feature.getGeometry().getCenter();
     switch (action) {
       case 'zoomToExtent':
         const extent = feature.getGeometry().getExtent();
         this.hsMapService.fitExtent(extent);
         break;
       case 'panToCenter':
-        const center = feature.getGeometry().getCenter();
         this.hsMapService.map.getView().setCenter(center);
         break;
       case 'showPopup':
+        this.hsQueryPopupService.fillFeatures([feature]);
+        const pixel = this.hsMapService.map.getPixelFromCoordinate(center);
+        this.hsQueryPopupService.showPopup({pixel, map: this.hsMapService.map});
         break;
       case 'hidePopup':
         break;

--- a/projects/hslayers/src/components/external/external.service.ts
+++ b/projects/hslayers/src/components/external/external.service.ts
@@ -1,0 +1,190 @@
+import {Injectable} from '@angular/core';
+
+import Feature from 'ol/Feature';
+import VectorSource from 'ol/source/Vector';
+import {Geometry} from 'ol/geom';
+import {Layer} from 'ol/layer';
+import {Map} from 'ol';
+import {ObjectEvent} from 'ol/Object';
+import {Source} from 'ol/source';
+
+import {DOMFeatureLink} from '../../common/dom-feature-link.type';
+import {
+  DOM_FEATURE_LINKS,
+  getDomFeatureLinks,
+} from '../../common/layer-extensions';
+import {HsLayerUtilsService} from '../utils/layer-utils.service';
+import {HsMapService} from '../map/map.service';
+import {HsUtilsService} from '../utils/utils.service';
+
+export type FeatureDomEventLink = {
+  handles: EventListenerOrEventListenerObject[];
+  layer: Layer<Source>;
+  domElements: Element[];
+  eventInDom: string;
+};
+
+export interface FeatureDomEventLinkDict {
+  [key: string]: FeatureDomEventLink;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HsExternalService {
+  featureLinks: FeatureDomEventLinkDict = {};
+  constructor(
+    public hsMapService: HsMapService,
+    public hsUtilsService: HsUtilsService,
+    private hsLayerUtilsService: HsLayerUtilsService
+  ) {
+    this.hsMapService.loaded().then((map) => this.init(map));
+  }
+
+  init(map: Map) {
+    for (const layer of map.getLayers().getArray()) {
+      this.layerAdded(layer as Layer<Source>);
+    }
+    map.getLayers().on('add', (e) => this.layerAdded(e.element));
+    map.getLayers().on('remove', (e) => this.layerRemoved(e.element));
+  }
+
+  layerRemoved(layer: Layer<Source>): void {
+    if (this.hsLayerUtilsService.isLayerVectorLayer(layer)) {
+      for (const key of Object.keys(this.featureLinks)) {
+        const link = this.featureLinks[key];
+        this.removeFeatureLink(link);
+        delete this.featureLinks[key];
+      }
+    }
+  }
+
+  layerAdded(layer: Layer<Source>): void {
+    if (this.hsLayerUtilsService.isLayerVectorLayer(layer)) {
+      if (getDomFeatureLinks(layer)) {
+        this.processLinks(layer);
+      }
+      layer.on('propertychange', (e) => {
+        this.hsUtilsService.debounce(
+          this.layerPropChanged(e),
+          100,
+          false,
+          this
+        );
+      });
+    }
+  }
+  layerPropChanged(e: ObjectEvent): void {
+    if (e.key == DOM_FEATURE_LINKS) {
+      this.processLinks(e.target as Layer<Source>);
+    }
+  }
+
+  private processLinks(layer: Layer<any>) {
+    const source: VectorSource<Geometry> =
+      this.hsLayerUtilsService.isLayerClustered(layer)
+        ? layer.getSource().getSource()
+        : layer.getSource();
+    for (const link of getDomFeatureLinks(layer)) {
+      const domElements = document.querySelectorAll(link.domSelector);
+      domElements.forEach((domElement) => {
+        const feature = this.getFeature(layer, source, link, domElement);
+        if (feature.getId() === undefined) {
+          feature.setId(this.hsUtilsService.generateUuid());
+        }
+        //We dont want to add handlers with the same feature and domElement twice
+        if (
+          feature &&
+          (!this.featureLinks[feature.getId()] ||
+            !this.featureLinks[feature.getId()].domElements.includes(
+              domElement
+            ))
+        ) {
+          const featureId = feature.getId();
+          //This was the only way how to unregister handlers afterwards
+          const handler = (e) => {
+            for (const action of link.actions) {
+              this.actOnFeature(action, feature, domElement, e);
+            }
+          };
+          if (!this.featureLinks[featureId]) {
+            this.featureLinks[featureId] = {
+              handles: [],
+              layer,
+              domElements: [],
+              eventInDom: link.eventInDom,
+            };
+          }
+          this.featureLinks[featureId].handles.push(handler);
+          this.featureLinks[featureId].domElements.push(domElement);
+          domElement.addEventListener(link.eventInDom, handler);
+        }
+      });
+    }
+    source.on('removefeature', (event) => {
+      for (const removedFeature of event.features) {
+        const linkage = this.featureLinks[removedFeature.getId()];
+        if (linkage) {
+          this.removeFeatureLink(linkage);
+          delete this.featureLinks[removedFeature.getId()];
+        }
+      }
+    });
+  }
+
+  private removeFeatureLink(linkage: FeatureDomEventLink) {
+    for (const handle of linkage.handles) {
+      for (const domEl of linkage.domElements) {
+        domEl.removeEventListener(linkage.eventInDom, handle);
+      }
+    }
+  }
+
+  actOnFeature(
+    action:
+      | 'zoomToExtent'
+      | 'panToCenter'
+      | 'showPopup'
+      | 'hidePopup'
+      | ((feature: Feature<Geometry>, domElement: Element, event: any) => any),
+    feature: any,
+    domElement: Element,
+    e: Event
+  ) {
+    switch (action) {
+      case 'zoomToExtent':
+        const extent = feature.getGeometry().getExtent();
+        this.hsMapService.fitExtent(extent);
+        break;
+      case 'panToCenter':
+        const center = feature.getGeometry().getCenter();
+        this.hsMapService.map.getView().setCenter(center);
+        break;
+      case 'showPopup':
+        break;
+      case 'hidePopup':
+        break;
+      default:
+        if (typeof action == 'function') {
+          action(feature, domElement, e);
+        }
+    }
+  }
+
+  private getFeature(
+    layer: Layer<Source>,
+    source: VectorSource<Geometry>,
+    link: DOMFeatureLink,
+    domElement: Element
+  ): Feature<Geometry> {
+    if (typeof link.feature == 'string') {
+      return source
+        .getFeatures()
+        .find((feature) => feature.get('id'), link.feature);
+    } else if (this.hsUtilsService.instOf(link.feature, Feature)) {
+      return link.feature as Feature<Geometry>;
+    } else if (typeof link.feature == 'function') {
+      return link.feature(layer, domElement);
+    }
+  }
+}

--- a/projects/hslayers/src/components/external/external.service.ts
+++ b/projects/hslayers/src/components/external/external.service.ts
@@ -154,21 +154,23 @@ export class HsExternalService {
     domElement: Element,
     e: Event
   ) {
-    const center = getCenter(feature.getGeometry().getExtent());
+    const extent = feature.getGeometry().getExtent();
+    const center = getCenter(extent);
+    const map = this.hsMapService.map;
     switch (action) {
       case 'zoomToExtent':
-        const extent = feature.getGeometry().getExtent();
         this.hsMapService.fitExtent(extent);
         break;
       case 'panToCenter':
-        this.hsMapService.map.getView().setCenter(center);
+        map.getView().setCenter(center);
         break;
       case 'showPopup':
         this.hsQueryPopupService.fillFeatures([feature]);
-        const pixel = this.hsMapService.map.getPixelFromCoordinate(center);
-        this.hsQueryPopupService.showPopup({pixel, map: this.hsMapService.map});
+        const pixel = map.getPixelFromCoordinate(center);
+        this.hsQueryPopupService.showPopup({pixel, map});
         break;
       case 'hidePopup':
+        this.hsQueryPopupService.closePopup();
         break;
       default:
         if (typeof action == 'function') {

--- a/projects/hslayers/src/components/external/external.service.ts
+++ b/projects/hslayers/src/components/external/external.service.ts
@@ -15,15 +15,15 @@ import {
 } from '../../common/layer-extensions';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
 import {HsMapService} from '../map/map.service';
-import {HsUtilsService} from '../utils/utils.service';
 import {HsQueryPopupService} from '../query/query-popup.service';
+import {HsUtilsService} from '../utils/utils.service';
 import {getCenter} from 'ol/extent';
 
 export type FeatureDomEventLink = {
   handles: EventListenerOrEventListenerObject[];
   layer: Layer<Source>;
   domElements: Element[];
-  eventInDom: string;
+  event: string;
 };
 
 export interface FeatureDomEventLinkDict {
@@ -115,12 +115,12 @@ export class HsExternalService {
               handles: [],
               layer,
               domElements: [],
-              eventInDom: link.eventInDom,
+              event: link.event,
             };
           }
           this.featureLinks[featureId].handles.push(handler);
           this.featureLinks[featureId].domElements.push(domElement);
-          domElement.addEventListener(link.eventInDom, handler);
+          domElement.addEventListener(link.event, handler);
         }
       });
     }
@@ -138,7 +138,7 @@ export class HsExternalService {
   private removeFeatureLink(linkage: FeatureDomEventLink) {
     for (const handle of linkage.handles) {
       for (const domEl of linkage.domElements) {
-        domEl.removeEventListener(linkage.eventInDom, handle);
+        domEl.removeEventListener(linkage.event, handle);
       }
     }
   }

--- a/projects/hslayers/src/components/external/external.service.ts
+++ b/projects/hslayers/src/components/external/external.service.ts
@@ -16,7 +16,8 @@ import {
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
 import {HsMapService} from '../map/map.service';
 import {HsUtilsService} from '../utils/utils.service';
-import { HsQueryPopupService } from '../query/query-popup.service';
+import {HsQueryPopupService} from '../query/query-popup.service';
+import {getCenter} from 'ol/extent';
 
 export type FeatureDomEventLink = {
   handles: EventListenerOrEventListenerObject[];
@@ -153,7 +154,7 @@ export class HsExternalService {
     domElement: Element,
     e: Event
   ) {
-    const center = feature.getGeometry().getCenter();
+    const center = getCenter(feature.getGeometry().getExtent());
     switch (action) {
       case 'zoomToExtent':
         const extent = feature.getGeometry().getExtent();

--- a/projects/hslayers/src/components/external/public-api.ts
+++ b/projects/hslayers/src/components/external/public-api.ts
@@ -1,0 +1,1 @@
+export * from './external.service';

--- a/projects/hslayers/src/components/query/feature/feature.component.ts
+++ b/projects/hslayers/src/components/query/feature/feature.component.ts
@@ -18,10 +18,9 @@ import {getTitle} from '../../../common/layer-extensions';
 
 @Component({
   selector: 'hs-query-feature',
-  templateUrl: './feature.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './feature.component.html'
 })
-export class HsQueryFeatureComponent implements AfterViewInit, OnDestroy {
+export class HsQueryFeatureComponent implements OnDestroy {
   @Input() feature;
   attributeName = '';
   attributeValue = '';
@@ -40,7 +39,7 @@ export class HsQueryFeatureComponent implements AfterViewInit, OnDestroy {
   selectedLayer = null;
   editType: string;
   getTitle = getTitle;
-  availableLayers;
+  availableLayers = [];
   availableLayersSubscription: any;
 
   constructor(
@@ -49,19 +48,16 @@ export class HsQueryFeatureComponent implements AfterViewInit, OnDestroy {
     public hsFeatureCommonService: HsFeatureCommonService,
     public hsLayerUtilsService: HsLayerUtilsService,
     public cd: ChangeDetectorRef
-  ) {}
-
-  ngAfterViewInit(): void {
-    if (!this.olFeature()) {
-      //Feature from WMS getFeatureInfo
-      return;
-    }
-    const featureLayer = this.hsMapService.getLayerForFeature(this.olFeature());
+  ) {
     this.availableLayersSubscription =
-      this.hsFeatureCommonService.availableLayer$.subscribe((layers) => {
-        this.availableLayers = layers.filter((layer) => layer != featureLayer);
-        this.cd.markForCheck();
-      });
+    this.hsFeatureCommonService.availableLayer$.subscribe((layers) => {
+      if (!this.olFeature()) {
+        //Feature from WMS getFeatureInfo
+        return;
+      }
+      const featureLayer = this.hsMapService.getLayerForFeature(this.olFeature());
+      this.availableLayers = layers.filter((layer) => layer != featureLayer);
+    });
   }
 
   ngOnDestroy(): void {
@@ -69,7 +65,7 @@ export class HsQueryFeatureComponent implements AfterViewInit, OnDestroy {
   }
 
   olFeature(): Feature<Geometry> {
-    return this.feature.feature;
+    return this.feature?.feature;
   }
 
   isFeatureRemovable(): boolean {

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -6,6 +6,7 @@ import {HsConfig} from './config.service';
 import {HsDrawComponent} from './components/draw/draw.component';
 import {HsDrawToolbarComponent} from './components/draw/draw-toolbar/draw-toolbar.component';
 // import {HsFeatureInfoComponent} from './components/query/query-popup-feature/feature-widgets/feature-info.component';
+import {HsExternalService} from './components/external/external.service';
 import {HsFeatureTableComponent} from './components/feature-table/feature-table.component';
 import {HsGeolocationComponent} from './components/geolocation/geolocation.component';
 import {HsInfoComponent} from './components/info/info.component';
@@ -32,6 +33,7 @@ import {HsStylerComponent} from './components/styles/styler.component';
 import {HsToolbarComponent} from './components/toolbar/toolbar.component';
 import {HsToolbarPanelContainerService} from './components/toolbar/toolbar-panel-container.service';
 import {HsTripPlannerComponent} from './components/trip-planner/trip-planner.component';
+import {HsQueryPopupWidgetContainerService} from './components/query/query-popup-widget-container.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -49,7 +51,9 @@ export class HslayersComponent implements OnInit {
     private HsLayerManagerService: HsLayerManagerService,
     private hsToolbarPanelContainerService: HsToolbarPanelContainerService,
     private hsQueryPopupService: HsQueryPopupService,
-    private HsMapSwipeService: HsMapSwipeService
+    private HsMapSwipeService: HsMapSwipeService,
+    private hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
+    hsExternalService: HsExternalService
   ) {}
 
   /**

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.html
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.html
@@ -1,2 +1,3 @@
 <a id="poly1">Polygon 1</a>
+<a id="poly2">Polygon 2</a>
 <hslayers></hslayers>

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.html
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.html
@@ -1,1 +1,2 @@
+<a id="poly1">Polygon 1</a>
 <hslayers></hslayers>

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -212,6 +212,7 @@ export class HslayersAppComponent {
         cluster: false,
         inlineLegend: true,
         popUp: {
+          
           attributes: ['name'],
           widgets: ['layer-name', 'clear-layer'],
         },
@@ -337,7 +338,7 @@ export class HslayersAppComponent {
         {name: 'warning', url: '/assets/icons/warning.svg'},
         {name: 'wifi', url: '/assets/icons/wifi8.svg'},
       ],
-      // popUpDisplay: 'hover',
+      popUpDisplay: 'hover',
       default_layers: [
         new Tile({
           source: new OSM(),

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -63,6 +63,7 @@ export class HslayersAppComponent {
           },
           'properties': {
             'name': 'Poly 3',
+            'id': 'poly1',
             'population': Math.floor(Math.random() * 100000),
           },
         },
@@ -372,6 +373,38 @@ export class HslayersAppComponent {
             }),
           }),
           source: new VectorSource({features}),
+        }),
+        new VectorLayer({
+          properties: {
+            title: 'Polygons',
+            synchronize: false,
+            cluster: false,
+            inlineLegend: true,
+            popUp: {
+              attributes: ['name'],
+              widgets: ['layer-name', 'clear-layer'],
+            },
+            domFeatureLinks: [
+              {
+                domSelector: '#poly1',
+                feature: 'poly1',
+                eventInDom: 'mouseover',
+                actions: ['zoomToExtent'],
+              },
+            ],
+            editor: {
+              editable: true,
+              defaultAttributes: {
+                name: 'New polygon',
+                description: 'none',
+              },
+            },
+            sld: polygonSld,
+            path: 'User generated',
+          },
+          source: new VectorSource({
+            features: new GeoJSON().readFeatures(geojsonObject),
+          }),
         }),
         new VectorLayer({
           properties: {

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -83,6 +83,7 @@ export class HslayersAppComponent {
           },
           'properties': {
             'name': 'Poly 2',
+            'id': 'poly2',
             'population': Math.floor(Math.random() * 100000),
           },
         },
@@ -390,6 +391,12 @@ export class HslayersAppComponent {
                 feature: 'poly1',
                 eventInDom: 'mouseover',
                 actions: ['zoomToExtent'],
+              },
+              {
+                domSelector: '#poly2',
+                feature: 'poly2',
+                eventInDom: 'mouseover',
+                actions: ['showPopup'],
               },
             ],
             editor: {

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -390,13 +390,13 @@ export class HslayersAppComponent {
               {
                 domSelector: '#poly1',
                 feature: 'poly1',
-                eventInDom: 'mouseover',
+                event: 'mouseover',
                 actions: ['zoomToExtent'],
               },
               {
                 domSelector: '#poly2',
                 feature: 'poly2',
-                eventInDom: 'mouseover',
+                event: 'mouseover',
                 actions: ['showPopup'],
               },
             ],


### PR DESCRIPTION
## Description

Create a layer config property which defines what should happen to
a feature when user moves mouse over or clicks on a element outside hslayers.
The elements can be found for each feature by CSS selectors. Full config:
```
domFeatureLinks: [
              {
                domSelector: '#poly1',
                feature: 'poly1',
                event: 'mouseover',
                actions: ['zoomToExtent'],
              },
            ]
```
## Related issues or pull requests

fixes #2428

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
