### PR TITLE
Ability to load external server list of services and add them to the map

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -65,7 +65,6 @@
     "queryFormat": "Formát dotazu",
     "registerMetadata": "Registrovat metadata",
     "resampleLayer": "Převzorkovat vrstvu",
-    "selectAllLayers": "Vybrat všechny vrstvy",
     "serviceTypeNotMatching": "Typ služby URL se neshoduje s vybranou kategorií",
     "SHP": {
       "loginRequired": "Před načtením vrstvy je vyžadováno přihlášení",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -38,7 +38,8 @@
       "selectAll": "Select all Layers",
       "submitLayerName": "Fill in layer name",
       "submitLayerTitle": "Fill in layer title"
-    }
+    },
+    "requestServiceLayers": "Request service layers"
   },
   "ADDLAYERS": {
     "addSelected": "Add selected layers to the map",
@@ -66,7 +67,6 @@
     "queryFormat": "Query format",
     "registerMetadata": "Register metadata",
     "resampleLayer": "Resample layer",
-    "selectAllLayers": "Select All layers",
     "serviceTypeNotMatching": "URL service type does not match selected category",
     "SHP": {
       "loginRequired": "User login is required before layer can be loaded",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -38,7 +38,8 @@
       "selectAll": "Izvēlēties visus slāņus",
       "submitLayerName": "Ievadiet slāņa nosaukumu",
       "submitLayerTitle": "Ievadiet slāņa nosaukumu"
-    }
+    },
+    "requestServiceLayers": "Pieprasīt pakalpojumu slāņus"
   },
   "ADDLAYERS": {
     "addSelected": "Pievienot izvēlētos slāņus kartei",
@@ -66,7 +67,6 @@
     "queryFormat": "Vaicājuma formāts",
     "registerMetadata": "Reģistrēt metadatus",
     "resampleLayer": "Atkārtojiet slāņa atlasi",
-    "selectAllLayers": "Atlasīt visus slāņus",
     "serviceTypeNotMatching": "URL servisa tips neatbilsts izvēlētajaai kategorijai",
     "SHP": {
       "loginRequired": "Pirms slāņa ielādes ir nepieciešama lietotāja autentifikācija",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -65,7 +65,6 @@
     "queryFormat": "Formát dotazu",
     "registerMetadata": "Registrovať metadáta",
     "resampleLayer": "Prevzorkovať vrstvu",
-    "selectAllLayers": "Vybrať všetky vrstvy",
     "serviceTypeNotMatching": "Typ služby URL se nezhoduje s vybranou kategóriou",
     "SHP": {
       "loginRequired": "Pred načítaním vrstvy je potrebné prihlásiť sa ",

--- a/projects/hslayers/src/components/add-data/common/common.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common.service.ts
@@ -12,12 +12,13 @@ import {HsToastService} from '../../layout/toast/toast.service';
 @Injectable({providedIn: 'root'})
 export class HsAddDataCommonService {
   layerToSelect: string;
+  addAllServiceLayers = false;
   loadingInfo = false;
   showDetails = false;
   url: string;
   //TODO: all dimension related things need to be refactored into separate module
   getDimensionValues = this.hsDimensionService.getDimensionValues;
-  serviceLayersCalled: Subject<string> = new Subject();
+  serviceLayersCalled: Subject<{url: string; addAll: boolean}> = new Subject();
   constructor(
     public hsMapService: HsMapService,
     public hsAddDataUrlService: HsAddDataUrlService,
@@ -36,6 +37,7 @@ export class HsAddDataCommonService {
     this.showDetails = false;
     this.url = '';
     this.hsAddDataUrlService.typeSelected = null;
+    this.addAllServiceLayers = false;
   }
 
   setPanelToCatalogue(): void {

--- a/projects/hslayers/src/components/add-data/common/common.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common.service.ts
@@ -12,13 +12,12 @@ import {HsToastService} from '../../layout/toast/toast.service';
 @Injectable({providedIn: 'root'})
 export class HsAddDataCommonService {
   layerToSelect: string;
-  addAllServiceLayers = false;
   loadingInfo = false;
   showDetails = false;
   url: string;
   //TODO: all dimension related things need to be refactored into separate module
   getDimensionValues = this.hsDimensionService.getDimensionValues;
-  serviceLayersCalled: Subject<{url: string; addAll: boolean}> = new Subject();
+  serviceLayersCalled: Subject<{url: string}> = new Subject();
   constructor(
     public hsMapService: HsMapService,
     public hsAddDataUrlService: HsAddDataUrlService,
@@ -37,7 +36,6 @@ export class HsAddDataCommonService {
     this.showDetails = false;
     this.url = '';
     this.hsAddDataUrlService.typeSelected = null;
-    this.addAllServiceLayers = false;
   }
 
   setPanelToCatalogue(): void {

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.html
@@ -1,6 +1,6 @@
 <div class="w-100 d-flex justify-content-between pb-2 bg-white" style="position: sticky;
                 bottom: 0">
-  <button class="btn btn-primary" (click)="selectAllLayers()">{{'ADDLAYERS.selectAllLayers' |
+  <button class="btn btn-primary" (click)="selectAll()">{{'ADDDATA.URL.selectAll' |
     translate}}</button>
   <button class="btn btn-primary" [disabled]="!hsAddDataUrlService.addingAllowed"
     [title]="'ADDLAYERS.addSelected' | translate" (click)="addLayers(true)">{{'ADDLAYERS.WFS.addToMap' |

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.html
@@ -3,6 +3,6 @@
   <button class="btn btn-primary" (click)="selectAll()">{{'ADDDATA.URL.selectAll' |
     translate}}</button>
   <button class="btn btn-primary" [disabled]="!hsAddDataUrlService.addingAllowed"
-    [title]="'ADDLAYERS.addSelected' | translate" (click)="addLayers(true)">{{'ADDLAYERS.WFS.addToMap' |
+    [title]="'ADDLAYERS.addSelected' | translate" (click)="add()">{{'ADDLAYERS.WFS.addToMap' |
     translate}}</button>
 </div>

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
@@ -54,8 +54,8 @@ export class HsUrlAddComponent {
 
   changed(): void {
     this.hsAddDataUrlService.searchForChecked([
-      ...this.layers,
-      ...this.services,
+      ...(this.layers ?? []),
+      ...(this.services ?? []),
     ]);
   }
 }

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
@@ -1,14 +1,18 @@
 import {Component, Input} from '@angular/core';
 
 import {HsAddDataUrlService} from '../../../url/add-data-url.service';
-import {HsUrlTypeServiceModel} from '../../../url/models/url-type-service.model';
+import {
+  HsUrlTypeServiceModel,
+  Service,
+} from '../../../url/models/url-type-service.model';
 
 @Component({
   selector: 'hs-url-add',
   templateUrl: './add.component.html',
 })
 export class HsUrlAddComponent {
-  @Input() records: any;
+  @Input() services?: Service[];
+  @Input() layers: {name: string; checked: boolean}[];
   @Input() injectedService: HsUrlTypeServiceModel;
   _selectAll = true;
 
@@ -19,7 +23,9 @@ export class HsUrlAddComponent {
    */
   selectAll(): void {
     this._selectAll = !this._selectAll;
-    this.checkAllRecords(this.records);
+    this.checkAllRecords(
+      this.services?.length > 0 ? this.services : this.layers
+    );
   }
 
   checkAllRecords(records: any[]): void {
@@ -27,7 +33,6 @@ export class HsUrlAddComponent {
       return;
     }
     for (const r of records) {
-      r.checked = false;
       r.checked = !this._selectAll;
       if (r.Layer) {
         this.checkAllRecords(r.Layer);
@@ -36,13 +41,21 @@ export class HsUrlAddComponent {
     this.changed();
   }
 
-  addLayers(checked: boolean): void {
-    this.injectedService.addLayers(checked);
+  add(): void {
+    if (this.layers) {
+      this.injectedService.addLayers(true);
+    }
+    if (this.injectedService.addServices && this.services) {
+      this.injectedService.addServices(this.services);
+    }
     //FIXME: to implement
     // this.injectedService.zoomToLayers();
   }
 
   changed(): void {
-    this.hsAddDataUrlService.searchForChecked(this.records);
+    this.hsAddDataUrlService.searchForChecked([
+      ...this.layers,
+      ...this.services,
+    ]);
   }
 }

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
@@ -8,29 +8,29 @@ import {HsUrlTypeServiceModel} from '../../../url/models/url-type-service.model'
   templateUrl: './add.component.html',
 })
 export class HsUrlAddComponent {
-  @Input() layers: any;
+  @Input() records: any;
   @Input() injectedService: HsUrlTypeServiceModel;
-  selectAll = true;
+  _selectAll = true;
 
   constructor(public hsAddDataUrlService: HsAddDataUrlService) {}
 
   /**
-   * Select all layers from service.
+   * Select all records from service.
    */
-  selectAllLayers(): void {
-    this.selectAll = !this.selectAll;
-    this.checkAllLayers(this.layers);
+  selectAll(): void {
+    this._selectAll = !this._selectAll;
+    this.checkAllRecords(this.records);
   }
 
-  checkAllLayers(layers: any[]): void {
-    if (!layers) {
+  checkAllRecords(records: any[]): void {
+    if (!records) {
       return;
     }
-    for (const layer of layers) {
-      layer.checked = false;
-      layer.checked = !this.selectAll;
-      if (layer.Layer) {
-        this.checkAllLayers(layer.Layer);
+    for (const r of records) {
+      r.checked = false;
+      r.checked = !this._selectAll;
+      if (r.Layer) {
+        this.checkAllRecords(r.Layer);
       }
     }
     this.changed();
@@ -43,6 +43,6 @@ export class HsUrlAddComponent {
   }
 
   changed(): void {
-    this.hsAddDataUrlService.searchForChecked(this.layers);
+    this.hsAddDataUrlService.searchForChecked(this.records);
   }
 }

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.html
@@ -147,7 +147,7 @@
             <input class="checkbox-lg" type="checkbox" name="service" (change)="changed('services')"
               style="cursor: pointer;" [(ngModel)]="service.checked" />
           </td>
-          <td (click)="addService({service})" data-toggle="tooltip" [title]="'ADDDATA.requestServiceLayers' | translate"
+          <td (click)="expandService(service)" data-toggle="tooltip" [title]="'ADDDATA.requestServiceLayers' | translate"
             style="cursor: pointer;">
             {{service.name}}
             <span style="font-size: x-small;"><i class="icon-chevron-right"></i></span>
@@ -179,6 +179,6 @@
       </div>
     </div>
   </ng-container>
-  <hs-url-add class="w-100" [injectedService]="injectedService" [records]="data.services ?? data.layers">
+  <hs-url-add class="w-100" [injectedService]="injectedService" [services]="data.services" [layers]="data.layers">
   </hs-url-add>
 </div>

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.html
@@ -100,15 +100,15 @@
       <tbody *ngFor="let layer of data.layers | slice:0:limitShown; trackBy:( 'Name' | trackByProperty )">
         <tr>
           <td [attr.rowspan]="layer.Style?.length ? 3 : 2" [ngClass]="{'align-middle': !hasNestedLayers(layer)}">
-            <input type="checkbox" class="checkbox-lg" [(ngModel)]="layer.checked" name="layer"
+            <input type="checkbox" class="checkbox-lg" [(ngModel)]="layer.checked" name="layer" style="cursor: pointer;"
               (change)="searchForChecked(layer)" />
           </td>
           <td hsWmsLayerHighlight style="max-width: 25.375em" class="text-truncate"
             [title]="'Title: ' + layer.Title  + '\nName: ' + layer.Name"
             (click)="hsUrlWmsService.expandTableRow($event)">{{layer.Title}}</td>
           <!-- <td style="max-width: 13.75em" class="text-truncate" [title]="layer.Name">{{layer.Name}}</td> -->
-          <td hsWmsLayerHighlight style="max-width: 10.875em; width:30%" class="text-truncate"
-            [title]="layer.Abstract" (click)="hsUrlWmsService.expandTableRow($event)">
+          <td hsWmsLayerHighlight style="max-width: 10.875em; width:30%" class="text-truncate" [title]="layer.Abstract"
+            (click)="hsUrlWmsService.expandTableRow($event)">
             {{layer.Abstract}}</td>
         </tr>
         <tr *ngIf="layer.Style?.length > 1 && layer.checked">
@@ -144,18 +144,20 @@
       <tbody *ngFor="let service of data.services; trackBy:( 'id' | trackByProperty )">
         <tr>
           <td>
-            <button class="but-title-sm" (click)="addService({service})" data-toggle="tooltip"
-              [title]="'Add service layers'">
-              <i class="icon-plus"></i>
-            </button>
+            <input class="checkbox-lg" type="checkbox" name="service" (change)="changed('services')"
+              style="cursor: pointer;" [(ngModel)]="service.checked" />
           </td>
-          <td class="pt-2">{{service.name}}</td>
+          <td (click)="addService({service})" data-toggle="tooltip" [title]="'ADDDATA.requestServiceLayers' | translate"
+            style="cursor: pointer;">
+            {{service.name}}
+            <span style="font-size: x-small;"><i class="icon-chevron-right"></i></span>
+          </td>
         </tr>
       </tbody>
       <tbody *ngFor="let layer of data.layers; trackBy:( 'id' | trackByProperty )">
         <tr>
-          <td><input class="checkbox-lg ms-2" type="checkbox" name="layer" (change)="changed()"
-              [(ngModel)]="layer.checked" /></td>
+          <td><input class="checkbox-lg" type="checkbox" name="layer" style="cursor: pointer;"
+              (change)="changed('layers')" [(ngModel)]="layer.checked" /></td>
           <td>{{layer.name}}</td>
         </tr>
       </tbody>
@@ -177,6 +179,6 @@
       </div>
     </div>
   </ng-container>
-  <hs-url-add class="w-100" [injectedService]="injectedService" [layers]="data.layers">
+  <hs-url-add class="w-100" [injectedService]="injectedService" [records]="data.services ?? data.layers">
   </hs-url-add>
 </div>

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.ts
@@ -60,8 +60,13 @@ export class HsUrlDetailsComponent implements AfterContentInit {
       return false;
     }
   }
-  changed(): void {
-    this.hsAddDataUrlService.searchForChecked(this.data.layers);
+  changed(whichArray: 'layers' | 'services'): void {
+    if (whichArray == 'layers') {
+      this.hsAddDataUrlService.searchForChecked(this.data.layers);
+    }
+    if (whichArray == 'services') {
+      this.hsAddDataUrlService.searchForChecked(this.data.services);
+    }
   }
 
   addService(service): void {

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.ts
@@ -6,7 +6,10 @@ import {HsAddDataService} from '../../../add-data.service';
 import {HsAddDataUrlService} from '../../../url/add-data-url.service';
 import {HsLanguageService} from '../../../../language/language.service';
 import {HsLayerUtilsService} from '../../../../utils/layer-utils.service';
-import {HsUrlTypeServiceModel} from '../../../url/models/url-type-service.model';
+import {
+  HsUrlTypeServiceModel,
+  Service,
+} from '../../../url/models/url-type-service.model';
 import {HsUrlWmsService} from '../../../url/wms/wms.service';
 import {HsUtilsService} from '../../../../utils/utils.service';
 
@@ -69,9 +72,9 @@ export class HsUrlDetailsComponent implements AfterContentInit {
     }
   }
 
-  addService(service): void {
-    if (this.injectedService.addService) {
-      this.injectedService.addService(service);
+  expandService(service: Service): void {
+    if (this.injectedService.expandService) {
+      this.injectedService.expandService(service);
     }
   }
 }

--- a/projects/hslayers/src/components/add-data/common/url/nested-layers-table/nested-layers-table.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/nested-layers-table/nested-layers-table.component.html
@@ -2,7 +2,7 @@
     <tbody *ngFor="let sub_layer of layers; trackBy:( 'Name' | trackByProperty )">
         <tr>
             <td style="width: 1em"><input type="checkbox" [(ngModel)]="sub_layer.checked" (change)="checked(sub_layer)"
-                    [ngModelOptions]="{standalone: true}" /></td>
+                    [ngModelOptions]="{standalone: true}" style="cursor: pointer;" /></td>
             <td hsWmsLayerHighlight class="text-truncate" style="max-width: 12em;" id="hs-add-layer-{{sub_layer.Name}}"
                 [title]="'Title: ' + sub_layer.Title  + '\nName: ' + sub_layer.Name"
                 (click)="hsUrlWmsService.expandTableRow($event)">{{sub_layer.Title}}

--- a/projects/hslayers/src/components/add-data/url/add-data-ows.service.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-ows.service.ts
@@ -39,9 +39,12 @@ export class HsAddDataOwsService {
     public hsWmtsGetCapabilitiesService: HsWmtsGetCapabilitiesService,
     public hsUrlWmtsService: HsUrlWmtsService
   ) {
-    this.hsAddDataCommonService.serviceLayersCalled.subscribe((url) => {
-      this.setUrlAndConnect({uri: url});
-    });
+    this.hsAddDataCommonService.serviceLayersCalled.subscribe(
+      ({url, addAll}) => {
+        this.setUrlAndConnect({uri: url});
+        this.hsAddDataCommonService.addAllServiceLayers = addAll;
+      }
+    );
   }
   async connect(style?: string): Promise<Layer<Source>[]> {
     await this.setTypeServices();

--- a/projects/hslayers/src/components/add-data/url/add-data-ows.service.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-ows.service.ts
@@ -39,12 +39,9 @@ export class HsAddDataOwsService {
     public hsWmtsGetCapabilitiesService: HsWmtsGetCapabilitiesService,
     public hsUrlWmtsService: HsUrlWmtsService
   ) {
-    this.hsAddDataCommonService.serviceLayersCalled.subscribe(
-      ({url, addAll}) => {
-        this.setUrlAndConnect({uri: url});
-        this.hsAddDataCommonService.addAllServiceLayers = addAll;
-      }
-    );
+    this.hsAddDataCommonService.serviceLayersCalled.subscribe(({url}) => {
+      this.setUrlAndConnect({uri: url});
+    });
   }
   async connect(style?: string): Promise<Layer<Source>[]> {
     await this.setTypeServices();

--- a/projects/hslayers/src/components/add-data/url/add-data-url.component.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-url.component.ts
@@ -39,6 +39,7 @@ export class HsAddDataUrlComponent {
   }
 
   selectType(type: AddDataUrlType): void {
+    this.hsAddDataCommonService.clearParams();
     this.hsAddDataUrlService.typeSelected = type;
   }
 

--- a/projects/hslayers/src/components/add-data/url/add-data-url.service.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-url.service.ts
@@ -124,8 +124,8 @@ export class HsAddDataUrlService {
     }, 1000);
   }
 
-  searchForChecked(layers: Array<any>): void {
+  searchForChecked(records: Array<any>): void {
     this.addingAllowed =
-      layers.some((l) => l.checked) || this.typeSelected == 'arcgis';
+      records?.some((l) => l.checked) ?? this.typeSelected == 'arcgis';
   }
 }

--- a/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
+++ b/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
@@ -6,6 +6,12 @@ import {addLayerOptions} from '../types/layer-options.type';
 import {addLayersRecursivelyOptions} from '../types/recursive-options.type';
 import {urlDataObject} from '../types/data-object.type';
 
+export type Service = {
+  name: string;
+  checked: boolean;
+  type?: string;
+};
+
 export interface HsUrlTypeServiceModel {
   data: urlDataObject;
 
@@ -20,6 +26,7 @@ export interface HsUrlTypeServiceModel {
     options: addLayersRecursivelyOptions,
     collection: Layer<Source>[]
   ): void;
-  addService?(params: any): void;
+  expandService?(service: Service): void;
+  addServices?(services: Service[]);
   setDataToDefault(): void;
 }

--- a/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
+++ b/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
@@ -20,6 +20,6 @@ export interface HsUrlTypeServiceModel {
     options: addLayersRecursivelyOptions,
     collection: Layer<Source>[]
   ): void;
-  addService?(params: any): Promise<void>;
+  addService?(params: any): void;
   setDataToDefault(): void;
 }

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -31,7 +31,6 @@ import {
 import {addAnchors} from '../../../../common/attribution-utils';
 import {addLayerOptions} from '../types/layer-options.type';
 import {addLayersRecursivelyOptions} from '../types/recursive-options.type';
-import {getName, getTitle} from '../../../../common/layer-extensions';
 import {getPreferredFormat} from '../../../../common/format-utils';
 import {urlDataObject} from '../types/data-object.type';
 
@@ -208,7 +207,7 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
         this.data.layers,
         'Name'
       );
-
+      this.hsAddDataUrlService.searchForChecked(this.data.layers);
       //TODO: shalln't we move this logic after the layer is added to map?
       if (layerToSelect) {
         this.data.extent = this.getLayerBBox(serviceLayer);


### PR DESCRIPTION
## Description

This PR allows the user to load a list of external services from which you can choose to load multiple services at once, or expand each of the services to select specific layers to add to the map. Currenly supported for Arcgis only.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
