### PR TITLE
fix: Setting of vector layer definition

### DIFF
--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -95,7 +95,7 @@ export class HsAddDataVectorService {
         TODO: Should have set definition property with protocol inside 
         so layer synchronizer would know if to sync 
         */
-        if (!this.hsUtilsService.undefineEmptyString(url) === undefined) {
+        if (this.hsUtilsService.undefineEmptyString(url) !== undefined) {
           setDefinition(lyr, {
             format: 'hs.format.WFS',
             url: url,


### PR DESCRIPTION
## Description

Layers  with url (those that are supposed to be synced with layman) were falling into else block thus not working properly

![image](https://user-images.githubusercontent.com/44566616/149166260-b1a51a4e-b06c-4238-976b-3d8e7bd48775.png)

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
