### PR TITLE
WMS layers sublayers should store array with layer names (Issue-2496)

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -44,7 +44,7 @@ const QUERY_FILTER = 'queryFilter';
 const QUERYABLE = 'queryable';
 const REMOVABLE = 'removable';
 const SHOW_IN_LAYER_MANAGER = 'showInLayerManager';
-const SUB_LAYERS = 'subLayers';
+const SUB_LAYERS = ['subLayers', 'sublayers'];
 const SWIPE_RIGHT = 'swipeRight';
 const THUMBNAIL = 'thumbnail';
 const TITLE = 'title';
@@ -560,7 +560,7 @@ export function getShowInLayerManager(layer: Layer<Source>): boolean {
  * @param subLayers - String of all possible WMS layers sub-layer names separated by comma
  */
 export function setSubLayers(layer: Layer<Source>, subLayers: string): void {
-  layer.set(SUB_LAYERS, subLayers);
+  layer.set(SUB_LAYERS[0], subLayers);
 }
 
 /**
@@ -568,7 +568,7 @@ export function setSubLayers(layer: Layer<Source>, subLayers: string): void {
  * @param layer -
  */
 export function getSubLayers(layer: Layer<Source>): string {
-  return layer.get(SUB_LAYERS);
+  return layer.get(SUB_LAYERS[0]) ?? layer.get(SUB_LAYERS[1]);
 }
 
 export function setThumbnail(layer: Layer<Source>, thumbnail: string): void {

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -6,15 +6,13 @@ import {HsLaymanLayerDescriptor} from '../components/save-map/layman-layer-descr
 import {Source} from 'ol/source';
 import {accessRightsModel} from '../components/add-data/common/access-rights.model';
 
-const TITLE = 'title';
-const NAME = 'name';
 const ABSTRACT = 'abstract';
 const ACCESS_RIGHTS = 'access_rights';
 const ACTIVE = 'active';
 const ATTRIBUTION = 'attribution';
 const AUTO_LEGEND = 'autoLegend';
-const CAPABILITIES = 'capabilities';
 const BASE = 'base';
+const CAPABILITIES = 'capabilities';
 const CLUSTER = 'cluster';
 const CUSTOM_INFO_TEMPLATE = 'customInfoTemplate';
 const DEFINITION = 'definition';
@@ -27,30 +25,32 @@ const FEATURE_INFO_LANG = 'featureInfoLang';
 const FROM_COMPOSITION = 'fromComposition';
 const GET_FEATURE_INFO_TARGET = 'getFeatureInfoTarget';
 const HS_LAYMAN_SYNCHRONIZING = 'hsLaymanSynchronizing';
+const HS_QML = 'qml';
+const HS_SLD = 'sld';
 const INFO_FORMAT = 'infoFormat';
 const INLINE_LEGEND = 'inlineLegend';
 const LAYMAN_LAYER_DESCRIPTOR = 'laymanLayerDescriptor';
+const LEGENDS = 'legends';
 const MAX_RESOLUTION_DENOMINATOR = 'maxResolutionDenominator';
 const METADATA = 'metadata';
 const MINIMUM_TERRAIN_LEVEL = 'minimumTerrainLevel';
+const NAME = 'name';
 const ON_FEATURE_SELECTED = 'onFeatureSelected';
 const PATH = 'path';
 const POPUP = 'popUp';
 const POPUP_CLASS = 'popupClass';
-const QUERYABLE = 'queryable';
 const QUERY_CAPABILITIES = 'queryCapabilities';
 const QUERY_FILTER = 'queryFilter';
+const QUERYABLE = 'queryable';
 const REMOVABLE = 'removable';
 const SHOW_IN_LAYER_MANAGER = 'showInLayerManager';
-const HS_SLD = 'sld';
-const HS_QML = 'qml';
-const THUMBNAIL = 'thumbnail';
-const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
-const LEGENDS = 'legends';
-const SUB_LAYERS = 'sublayers';
-const WORKSPACE = 'workspace';
-const WFS_URL = 'wfsUrl';
+const SUB_LAYERS = 'subLayers';
 const SWIPE_RIGHT = 'swipeRight';
+const THUMBNAIL = 'thumbnail';
+const TITLE = 'title';
+const VIRTUAL_ATTRIBUTES = 'virtualAttributes';
+const WFS_URL = 'wfsUrl';
+const WORKSPACE = 'workspace';
 
 export type Attribution = {
   onlineResource?: string;
@@ -557,10 +557,10 @@ export function getShowInLayerManager(layer: Layer<Source>): boolean {
 /**
  * Set list of all possible sub-layers for WMS
  * @param layer -
- * @param sublayers - String of all possible WMS layers sub-layer names separated by comma
+ * @param subLayers - String of all possible WMS layers sub-layer names separated by comma
  */
-export function setSubLayers(layer: Layer<Source>, sublayers: string): void {
-  layer.set(SUB_LAYERS, sublayers);
+export function setSubLayers(layer: Layer<Source>, subLayers: string): void {
+  layer.set(SUB_LAYERS, subLayers);
 }
 
 /**

--- a/projects/hslayers/src/components/add-data/common/common.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common.service.ts
@@ -147,7 +147,7 @@ export class HsAddDataCommonService {
   /**
    * @param service -
    */
-  getSublayerNames(service): string[] {
+  getSublayerNames(service): string {
     if (service.Layer) {
       return service.Layer.map((l) => {
         let tmp: string[] = [];
@@ -158,10 +158,10 @@ export class HsAddDataCommonService {
           const children = this.getSublayerNames(l);
           tmp = tmp.concat(children);
         }
-        return tmp;
+        return tmp.join(',');
       });
     } else {
-      return [];
+      return '';
     }
   }
 }

--- a/projects/hslayers/src/components/add-data/common/common.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common.service.ts
@@ -147,15 +147,16 @@ export class HsAddDataCommonService {
   /**
    * @param service -
    */
-  getSublayerNames(service): any[] {
+  getSublayerNames(service): string[] {
     if (service.Layer) {
       return service.Layer.map((l) => {
-        const tmp: any = {};
+        let tmp: string[] = [];
         if (l.Name) {
-          tmp.name = l.Name;
+          tmp.push(l.Name);
         }
         if (l.Layer) {
-          tmp.children = this.getSublayerNames(l);
+          const children = this.getSublayerNames(l);
+          tmp = tmp.concat(children);
         }
         return tmp;
       });

--- a/projects/hslayers/src/components/add-data/url/add-data-url-base.component.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-url-base.component.ts
@@ -6,7 +6,7 @@ import {
   OnInit,
 } from '@angular/core';
 
-import {Subject} from 'rxjs/internal/Subject';
+import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
 import {HsAddDataCommonService} from '../common/common.service';

--- a/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
+++ b/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
@@ -136,7 +136,7 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
           queryFormat: this.data.query_format,
           tileSize: this.data.tile_size,
           crs: this.data.srs,
-          subLayers: null,
+          subLayers: '',
         }
       );
     } else {

--- a/projects/hslayers/src/components/add-data/url/types/layer-options.type.ts
+++ b/projects/hslayers/src/components/add-data/url/types/layer-options.type.ts
@@ -8,6 +8,6 @@ export type addLayerOptions = {
   queryFormat?: string;
   sld?: string;
   qml?: string;
-  subLayers?: any[];
+  subLayers?: string;
   tileSize?;
 };

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -345,7 +345,7 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
           queryFormat: this.data.query_format,
           tileSize: this.data.tile_size,
           crs: this.data.srs,
-          subLayers: null,
+          subLayers: '',
         }
       );
     } else {

--- a/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
@@ -126,10 +126,9 @@ export class HsLayerManagerMetadataService {
                 sublayer.MaxScaleDenominator
               );
             if (maxScale < sublayer.MaxScaleDenominator) {
-              maxScale =
-                this.HsLayerUtilsService.calculateResolutionFromScale(
-                  sublayer.MaxScaleDenominator
-                );
+              maxScale = this.HsLayerUtilsService.calculateResolutionFromScale(
+                sublayer.MaxScaleDenominator
+              );
             }
           } else if (!sublayer.maxResolution) {
             sublayer.maxResolution = maxScale;


### PR DESCRIPTION
## Description
Made small changes fixing getSubLayers by getting subLayers property instead of sublayers. When adding WMS services subLayers will store sublayer names only.

## Related issues or pull requests
closes #2496 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
