### PR TITLE
perf: Remove usage of panelSpaceWidth function

### DIFF
--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -85,7 +85,7 @@ export class HsLayoutService {
    */
   initializedOnce = false;
   /**
-   * Whether the app has been initialized already once. 
+   * Whether the app has been initialized already once.
    * Need this to not add panels wtice when NgRouter is used
    * @public
    * @default false
@@ -323,7 +323,7 @@ export class HsLayoutService {
       ows: 700,
       composition_browser: 550,
       addData: 700,
-      mapSwipe: 550
+      mapSwipe: 550,
     };
     const layoutWidth = this.layoutElement.clientWidth;
     Object.assign(panelWidths, this.HsConfig.panelWidths);

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -14,6 +14,7 @@ import {HsPanelComponent} from './panel-component.interface';
 import {HsPanelContainerServiceInterface} from './panel-container.service.interface';
 import {HsPanelHostDirective} from './panel-host.directive';
 import {HsPanelItem} from './panel-item';
+import {HsConfig} from '../../../config.service';
 
 @Component({
   selector: 'hs-panel-container',
@@ -30,7 +31,10 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
   @Input() panelObserver?: ReplaySubject<HsPanelItem>;
   interval: any;
   private ngUnsubscribe = new Subject<void>();
-  constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
+  constructor(
+    private componentFactoryResolver: ComponentFactoryResolver,
+    private HsConfig: HsConfig
+  ) {}
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
@@ -57,6 +61,14 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
   }
 
   loadPanel(panelItem: HsPanelItem): void {
+    const panelWidths = {
+      default: 425,
+      ows: 700,
+      composition_browser: 550,
+      addData: 700,
+      mapSwipe: 550,
+    };
+
     const componentFactory =
       this.componentFactoryResolver.resolveComponentFactory(
         panelItem.component
@@ -65,6 +77,16 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     const componentRef = viewContainerRef.createComponent(componentFactory);
     const componentRefInstance = <HsPanelComponent>componentRef.instance;
     componentRefInstance.viewRef = componentRef.hostView;
+    /**
+     * Assign panel width class to a component host first child
+     * Used to define panelSpace panel width
+     */
+    Object.assign(panelWidths, this.HsConfig.panelWidths);
+    const panelWidth =
+      panelWidths[componentRefInstance.name] || panelWidths.default;
+    componentRef.location.nativeElement.children[0].classList.add(
+      `hs-panelWidth-${Math.round(panelWidth / 25) * 25}`
+    );
     if (componentRefInstance.data == undefined) {
       componentRefInstance.data = panelItem.data || this.data;
     }

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -10,11 +10,11 @@ import {
 import {ReplaySubject, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
+import {HsConfig} from '../../../config.service';
 import {HsPanelComponent} from './panel-component.interface';
 import {HsPanelContainerServiceInterface} from './panel-container.service.interface';
 import {HsPanelHostDirective} from './panel-host.directive';
 import {HsPanelItem} from './panel-item';
-import {HsConfig} from '../../../config.service';
 
 @Component({
   selector: 'hs-panel-container',
@@ -84,9 +84,13 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     Object.assign(panelWidths, this.HsConfig.panelWidths);
     const panelWidth =
       panelWidths[componentRefInstance.name] || panelWidths.default;
-    componentRef.location.nativeElement.children[0].classList.add(
-      `hs-panelWidth-${Math.round(panelWidth / 25) * 25}`
-    );
+    setTimeout(() => {
+      //Without timeout componentRef.location.nativeElement could containe only placeholder <!--container--> until the real content is loaded
+      componentRef.location.nativeElement.children[0].classList.add(
+        `hs-panelWidth-${Math.round(panelWidth / 25) * 25}`
+      );
+    }, 0);
+
     if (componentRefInstance.data == undefined) {
       componentRefInstance.data = panelItem.data || this.data;
     }

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -87,7 +87,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       //Without timeout componentRef.location.nativeElement could containe only placeholder <!--container--> until the real content is loaded
       componentRef.location.nativeElement.children[0].classList.add(
-        `hs-panelWidth-${Math.round(panelWidth / 25) * 25}`
+        `hs-panel-width-${Math.round(panelWidth / 25) * 25}`
       );
     }, 0);
 

--- a/projects/hslayers/src/components/layout/partials/layout.component.scss
+++ b/projects/hslayers/src/components/layout/partials/layout.component.scss
@@ -14,9 +14,13 @@
     pointer-events: auto;
     /* position: absolute; */
     top: 0;
-    width: 400px;
+    min-width: 425px;
     z-index: 2;
     transition: width 100ms ease-out;
+
+    &.labels{
+        width: 425px;
+    }
 }
 
 .hs-sb-right .hs-panelspace {

--- a/projects/hslayers/src/components/layout/partials/layout.html
+++ b/projects/hslayers/src/components/layout/partials/layout.html
@@ -1,22 +1,26 @@
 <div #hslayout class="hs-page-wrapper hsl" style="width: 100%; height: 100%;">
-    <div class="hs-content-wrapper d-flex w-100 h-100" [ngClass]="{'hs-open': HsLayoutService.sidebarExpanded && HsLayoutService.sidebarVisible(), 'hs-sb-right': HsConfig.sidebarPosition == 'right' && HsLayoutService.sidebarVisible(), 'hs-sb-left': HsConfig.sidebarPosition == 'left' && HsLayoutService.sidebarVisible(),'hs-sb-bottom':HsLayoutService.sidebarBottom()}">
+    <div class="hs-content-wrapper d-flex w-100 h-100"
+        [ngClass]="{'hs-open': HsLayoutService.sidebarExpanded && HsLayoutService.sidebarVisible(), 'hs-sb-right': HsConfig.sidebarPosition == 'right' && HsLayoutService.sidebarVisible(), 'hs-sb-left': HsConfig.sidebarPosition == 'left' && HsLayoutService.sidebarVisible(),'hs-sb-bottom':HsLayoutService.sidebarBottom()}">
         <!-- ng-if="HsLayoutService.componentEnabled('guiOverlay')" -->
         <div class="hs-map-space d-flex">
             <hs-map class="hs-flex-fill d-flex"></hs-map>
             <ng-template map-host></ng-template>
             <hs-panel-container [service]="HsOverlayPanelContainerService"></hs-panel-container>
         </div>
-        <div class="hs-panelspace" *ngIf="HsLayoutService.sidebarVisible()" [ngClass]="{'labels': HsLayoutService.sidebarLabels, 'buttons': HsLayoutService.sidebarButtons}" [ngStyle]="{width: panelSpaceWidth()+'px'}">
+        <div class="hs-panelspace" *ngIf="HsLayoutService.sidebarVisible()"
+            [ngClass]="{'labels': HsLayoutService.sidebarLabels, 'buttons': HsLayoutService.sidebarButtons}">
             <div class="hs-panelspace-wrapper me-1">
                 <hs-sidebar class="border-0"></hs-sidebar>
                 <div class="hs-panelplace">
-                    <hs-mini-sidebar *ngIf="HsLayoutService.minisidebar" [hidden]="!panelVisible('sidebar', this)"></hs-mini-sidebar>
-                    <hs-panel-container [service]="HsPanelContainerService" class="hs-panelplace" [ngStyle]="{width: (panelSpaceWidth()-50)+'px'}">
+                    <hs-mini-sidebar *ngIf="HsLayoutService.minisidebar" [hidden]="!panelVisible('sidebar', this)">
+                    </hs-mini-sidebar>
+                    <hs-panel-container [service]="HsPanelContainerService" class="hs-panelplace">
                     </hs-panel-container>
                 </div>
             </div>
         </div>
-        <hs-toast aria-live="polite" aria-atomic="true" [ngClass]="HsConfig.sidebarPosition == 'left' ? 'hs-sb-right' : 'hs-sb-left'" ></hs-toast>
+        <hs-toast aria-live="polite" aria-atomic="true"
+            [ngClass]="HsConfig.sidebarPosition == 'left' ? 'hs-sb-right' : 'hs-sb-left'"></hs-toast>
         <div class="hs-dialog-area"></div>
     </div>
     <hs-dialog-container></hs-dialog-container>

--- a/projects/hslayers/src/components/sidebar/sidebar.service.ts
+++ b/projects/hslayers/src/components/sidebar/sidebar.service.ts
@@ -167,7 +167,7 @@ export class HsSidebarService {
   fitsSidebar(button: HsButton): boolean {
     const dimensionToCheck =
       window.innerWidth > 767 ? 'clientHeight' : 'clientWidth';
-
+    this.HsLayoutService.sidebarToggleable = window.innerWidth > 767;
     let maxNumberOfButtons = Math.floor(
       this.HsLayoutService.layoutElement[dimensionToCheck] / 60
     );

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -205,7 +205,6 @@ export class HsConfig {
     ];
     delete newConfig.symbolizerIcons;
     Object.assign(this, newConfig);
-
     this.configChanges.next(this);
   }
 

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -65,7 +65,7 @@ $list-group-item-padding-x: 1.25rem;
 
   @media screen and (min-width:767px) {
     @for $i from 0 through 20{
-      .hs-panelspace hs-panel-container .hs-panelWidth-#{400 + ($i * 25) } {
+      .hs-panelspace hs-panel-container .hs-panel-width-#{400 + ($i * 25) } {
         width: 400 + ($i * 25)+px;
       }
     }

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -63,6 +63,14 @@ $list-group-item-padding-x: 1.25rem;
   // Utilities
   @import "bootstrap/scss/utilities/api";
 
+  @media screen and (min-width:767px) {
+    @for $i from 0 through 14{
+      .hs-panelspace hs-panel-container .hs-panelWidth-#{400 + ($i * 25) } {
+        width: 400 + ($i * 25)+px;
+      }
+    }
+  }
+
   //Dropped in b5. suggested to use utilities mb-*. Might refactor later
   .form-group {
     margin-bottom: 1rem;

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -64,7 +64,7 @@ $list-group-item-padding-x: 1.25rem;
   @import "bootstrap/scss/utilities/api";
 
   @media screen and (min-width:767px) {
-    @for $i from 0 through 14{
+    @for $i from 0 through 20{
       .hs-panelspace hs-panel-container .hs-panelWidth-#{400 + ($i * 25) } {
         width: 400 + ($i * 25)+px;
       }

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -28,7 +28,7 @@ $list-group-item-padding-x: 1.25rem;
 .hsl {
   @media screen and (min-width:767px) {
     @for $i from 0 through 14{
-      .hs-panelspace hs-panel-container .hs-panelWidth-#{400 + ($i * 25) } {
+      .hs-panelspace hs-panel-container .hs-panel-width-#{400 + ($i * 25) } {
         width: 400 + ($i * 25)+px;
       }
     }

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -26,6 +26,14 @@ $list-group-item-padding-x: 1.25rem;
 }
 
 .hsl {
+  @media screen and (min-width:767px) {
+    @for $i from 0 through 14{
+      .hs-panelspace hs-panel-container .hs-panelWidth-#{400 + ($i * 25) } {
+        width: 400 + ($i * 25)+px;
+      }
+    }
+  }
+
   //Dropped in b5. suggested to use utilities mb-*. Might refactor later
   .form-group {
     margin-bottom: 1rem;

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -25,6 +25,7 @@ import {HsPrintComponent} from './components/print/print.component';
 import {HsQueryComponent} from './components/query/query.component';
 import {HsQueryPopupComponent} from './components/query/query-popup/query-popup.component';
 import {HsQueryPopupService} from './components/query/query-popup.service';
+import {HsQueryPopupWidgetContainerService} from './components/query/query-popup-widget-container.service';
 import {HsSaveMapComponent} from './components/save-map/save-map.component';
 import {HsSearchComponent} from './components/search/search.component';
 import {HsSearchToolbarComponent} from './components/search/search-toolbar.component';
@@ -33,7 +34,6 @@ import {HsStylerComponent} from './components/styles/styler.component';
 import {HsToolbarComponent} from './components/toolbar/toolbar.component';
 import {HsToolbarPanelContainerService} from './components/toolbar/toolbar-panel-container.service';
 import {HsTripPlannerComponent} from './components/trip-planner/trip-planner.component';
-import {HsQueryPopupWidgetContainerService} from './components/query/query-popup-widget-container.service';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector


### PR DESCRIPTION
## Description

Because panelSpaceWidth function is called on every digest cycle twice so I tought it might be quite beneficial for us to replace it with something more efficient which would be css. The problematic part is that the new approach must be able to handle dynamicaly created panel that are not part of the library which makes panel specific css classes unusable .
So I tought we might make a little trade off of absolute freedom of width declaration using for example 14 predefined 'size classes' generated like so:
```
    @for $i from 0 through 14{
      .hs-panelspace hs-panel-container .hs-panelWidth-#{400 + ($i * 25) } {
        width: 400 + ($i * 25)+px;
      }

      //Output:
      .hsl .hs-panelspace hs-panel-container .hs-panelWidth-400 {
          width: 400px;
        }
      .hsl .hs-panelspace hs-panel-container .hs-panelWidth-425 {
        width: 425px;
      }
      ....
```
These would be added to the panel element while being created -> based on `panelWidth` property of `data` argument in `hsPanelContainerService.create`  eg.:

- ` this.HsPanelContainerService.create({ component: AnyComponentClass });`

One problematic aspect I should point out is **how to find the right element** on which we add class onto. Basically looking for the element with `[hidden]=isVisible()`. However it doesnt necessarily need to be a first element (eg. query component) or div.
```
      componentRef.location.nativeElement.children[0].classList.add(
        `hs-panelWidth-${Math.round(panelItem.data.panelWidth / 25) * 25}`
      );
```
We cant use the host element of component because panel space would get the width from the most broad one.. 

So lets see maybe we can put it together somehow

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [x] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
