### PR TITLE
fix: Map swipe disabled by default (Issue-2476)

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -845,11 +845,9 @@
     "horizontalSwipe": "Vodorovný posuvník",
     "leftSide": "Levá strana",
     "rightSide": "Pravá strana",
-    "swipeMapWarning": "Varování půlené mapy",
     "bottom": "Spodní část",
     "top": "Horní část",
     "resetSlider": "Vrátit posuvník",
-    "initialSwipeRightNot": "Výchozí vrstvy pro pravou stranu půlené mapy nebyly nastaveny",
     "dndLayers": "Přetahujte vrstvy mezi sloupci pro přesun do opačné poloviny mapy",
     "disableSwipe": ""
   }

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -844,11 +844,9 @@
   "MAP_SWIPE": {
     "bottom": "Bottom",
     "horizontalSwipe": "Horizontal swipe",
-    "initialSwipeRightNot": "Initial layers for the right side of map swipe have not been set",
     "leftSide": "Left side",
     "resetSlider": "Reset slider",
     "rightSide": "Right side",
-    "swipeMapWarning": "Swipe map warning",
     "top": "Top",
     "dndLayers": "Use drag&drop to move layers between the map sides!",
     "verticalSwipe": "Vertical swipe",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -844,11 +844,9 @@
   "MAP_SWIPE": {
     "bottom": "Apakša",
     "horizontalSwipe": "Horizontālā vilkšana",
-    "initialSwipeRightNot": "Sākotnējie kartes vilkšanas labās puses slāņi nav iestatīti",
     "leftSide": "Kreisā puse",
     "resetSlider": "Atiestatīt slīdni",
     "rightSide": "Labā puse",
-    "swipeMapWarning": "Pārvelkamās kartes brīdinājums",
     "top": "Augša",
     "dndLayers": "Izmantojiet vilkšanu un nomešanu, lai pārvietotu slāņus starp kartes pusēm",
     "disableSwipe": "Atspējot vilkšanu",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -848,8 +848,6 @@
     "leftSide": "Ľavá strana",
     "resetSlider": "Resetovať posúvač",
     "rightSide": "Pravá strana",
-    "top": "Vrchná časť",
-    "swipeMapWarning": "Upozornenie nástroja posuvnej mapy",
-    "initialSwipeRightNot": "Počiatočné vrstvy pre pravú stranu posuvnej mapy neboli definované"
+    "top": "Vrchná časť"
   }
 }

--- a/projects/hslayers/src/components/map-swipe/map-swipe.component.html
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.component.html
@@ -4,6 +4,20 @@
     <div class="alert alert-info ps-2" role="alert">
       {{'MAP_SWIPE.dndLayers' | translate}}
     </div>
+    <div class="btn-group align-items-center d-flex justify-content-between" style="margin-bottom: 1rem;" data-toggle="buttons">
+      <button class="btn btn-sm btn-secondary" type="button" (click)="hsMapSwipeService.setOrientation()"
+              [disabled]="!hsMapSwipeService.swipeControlActive">
+        {{getOrientationButtonString() | translate}}
+      </button>
+      <button class="btn btn-sm btn-secondary" type="button" (click)="resetSwipePos()"
+              [disabled]="!hsMapSwipeService.swipeControlActive">
+        {{'MAP_SWIPE.resetSlider' | translate}}
+      </button>
+      <button class="btn btn-sm btn-primary" type="button" (click)="hsMapSwipeService.setControl()"
+              [ngClass]="hsMapSwipeService.swipeControlActive ? 'active' : ''">
+        {{getEnabledButtonString() | translate}}
+      </button>
+    </div>
     <div *ngIf="hsMapSwipeService.layersAvailable() && hsMapSwipeService.swipeControlActive" class="pt-1">
       <table class="table table-sm table-striped table-borderless p-1" style="table-layout: fixed;">
         <thead>
@@ -21,18 +35,18 @@
         <tbody>
           <tr>
             <td cdkDropList #leftList="cdkDropList" [cdkDropListConnectedTo]="[rightList]"
-              [cdkDropListData]="hsMapSwipeService.layers" (cdkDropListDropped)="drop($event)">
+                [cdkDropListData]="hsMapSwipeService.layers" (cdkDropListDropped)="drop($event)">
               <div class="list-group-item p-2" [ngClass]="{'activeLayer': layer.active}"
-                *ngFor="let layer of hsMapSwipeService.layers" cdkDrag>
+                   *ngFor="let layer of hsMapSwipeService.layers" cdkDrag>
                 <div class="hs-lm-item-title" style="word-break:break-all; cursor:move">
                   <p class="m-0">{{hsLayerUtilsService.translateTitle(layer.title)}}</p>
                 </div>
               </div>
             </td>
             <td cdkDropList #rightList="cdkDropList" [cdkDropListConnectedTo]="[leftList]"
-              [cdkDropListData]="hsMapSwipeService.rightLayers" (cdkDropListDropped)="drop($event, true)">
+                [cdkDropListData]="hsMapSwipeService.rightLayers" (cdkDropListDropped)="drop($event, true)">
               <div class="list-group-item p-2" [ngClass]="{'activeLayer': layer.active}"
-                *ngFor="let layer of hsMapSwipeService.rightLayers" cdkDrag>
+                   *ngFor="let layer of hsMapSwipeService.rightLayers" cdkDrag>
                 <div class="hs-lm-item-title" style="word-break:break-all; cursor:move">
                   <p class="m-0">{{hsLayerUtilsService.translateTitle(layer.title)}}</p>
                 </div>
@@ -41,16 +55,6 @@
           </tr>
         </tbody>
       </table>
-    </div>
-    <div class="btn-group align-items-center d-flex justify-content-between" data-toggle="buttons">
-      <button class="btn btn-sm btn-secondary" type="button" (click)="hsMapSwipeService.setOrientation()"
-        [disabled]="!hsMapSwipeService.swipeControlActive">{{getOrientationButtonString() | translate}}</button>
-      <button class="btn btn-sm btn-secondary" type="button" (click)="resetSwipePos()"
-        [disabled]="!hsMapSwipeService.swipeControlActive">{{'MAP_SWIPE.resetSlider' |
-        translate}}</button>
-      <button class="btn btn-sm btn-primary" type="button" (click)="hsMapSwipeService.setControl()"
-        [ngClass]="hsMapSwipeService.swipeControlActive ? 'active' : ''">{{getEnabledButtonString() |
-        translate}}</button>
     </div>
   </div>
 </div>

--- a/projects/hslayers/src/components/map-swipe/map-swipe.component.html
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.component.html
@@ -4,11 +4,11 @@
     <div class="alert alert-info ps-2" role="alert">
       {{'MAP_SWIPE.dndLayers' | translate}}
     </div>
-    <div *ngIf="hsMapSwipeService.layersAvailable() && swipeControlEnabled" class="pt-1">
+    <div *ngIf="hsMapSwipeService.layersAvailable() && hsMapSwipeService.swipeControlActive" class="pt-1">
       <table class="table table-sm table-striped table-borderless p-1" style="table-layout: fixed;">
         <thead>
           <tr style="text-align: center;">
-            <ng-container *ngIf="orientation === 'vertical'; else topDownLabels">
+            <ng-container *ngIf="hsMapSwipeService.orientation === 'vertical'; else topDownLabels">
               <th>{{'MAP_SWIPE.leftSide' | translate}}</th>
               <th>{{'MAP_SWIPE.rightSide' | translate}}</th>
             </ng-container>
@@ -43,13 +43,14 @@
       </table>
     </div>
     <div class="btn-group align-items-center d-flex justify-content-between" data-toggle="buttons">
-      <button class="btn btn-sm btn-secondary" type="button" (click)="setOrientation()"
-        [disabled]="!swipeControlEnabled">{{getOrientationButtonString() | translate}}</button>
+      <button class="btn btn-sm btn-secondary" type="button" (click)="hsMapSwipeService.setOrientation()"
+        [disabled]="!hsMapSwipeService.swipeControlActive">{{getOrientationButtonString() | translate}}</button>
       <button class="btn btn-sm btn-secondary" type="button" (click)="resetSwipePos()"
-        [disabled]="!swipeControlEnabled">{{'MAP_SWIPE.resetSlider' |
+        [disabled]="!hsMapSwipeService.swipeControlActive">{{'MAP_SWIPE.resetSlider' |
         translate}}</button>
-      <button class="btn btn-sm btn-primary" type="button" (click)="setControlStatus()"
-        [ngClass]="swipeControlEnabled ? 'active' : ''">{{getEnabledButtonString() | translate}}</button>
+      <button class="btn btn-sm btn-primary" type="button" (click)="hsMapSwipeService.setControl()"
+        [ngClass]="hsMapSwipeService.swipeControlActive ? 'active' : ''">{{getEnabledButtonString() |
+        translate}}</button>
     </div>
   </div>
 </div>

--- a/projects/hslayers/src/components/map-swipe/map-swipe.component.scss
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.component.scss
@@ -1,24 +1,31 @@
 .activeLayer {
-    background-color: rgba(0, 0, 0, 0.2);
-  }
-  .cdk-drag-placeholder {
-    background-color: rgba(0, 0, 0, 0.24);
-    color: white;
-  }
-  .cdk-drag-preview {
-     box-sizing: border-box;
-    background-color: rgba(185, 185, 185, 0.75);
-    border: 1px solid rgba(185, 185, 185, 1);;
-    overflow: hidden;
-    color: transparent;
-    box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
-              0 8px 10px 1px rgba(0, 0, 0, 0.14),
-              0 3px 14px 2px rgba(0, 0, 0, 0.12);
-  }
-  .cdk-drag-animating {
-    transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-  }
+  background-color: rgba(0, 0, 0, 0.2);
+}
 
-  .list-group.cdk-drop-list-dragging .list-group-item:not(.cdk-drag-placeholder) {
+.cdk-drag-placeholder {
+  background-color: rgba(0, 0, 0, 0.24);
+  color: white;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  background-color: rgba(185, 185, 185, 0.75);
+  border: 1px solid rgba(185, 185, 185, 1);
+  overflow: hidden;
+  color: transparent;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 
+            0 8px 10px 1px rgba(0, 0, 0, 0.14), 
+            0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+td.cdk-drop-list {
+  vertical-align: top;
+}
+
+.list-group.cdk-drop-list-dragging .list-group-item:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/projects/hslayers/src/components/map-swipe/map-swipe.component.ts
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.component.ts
@@ -25,16 +25,13 @@ export class HsMapSwipeComponent
   implements OnDestroy
 {
   private ngUnsubscribe = new Subject<void>();
-  orientation = 'vertical';
-  swipeControlEnabled = true;
-  orientationVertical = true;
   constructor(
     public hsLayoutService: HsLayoutService,
     public hsSidebarService: HsSidebarService,
     public hsLanguageService: HsLanguageService,
     public hsMapSwipeService: HsMapSwipeService,
     public hsLayerUtilsService: HsLayerUtilsService, //In template
-    public hsLayerShiftingService: HsLayerShiftingService
+    public hsLayerShiftingService: HsLayerShiftingService,
   ) {
     super(hsLayoutService);
     hsSidebarService.buttons.push({
@@ -52,19 +49,10 @@ export class HsMapSwipeComponent
   name = 'mapSwipe';
 
   /**
-   * Set swipe control orientation
-   */
-  setOrientation(): void {
-    this.orientationVertical = !this.orientationVertical;
-    this.orientation = this.orientationVertical ? 'vertical' : 'horizontal';
-    this.hsMapSwipeService.swipeCtrl.set('orientation', this.orientation);
-  }
-
-  /**
    * Return label for button changing map swipe state from enabled to disabled
    */
   getEnabledButtonString(): string {
-    if (this.swipeControlEnabled) {
+    if (this.hsMapSwipeService.swipeControlActive) {
       return 'MAP_SWIPE.disableSwipe';
     } else {
       return 'MAP_SWIPE.enableSwipe';
@@ -75,20 +63,13 @@ export class HsMapSwipeComponent
    * Return label for button changing swipe orientation from horizontal swipe to vertical swipe
    */
   getOrientationButtonString(): string {
-    if (this.orientationVertical) {
+    if (this.hsMapSwipeService.orientationVertical) {
       return 'MAP_SWIPE.horizontalSwipe';
     } else {
       return 'MAP_SWIPE.verticalSwipe';
     }
   }
 
-  /**
-   * Set map swipe control status enabled/disabled
-   */
-  setControlStatus(): void {
-    this.swipeControlEnabled = !this.swipeControlEnabled;
-    this.hsMapSwipeService.setControl(this.swipeControlEnabled);
-  }
   /**
    * Reset swipe slider position to default
    */

--- a/projects/hslayers/src/components/map-swipe/map-swipe.service.ts
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.service.ts
@@ -21,7 +21,6 @@ export class HsMapSwipeService {
   swipeCtrl: SwipeControl;
   rightLayers: LayerListItem[] = [];
   layers: LayerListItem[] = [];
-  initialRight: Layer<Source>[] = [];
   movingRight: boolean;
   wasMoved: boolean;
   swipeControlActive: boolean;
@@ -36,10 +35,10 @@ export class HsMapSwipeService {
     public hsLayerManagerService: HsLayerManagerService
   ) {
     this.swipeControlActive =
-      this.hsConfig?.mapSwipe?.mapSwipeActiveOnStart ?? false;
+      this.hsConfig?.componentsEnabled?.mapSwipe ?? false;
     this.orientation =
-      this.hsConfig?.mapSwipe?.mapSwipeOrientation ?? 'vertical';
-    this.initialRight = this.hsConfig?.mapSwipe?.initialSwipeRight ?? [];
+      this.hsConfig?.mapSwipeOptions?.orientation ?? 'vertical';
+
     if (this.orientation !== 'vertical') {
       this.orientationVertical = false;
     }
@@ -120,10 +119,7 @@ export class HsMapSwipeService {
       this.layers.filter((l) => l.layer == layer.layer).length == 0 &&
       this.rightLayers.filter((l) => l.layer == layer.layer).length == 0
     ) {
-      if (
-        this.initialRight?.includes(layer.layer) ||
-        getSwipeSide(layer.layer) === 2
-      ) {
+      if (getSwipeSide(layer.layer) === 2) {
         this.swipeCtrl.addLayer(layer, true);
         this.rightLayers.push(layer);
       } else {
@@ -213,19 +209,6 @@ export class HsMapSwipeService {
       return;
     }
     this.fillExplicitLayers();
-    if (this.initialRight?.length == 0) {
-      this.hsToastService.createToastPopupMessage(
-        'MAP_SWIPE.swipeMapWarning',
-        'MAP_SWIPE.initialSwipeRightNot'
-      );
-    } else {
-      const initialLayers = this.hsLayerShiftingService.layersCopy.filter((l) =>
-        this.initialRight?.includes(l.layer)
-      );
-      this.rightLayers = this.rightLayers.concat(
-        initialLayers.filter((l) => !this.rightLayers.includes(l))
-      );
-    }
     this.layers = this.layers.concat(
       this.hsLayerShiftingService.layersCopy
         .filter((l) => !this.layers.includes(l))

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -19,9 +19,7 @@ export type SymbolizerIcon = {
 };
 
 export type MapSwipeOptions = {
-  initialSwipeRight?: Layer<Source>[];
-  mapSwipeActiveOnStart?: boolean;
-  mapSwipeOrientation?: 'vertical' | 'horizontal';
+  orientation?: 'vertical' | 'horizontal';
 };
 
 @Injectable()
@@ -43,6 +41,7 @@ export class HsConfig {
     defaultViewButton: true,
     mapControls: true,
     basemapGallery: false,
+    mapSwipe: false,
   };
   clusteringDistance?: number;
   mapInteractionsEnabled?: boolean;
@@ -98,7 +97,7 @@ export class HsConfig {
       url: string;
     };
   };
-  mapSwipe?: MapSwipeOptions = {};
+  mapSwipeOptions?: MapSwipeOptions = {};
   status_manager_url?: string;
   permalinkLocation?: {origin: string; pathname: string};
   social_hashtag?: string;

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -18,6 +18,12 @@ export type SymbolizerIcon = {
   url: string;
 };
 
+export type MapSwipeOptions = {
+  initialSwipeRight?: Layer<Source>[];
+  mapSwipeActiveOnStart?: boolean;
+  mapSwipeOrientation?: 'vertical' | 'horizontal';
+};
+
 @Injectable()
 export class HsConfig {
   private defaultSymbolizerIcons? = [
@@ -92,9 +98,7 @@ export class HsConfig {
       url: string;
     };
   };
-  initialSwipeRight?: Layer<Source>[];
-  mapSwipeActiveOnStart?: boolean = false;
-  mapSwipeOrientation?: 'vertical' | 'horizontal';
+  mapSwipe?: MapSwipeOptions = {};
   status_manager_url?: string;
   permalinkLocation?: {origin: string; pathname: string};
   social_hashtag?: string;

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -93,6 +93,7 @@ export class HsConfig {
     };
   };
   initialSwipeRight?: Layer<Source>[];
+  mapSwipeActiveOnStart?: boolean = false;
   mapSwipeOrientation?: 'vertical' | 'horizontal';
   status_manager_url?: string;
   permalinkLocation?: {origin: string; pathname: string};

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -278,6 +278,7 @@ export class HslayersAppComponent {
       },
       initialSwipeRight: [polygons],
       mapSwipeOrientation: 'vertical',
+      mapSwipeActiveOnStart: true,
       componentsEnabled: {
         basemapGallery: true,
       },

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -22,7 +22,7 @@ export class HslayersAppComponent {
   constructor(
     public HsConfig: HsConfig,
     private HsEventBusService: HsEventBusService,
-    private HsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
+    private HsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService
   ) {
     const count = 200;
     const features = new Array(count);
@@ -276,9 +276,11 @@ export class HslayersAppComponent {
         tripPlanner: true,
         mapSwipe: true,
       },
-      initialSwipeRight: [polygons],
-      mapSwipeOrientation: 'vertical',
-      mapSwipeActiveOnStart: true,
+      mapSwipe: {
+        initialSwipeRight: null,
+        mapSwipeOrientation: 'vertical',
+        mapSwipeActiveOnStart: true,
+      },
       componentsEnabled: {
         basemapGallery: true,
       },

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -237,6 +237,7 @@ export class HslayersAppComponent {
       properties: {
         title: 'Optical satellite basemap',
         from_composition: true,
+        swipeSide: 2,
         dimensions: {
           time: {
             value: '2020-11-20',
@@ -276,13 +277,12 @@ export class HslayersAppComponent {
         tripPlanner: true,
         mapSwipe: true,
       },
-      mapSwipe: {
-        initialSwipeRight: null,
-        mapSwipeOrientation: 'vertical',
-        mapSwipeActiveOnStart: true,
+      mapSwipeOptions: {
+        orientation: 'vertical',
       },
       componentsEnabled: {
         basemapGallery: true,
+        mapSwipe: true,
       },
       enabledLanguages: 'sk, en',
       assetsPath: 'assets',


### PR DESCRIPTION
## Description

Set map swipe disabled by default and added mapSwipe to componentsEnabled, to enable it.
Created mapSwipeOptions object for setting swipe control orientation and potential place for future config addons.
Removed initialSwipeRight in favour of layer properties swipeSide property.

## Related issues or pull requests

closes #2476 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
