### PR TITLE
fix: Make instance checking more robust when mod-fed is used

### DIFF
--- a/projects/hslayers/src/components/utils/layer-utils.service.ts
+++ b/projects/hslayers/src/components/utils/layer-utils.service.ts
@@ -138,6 +138,12 @@ export class HsLayerUtilsService {
     if (this.HsUtilsService.instOf(src, XYZ)) {
       return (src as XYZ).getUrls()[0];
     }
+    if ((src as any).getUrl) {
+      return (src as any).getUrl();
+    }
+    if ((src as any).getUrls) {
+      return (src as any).getUrls()[0];
+    }
   }
 
   /**

--- a/projects/hslayers/src/components/utils/utils.service.ts
+++ b/projects/hslayers/src/components/utils/utils.service.ts
@@ -390,6 +390,9 @@ export class HsUtilsService {
     if (obj === undefined || obj === null) {
       return false;
     }
+    if (klass.default) {
+      klass = klass.default;
+    }
     if (this.isFunction(klass)) {
       return obj instanceof klass;
     }


### PR DESCRIPTION
## Description

When module federation is used modules sometimes are loaded in a wrapper which makes class checking fail
![image](https://user-images.githubusercontent.com/395514/151079236-92d62959-f3c3-400a-a461-2b753372ef2b.png)

## Related issues or pull requests


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
