### PR TITLE
Fix panel width resetting and refactor enabling panels

### DIFF
--- a/projects/hslayers/src/components/add-data/url/wms/wms.spec.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.spec.ts
@@ -74,7 +74,7 @@ describe('add-data-url', () => {
         HsUrlWmsService,
         {
           provide: HsConfig,
-          useValue: EmptyMock,
+          useValue: {panelsEnabled: {}},
         },
         {
           provide: HsUtilsService,

--- a/projects/hslayers/src/components/layout/layout.service.mock.ts
+++ b/projects/hslayers/src/components/layout/layout.service.mock.ts
@@ -3,6 +3,10 @@ export class HsLayoutServiceMock {
   constructor() {}
 
   panelVisible() {
-    return true
+    return true;
+  }
+
+  componentEnabled() {
+    return true;
   }
 }

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -304,6 +304,14 @@ export class HsLayoutService {
       this.sidebarLabels = false;
     }
     this.mainpanel = which;
+    const componentRefInstance = this.hsPanelContainerService.panels.find(
+      (p) => p.name == which
+    );
+    this.hsPanelContainerService.setPanelWidth(
+      {}, //Class for hsl internal panels is already set so we don't care about default widths here
+      this.HsConfig.panelWidths,
+      componentRefInstance
+    );
     this.HsEventBusService.mainPanelChanges.next(which);
   }
 

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -94,28 +94,6 @@ export class HsLayoutService {
   contentWrapper: any;
   layoutElement: any;
   private _sidebarVisible: any;
-  panelsEnabledDefaults = {
-    legend: true,
-    info: true,
-    composition_browser: true,
-    toolbar: true,
-    measure: true,
-    mobile_settings: false,
-    draw: true,
-    layermanager: true,
-    print: true,
-    saveMap: true,
-    language: true,
-    permalink: true,
-    compositionLoadingProgress: false,
-    sensors: true,
-    tracking: true,
-    filter: false,
-    search: false,
-    tripPlanner: false,
-    addData: true,
-    mapSwipe: false,
-  };
   mapSpaceRef: BehaviorSubject<ViewContainerRef> = new BehaviorSubject(null);
 
   constructor(
@@ -153,16 +131,15 @@ export class HsLayoutService {
 
   parseConfig() {
     this.panel_enabled = {};
-    for (const key of Object.keys(this.panelsEnabledDefaults)) {
+    for (const key of Object.keys(this.HsConfig.panelsEnabled)) {
       this.panelEnabled(key, this.getPanelEnableState(key));
     }
   }
 
   getPanelEnableState(panel): boolean {
     if (
-      this.panelsEnabledDefaults[panel] == undefined &&
-      (this.HsConfig?.panelsEnabled == undefined ||
-        this.HsConfig?.panelsEnabled[panel] == undefined)
+      this.HsConfig?.panelsEnabled == undefined ||
+      this.HsConfig?.panelsEnabled[panel] == undefined
     ) {
       /* 
       Function called from sidebar and panel is 
@@ -170,14 +147,7 @@ export class HsLayoutService {
       */
       return true;
     }
-    if (this.HsConfig.panelsEnabled == undefined) {
-      return this.panelsEnabledDefaults[panel];
-    }
-    if (this.HsConfig.panelsEnabled[panel] == undefined) {
-      return this.panelsEnabledDefaults[panel];
-    } else {
-      return this.HsConfig.panelsEnabled[panel];
-    }
+    return this.HsConfig.panelsEnabled[panel];
   }
 
   /**

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -308,7 +308,6 @@ export class HsLayoutService {
       (p) => p.name == which
     );
     this.hsPanelContainerService.setPanelWidth(
-      {}, //Class for hsl internal panels is already set so we don't care about default widths here
       this.HsConfig.panelWidths,
       componentRefInstance
     );

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -92,20 +92,15 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
      * Assign panel width class to a component host first child
      * Used to define panelSpace panel width
      */
-    Object.assign(panelWidths, this.HsConfig.panelWidths);
-    const panelWidth =
-      panelWidths[componentRefInstance.name] || panelWidths.default;
-    setTimeout(() => {
-      //Without timeout componentRef.location.nativeElement could containe only placeholder <!--container--> until the real content is loaded
-      componentRef.location.nativeElement.children[0].classList.add(
-        `hs-panel-width-${Math.round(panelWidth / 25) * 25}`
-      );
-    }, 0);
+    this.service.setPanelWidth(
+      panelWidths,
+      this.HsConfig.panelWidths,
+      componentRefInstance
+    );
 
     if (componentRefInstance.data == undefined) {
       componentRefInstance.data = panelItem.data || this.data;
     }
-
     this.service.panels.push(componentRef.instance as HsPanelComponent);
   }
 }

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -84,10 +84,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
      * Assign panel width class to a component host first child
      * Used to define panelSpace panel width
      */
-    this.service.setPanelWidth(
-      this.HsConfig.panelWidths,
-      componentRefInstance
-    );
+    this.service.setPanelWidth(this.HsConfig.panelWidths, componentRefInstance);
 
     if (componentRefInstance.data == undefined) {
       componentRefInstance.data = panelItem.data || this.data;

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -72,14 +72,6 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
   }
 
   loadPanel(panelItem: HsPanelItem): void {
-    const panelWidths = {
-      default: 425,
-      ows: 700,
-      composition_browser: 550,
-      addData: 700,
-      mapSwipe: 550,
-    };
-
     const componentFactory =
       this.componentFactoryResolver.resolveComponentFactory(
         panelItem.component
@@ -93,7 +85,6 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
      * Used to define panelSpace panel width
      */
     this.service.setPanelWidth(
-      panelWidths,
       this.HsConfig.panelWidths,
       componentRefInstance
     );

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
@@ -5,9 +5,6 @@ import {Type} from '@angular/core';
 
 export interface HsPanelContainerServiceInterface {
   setPanelWidth?(
-    defaults: {
-      [key: string]: number;
-    },
     panelWidths: {
       [key: string]: number;
     },

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
@@ -1,13 +1,13 @@
-import {HsPanelComponent} from './panel-component.interface';
-import {HsPanelItem} from './panel-item';
 import {ReplaySubject, Subject} from 'rxjs';
 import {Type} from '@angular/core';
 
+import {HsPanelComponent} from './panel-component.interface';
+import {HsPanelItem} from './panel-item';
+import {KeyNumberDict} from '../../../config.service';
+
 export interface HsPanelContainerServiceInterface {
   setPanelWidth?(
-    panelWidths: {
-      [key: string]: number;
-    },
+    panelWidths: KeyNumberDict,
     componentRefInstance: HsPanelComponent
   );
   panels: HsPanelComponent[];

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.interface.ts
@@ -4,6 +4,15 @@ import {ReplaySubject, Subject} from 'rxjs';
 import {Type} from '@angular/core';
 
 export interface HsPanelContainerServiceInterface {
+  setPanelWidth?(
+    defaults: {
+      [key: string]: number;
+    },
+    panelWidths: {
+      [key: string]: number;
+    },
+    componentRefInstance: HsPanelComponent
+  );
   panels: HsPanelComponent[];
   panelObserver: ReplaySubject<HsPanelItem>;
   panelDestroyObserver: Subject<any>;

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.ts
@@ -4,6 +4,10 @@ import {HsPanelItem} from './panel-item';
 import {Injectable, Type} from '@angular/core';
 import {ReplaySubject, Subject} from 'rxjs';
 
+type KeyNumberDic = {
+  [key: string]: number;
+};
+
 @Injectable({
   providedIn: 'root',
 })
@@ -36,5 +40,39 @@ export class HsPanelContainerService
 
   destroy(component: HsPanelComponent): void {
     this.panelDestroyObserver.next(component);
+  }
+
+  /**
+   * An admittedly hacky solution to set panel width
+   * from 2 dictionaries containing names (as in name property in PanelComponent)
+   * and numbers - defaults dictionary and HsConfig.panelWidths (priority) dictionary.
+   * It's also possible to set the css class hs-panel-width-(400-850) on the panel
+   * templates root element skipping the HsConfig.panelWidths.
+   * @param defaults - key-value pairs of panel names and their widths
+   * @param panelWidths - key-value pairs of panel names and their widths
+   * @param componentRefInstance - Panel component instance which can be read from HsPanelContainerService.panels array
+   */
+  setPanelWidth(
+    defaults: KeyNumberDic,
+    panelWidths: KeyNumberDic,
+    componentRefInstance: HsPanelComponent
+  ): void {
+    if (componentRefInstance == undefined) {
+      return;
+    }
+    Object.assign(defaults, panelWidths);
+    const pnlWidth = defaults[componentRefInstance.name] || defaults.default;
+    const guessedClass = `hs-panel-width-${Math.round(pnlWidth / 25) * 25}`;
+    setTimeout(() => {
+      const rootView = componentRefInstance.viewRef as any; //Any is used because the actual class RootViewRef is not exported from angular
+      //Without timeout componentRefInstance.viewRef.rootNodes could contain only placeholder <!--container--> until the real content is loaded
+      for (const rootNode of rootView.rootNodes) {
+        for (const child of rootNode.children) {
+          if (!child.classList.contains(guessedClass)) {
+            child.classList.add(guessedClass);
+          }
+        }
+      }
+    }, 0);
   }
 }

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.ts
@@ -41,8 +41,8 @@ export class HsPanelContainerService
 
   /**
    * An admittedly hacky solution to set panel width
-   * from 2 dictionaries containing names (as in name property in PanelComponent)
-   * and numbers - defaults dictionary and HsConfig.panelWidths (priority) dictionary.
+   * from dictionary containing names (as in name property in PanelComponent)
+   * and numbers stored in HsConfig.panelWidths in most cases.
    * It's also possible to set the css class hs-panel-width-(400-850) on the panel
    * templates root element skipping the HsConfig.panelWidths.
    * @param panelWidths - key-value pairs of panel names and their widths

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.ts
@@ -48,20 +48,17 @@ export class HsPanelContainerService
    * and numbers - defaults dictionary and HsConfig.panelWidths (priority) dictionary.
    * It's also possible to set the css class hs-panel-width-(400-850) on the panel
    * templates root element skipping the HsConfig.panelWidths.
-   * @param defaults - key-value pairs of panel names and their widths
    * @param panelWidths - key-value pairs of panel names and their widths
    * @param componentRefInstance - Panel component instance which can be read from HsPanelContainerService.panels array
    */
   setPanelWidth(
-    defaults: KeyNumberDic,
     panelWidths: KeyNumberDic,
     componentRefInstance: HsPanelComponent
   ): void {
     if (componentRefInstance == undefined) {
       return;
     }
-    Object.assign(defaults, panelWidths);
-    const pnlWidth = defaults[componentRefInstance.name] || defaults.default;
+    const pnlWidth = panelWidths[componentRefInstance.name] || panelWidths.default;
     const guessedClass = `hs-panel-width-${Math.round(pnlWidth / 25) * 25}`;
     setTimeout(() => {
       const rootView = componentRefInstance.viewRef as any; //Any is used because the actual class RootViewRef is not exported from angular

--- a/projects/hslayers/src/components/layout/panels/panel-container.service.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.service.ts
@@ -1,19 +1,16 @@
-import {HsPanelComponent} from './panel-component.interface';
-import {HsPanelContainerServiceInterface} from './panel-container.service.interface';
-import {HsPanelItem} from './panel-item';
 import {Injectable, Type} from '@angular/core';
 import {ReplaySubject, Subject} from 'rxjs';
 
-type KeyNumberDic = {
-  [key: string]: number;
-};
+import {HsPanelComponent} from './panel-component.interface';
+import {HsPanelContainerServiceInterface} from './panel-container.service.interface';
+import {HsPanelItem} from './panel-item';
+import {KeyNumberDict} from '../../../config.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class HsPanelContainerService
-  implements HsPanelContainerServiceInterface
-{
+  implements HsPanelContainerServiceInterface {
   panels: HsPanelComponent[] = [];
   panelObserver: ReplaySubject<HsPanelItem> = new ReplaySubject();
   panelDestroyObserver: Subject<any> = new Subject();
@@ -52,13 +49,14 @@ export class HsPanelContainerService
    * @param componentRefInstance - Panel component instance which can be read from HsPanelContainerService.panels array
    */
   setPanelWidth(
-    panelWidths: KeyNumberDic,
+    panelWidths: KeyNumberDict,
     componentRefInstance: HsPanelComponent
   ): void {
     if (componentRefInstance == undefined) {
       return;
     }
-    const pnlWidth = panelWidths[componentRefInstance.name] || panelWidths.default;
+    const pnlWidth =
+      panelWidths[componentRefInstance.name] || panelWidths.default;
     const guessedClass = `hs-panel-width-${Math.round(pnlWidth / 25) * 25}`;
     setTimeout(() => {
       const rootView = componentRefInstance.viewRef as any; //Any is used because the actual class RootViewRef is not exported from angular

--- a/projects/hslayers/src/components/measure/measure.component.ts
+++ b/projects/hslayers/src/components/measure/measure.component.ts
@@ -17,7 +17,8 @@ import {HsUtilsService} from '../utils/utils.service';
 })
 export class HsMeasureComponent
   extends HsPanelBaseComponent
-  implements OnDestroy {
+  implements OnDestroy
+{
   type: string;
   data;
   name = 'measure';
@@ -35,17 +36,20 @@ export class HsMeasureComponent
     this.data = this.HsMeasureService.data;
     this.type = 'distance';
 
-    hsSidebarService.buttons.push({
-      panel: 'measure',
-      module: 'hs.measure',
-      order: 2,
-      fits: true,
-      title: () => hsLanguageService.getTranslation('PANEL_HEADER.MEASURE'),
-      description: () =>
-        hsLanguageService.getTranslation('SIDEBAR.descriptions.MEASURE'),
-      icon: 'icon-design',
-      condition: true,
-    });
+    //Don't need two buttons (sidebar and toolbar) to toggle measure panel
+    if (!this.HsLayoutService.componentEnabled('measureToolbar')) {
+      hsSidebarService.buttons.push({
+        panel: 'measure',
+        module: 'hs.measure',
+        order: 2,
+        fits: true,
+        title: () => hsLanguageService.getTranslation('PANEL_HEADER.MEASURE'),
+        description: () =>
+          hsLanguageService.getTranslation('SIDEBAR.descriptions.MEASURE'),
+        icon: 'icon-design',
+        condition: true,
+      });
+    }
 
     if (this.HsUtilsService.runningInBrowser()) {
       document.addEventListener('keyup', (e) => {

--- a/projects/hslayers/src/components/measure/measure.spec.ts
+++ b/projects/hslayers/src/components/measure/measure.spec.ts
@@ -7,6 +7,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {TranslateModule} from '@ngx-translate/core';
 
+import {HsConfig} from './../../config.service';
 import {HsLayoutService} from '../layout/layout.service';
 import {HsLayoutServiceMock} from '../layout/layout.service.mock';
 import {HsMapService} from '../map/map.service';
@@ -42,11 +43,16 @@ describe('HsMeasure', () => {
         {provide: HsLayoutService, useValue: new HsLayoutServiceMock()},
         {provide: HsMapService, useValue: new HsMapServiceMock()},
         {provide: HsUtilsService, useValue: new HsUtilsServiceMock()},
+        HsConfig,
       ],
     }); //.compileComponents();
     fixture = TestBed.createComponent(HsMeasureComponent);
     service = TestBed.inject(HsMeasureService);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
   });
 });

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -22,8 +22,11 @@ export type MapSwipeOptions = {
   orientation?: 'vertical' | 'horizontal';
 };
 
-interface LooseObject {
-  [key: string]: number
+/**
+ * Names and corresponding numbers
+ */
+export interface KeyNumberDict {
+  [key: string]: number;
 }
 
 @Injectable()
@@ -137,7 +140,7 @@ export class HsConfig {
   connectTypes?: AddDataUrlType[];
   uploadTypes?: AddDataFileType[];
   datasources?: any;
-  panelWidths?: LooseObject = {
+  panelWidths?: KeyNumberDict = {
     default: 425,
     ows: 700,
     composition_browser: 550,
@@ -208,8 +211,10 @@ export class HsConfig {
   update?(newConfig: HsConfig): void {
     this.checkDeprecatedCesiumConfig(newConfig);
     Object.assign(this.componentsEnabled, newConfig.componentsEnabled);
+    //Delete since we assign the whole object later and don't want it replaced, but merged
     delete newConfig.componentsEnabled;
     Object.assign(this.panelWidths, newConfig.panelWidths);
+    //See componentsEnabled ^
     delete newConfig.panelWidths;
     this.symbolizerIcons = [
       ...this.updateSymbolizers(newConfig),

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -22,6 +22,10 @@ export type MapSwipeOptions = {
   orientation?: 'vertical' | 'horizontal';
 };
 
+interface LooseObject {
+  [key: string]: number
+}
+
 @Injectable()
 export class HsConfig {
   private defaultSymbolizerIcons? = [
@@ -133,7 +137,13 @@ export class HsConfig {
   connectTypes?: AddDataUrlType[];
   uploadTypes?: AddDataFileType[];
   datasources?: any;
-  panelWidths?: any;
+  panelWidths?: LooseObject = {
+    default: 425,
+    ows: 700,
+    composition_browser: 550,
+    addData: 700,
+    mapSwipe: 550,
+  };
   sidebarToggleable?: boolean;
   sizeMode?: string;
   symbolizerIcons?: SymbolizerIcon[];

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -209,6 +209,8 @@ export class HsConfig {
     this.checkDeprecatedCesiumConfig(newConfig);
     Object.assign(this.componentsEnabled, newConfig.componentsEnabled);
     delete newConfig.componentsEnabled;
+    Object.assign(this.panelWidths, newConfig.panelWidths);
+    delete newConfig.panelWidths;
     this.symbolizerIcons = [
       ...this.updateSymbolizers(newConfig),
       ...(newConfig.symbolizerIcons ?? []),

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -90,6 +90,26 @@ export class HsConfig {
     tripPlanner?: boolean;
     addData?: boolean;
     mapSwipe?: boolean;
+  } = {
+    legend: true,
+    info: true,
+    composition_browser: true,
+    toolbar: true,
+    measure: true,
+    mobile_settings: false,
+    draw: true,
+    layermanager: true,
+    print: true,
+    saveMap: true,
+    language: true,
+    permalink: true,
+    compositionLoadingProgress: false,
+    sensors: true,
+    filter: false,
+    search: false,
+    tripPlanner: false,
+    addData: true,
+    mapSwipe: false,
   };
   advancedForm?: boolean;
   project_name?: string;
@@ -215,7 +235,8 @@ export class HsConfig {
     delete newConfig.componentsEnabled;
     Object.assign(this.panelWidths, newConfig.panelWidths);
     //See componentsEnabled ^
-    delete newConfig.panelWidths;
+    Object.assign(this.panelsEnabled, newConfig.panelsEnabled);
+    delete newConfig.panelsEnabled;
     this.symbolizerIcons = [
       ...this.updateSymbolizers(newConfig),
       ...(newConfig.symbolizerIcons ?? []),

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -51,9 +51,9 @@ export class HslayersComponent implements OnInit {
     private HsLayerManagerService: HsLayerManagerService,
     private hsToolbarPanelContainerService: HsToolbarPanelContainerService,
     private hsQueryPopupService: HsQueryPopupService,
-    private HsMapSwipeService: HsMapSwipeService,
-    private hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
-    hsExternalService: HsExternalService
+    private HsMapSwipeService: HsMapSwipeService, //Leave this, need to inject somewhere
+    private hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService, //Leave this, need to inject somewhere
+    hsExternalService: HsExternalService //Leave this, need to inject somewhere
   ) {}
 
   /**
@@ -64,11 +64,7 @@ export class HslayersComponent implements OnInit {
    * @param data - Extra misc data object to be stored in panel
    */
   createPanel(name: string, panelComponent: Type<any>, data?: any): void {
-    let panelsEnabled = this.hsConfig.panelsEnabled;
-    if (panelsEnabled == undefined || panelsEnabled[name] == undefined) {
-      panelsEnabled = this.hsLayoutService.panelsEnabledDefaults;
-    }
-    if (panelsEnabled[name]) {
+    if (this.hsConfig.panelsEnabled[name]) {
       this.hsLayoutService.createPanel(panelComponent, data || {});
     }
   }


### PR DESCRIPTION
## Description

Panel widths for external panels where not applied when switching back and forth between active panel.

This PR also rewrites the way how panels are enabled and disabled by default. Instead of having a separate object to manage default statuses, we set those on HsConfig.panelsEnabled instead. Otherwise wrong  panels are enabled incorrectly when HsConfig.update is called repeatedly, because HsConfig.panelsEnabled isn't undefined anymore.
## Related issues or pull requests

https://github.com/hslayers/hslayers-ng/pull/2549

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
