### PR TITLE
fix: Finding of correct layer when feature IDs overlap

### DIFF
--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -30,6 +30,10 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
   /** Miscellaneous data object to set to each of the panels inside this container.
    * This is used if undefined value is passed to the create functions data parameter. */
   @Input() data: any;
+  /**
+   * Set this to true to not clear the ReplaySubject on container destruction because
+   * panels are added to ReplaySubject from app component and we cant re-add them. */
+  @Input() reusePanelObserver?: boolean;
   @Input() panelObserver?: ReplaySubject<HsPanelItem>;
   @Output() init = new EventEmitter<void>();
   interval: any;
@@ -39,7 +43,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     private HsConfig: HsConfig
   ) {}
   ngOnDestroy(): void {
-    if (this.service.panelObserver) {
+    if (this.service.panelObserver && this.reusePanelObserver !== true) {
       this.service.panelObserver.complete();
       this.service.panelObserver = new ReplaySubject<HsPanelItem>();
     }

--- a/projects/hslayers/src/components/query/query-popup/query-popup.component.html
+++ b/projects/hslayers/src/components/query/query-popup/query-popup.component.html
@@ -5,7 +5,7 @@
             <i class="icon-remove-circle"></i>
         </a>
         <div *ngFor="let layerDesc of data.service.featureLayersUnderMouse; let i = index" class="hs-popup-layer">
-            <hs-panel-container [service]="hsQueryPopupWidgetContainerService" [panelObserver]="layerDesc.panelObserver"
+            <hs-panel-container [service]="hsQueryPopupWidgetContainerService" [reusePanelObserver]="true" [panelObserver]="layerDesc.panelObserver"
                 [data]="{layerDescriptor: layerDesc, attributesForHover: attributesForHover, service: data.service}">
             </hs-panel-container>
         </div>

--- a/projects/hslayers/src/components/query/query-vector.service.ts
+++ b/projects/hslayers/src/components/query/query-vector.service.ts
@@ -3,12 +3,12 @@ import {Injectable} from '@angular/core';
 
 import * as extent from 'ol/extent';
 import Feature from 'ol/Feature';
+import {Cluster, Vector as VectorSource} from 'ol/source';
 import {GeoJSON, WKT} from 'ol/format';
 import {Geometry} from 'ol/geom';
 import {Map} from 'ol';
 import {Select} from 'ol/interaction';
 import {Subject} from 'rxjs';
-import {Vector as VectorSource} from 'ol/source';
 import {click} from 'ol/events/condition';
 import {toLonLat} from 'ol/proj';
 
@@ -214,8 +214,8 @@ export class HsQueryVectorService {
     const layer = this.hsMapService.getLayerForFeature(feature);
     if (layer == undefined) {
       return;
-    } else if (layer.getSource().getSource) {
-      return layer.getSource().getSource();
+    } else if (this.hsUtilsService.instOf(layer.getSource(), Cluster)) {
+      return (layer.getSource() as Cluster).getSource();
     } else {
       return layer.getSource();
     }

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -66,6 +66,7 @@ export class HslayersAppComponent {
             'id': 'poly1',
             'population': Math.floor(Math.random() * 100000),
           },
+          'id': 'poly1',
         },
         {
           'type': 'Feature',
@@ -86,6 +87,7 @@ export class HslayersAppComponent {
             'id': 'poly2',
             'population': Math.floor(Math.random() * 100000),
           },
+          'id': 'poly2',
         },
         {
           'type': 'Feature',


### PR DESCRIPTION
## Description

Multiple layers can have features with the same id. In that case we need to loop through feature
collections and compare by feature instance instead.

## Related issues or pull requests

fix #2617

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
