### PR TITLE
fix: Missing layer editor widgets after second toggle

### DIFF
--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -70,30 +70,17 @@ export class HsLayerEditorComponent {
     public HsEventBusService: HsEventBusService,
     public HsDialogContainerService: HsDialogContainerService,
     public HsLanguageService: HsLanguageService,
-    public hsLayerEditorWidgetContainerService: HsLayerEditorWidgetContainerService
-  ) {
-    this.hsLayerEditorWidgetContainerService.create(HsTypeWidgetComponent, {});
-    this.hsLayerEditorWidgetContainerService.create(
-      HsMetadataWidgetComponent,
-      {}
-    );
-    this.hsLayerEditorWidgetContainerService.create(HsScaleWidgetComponent, {});
-    this.hsLayerEditorWidgetContainerService.create(
-      HsClusterWidgetComponent,
-      {}
-    );
-    this.hsLayerEditorWidgetContainerService.create(
-      HsLegendWidgetComponent,
-      {}
-    );
-    this.hsLayerEditorWidgetContainerService.create(
-      HsLayerEditorDimensionsComponent,
-      {}
-    );
-    this.hsLayerEditorWidgetContainerService.create(
-      HsOpacityWidgetComponent,
-      {}
-    );
+    public hsWidgetContainerService: HsLayerEditorWidgetContainerService
+  ) {}
+
+  createWidgets() {
+    this.hsWidgetContainerService.create(HsTypeWidgetComponent, {});
+    this.hsWidgetContainerService.create(HsMetadataWidgetComponent, {});
+    this.hsWidgetContainerService.create(HsScaleWidgetComponent, {});
+    this.hsWidgetContainerService.create(HsClusterWidgetComponent, {});
+    this.hsWidgetContainerService.create(HsLegendWidgetComponent, {});
+    this.hsWidgetContainerService.create(HsLayerEditorDimensionsComponent, {});
+    this.hsWidgetContainerService.create(HsOpacityWidgetComponent, {});
   }
 
   /**

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.html
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.html
@@ -8,7 +8,7 @@
         </div>
         <div *ngIf="currentLayer.settings">
             <form>
-                <hs-panel-container [service]="hsLayerEditorWidgetContainerService">
+                <hs-panel-container [service]="hsWidgetContainerService" (init)="createWidgets()">
                 </hs-panel-container>
             </form>
             <div class="btn-group m-auto d-flex w-75" *ngIf="currentLayer.visible && getBase(currentLayer.layer)">

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -1,9 +1,11 @@
 import {
   Component,
   ComponentFactoryResolver,
+  EventEmitter,
   Input,
   OnDestroy,
   OnInit,
+  Output,
   ViewChild,
 } from '@angular/core';
 
@@ -29,6 +31,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
    * This is used if undefined value is passed to the create functions data parameter. */
   @Input() data: any;
   @Input() panelObserver?: ReplaySubject<HsPanelItem>;
+  @Output() init = new EventEmitter<void>();
   interval: any;
   private ngUnsubscribe = new Subject<void>();
   constructor(
@@ -61,6 +64,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
       .subscribe((item: HsPanelComponent) => {
         this.destroyPanel(item);
       });
+    this.init.emit();
   }
 
   destroyPanel(panel: HsPanelComponent): void {


### PR DESCRIPTION
## Description

Recreate layer editor widgets because widget container component is also recreated and distruction of it led to destruction of widget list

## Related issues or pull requests

fixes #2602
## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
