### PR TITLE
fix: Container layer not rendered when one of the sub-layers has resolution restriction

### DIFF
--- a/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
@@ -231,6 +231,16 @@ export class HsLayerManagerMetadataService {
           subLayerArray.includes(l.Name)
         );
       }
+      if (
+        layerObj.queryable &&
+        this.HsLayerUtilsService.getLayerParams(olLayer)?.INFO_FORMAT ==
+          undefined
+      ) {
+        this.HsLayerUtilsService.updateLayerParams(olLayer, {
+          //TODO: Hslayers needs to support other formats too
+          INFO_FORMAT: 'application/vnd.ogc.gml', //Assumption that this will be supported by the server.
+        });
+      }
       this.collectLegend(layerObj, legends);
     }
     if (getCachedCapabilities(olLayer) == undefined) {

--- a/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
@@ -307,14 +307,14 @@ export class HsLayerManagerMetadataService {
       //Identify max resolution of layer. If layer has sublayers the highest value is selected
       setTimeout(() => {
         if (getMaxResolutionDenominator(layer)) {
-          layer.set('maxResolution', getMaxResolutionDenominator(layer));
+          layer.setMaxResolution(getMaxResolutionDenominator(layer));
           return;
         }
         const maxResolution = this.searchForScaleDenominator(
           layer.getProperties()
         );
         if (maxResolution) {
-          layer.set('maxResolution', maxResolution);
+          layer.setMaxResolution(maxResolution);
         }
       });
       return true;

--- a/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
@@ -25,7 +25,6 @@ import {HsLogService} from '../../common/log/log.service';
 import {HsWfsGetCapabilitiesService} from '../../common/get-capabilities/wfs-get-capabilities.service';
 import {HsWmsGetCapabilitiesService} from '../../common/get-capabilities/wms-get-capabilities.service';
 import {HsWmtsGetCapabilitiesService} from '../../common/get-capabilities/wmts-get-capabilities.service';
-import {Title} from '@angular/platform-browser';
 import {
   WMSGetCapabilitiesResponse,
   WmsLayer,
@@ -297,8 +296,11 @@ export class HsLayerManagerMetadataService {
 
       this.parseWmsCaps(layerDescriptor, layerNameInParams, caps);
       if (getSubLayers(layer)) {
-        params.LAYERS = params.LAYERS.concat(',', getSubLayers(layer));
-        this.HsLayerUtilsService.updateLayerParams(layer, params);
+        /* When capabilities have been queried, it's safe to override LAYERS 
+         param now to not render the container layer, but sublayers. */
+        this.HsLayerUtilsService.updateLayerParams(layer, {
+          LAYERS: getSubLayers(layer),
+        });
       }
 
       this.fillMetadataUrlsIfNotExist(layer, caps);


### PR DESCRIPTION
## Description

Use infinite (but dont show in layer editor as Infinite) maxScaleDenominator for the container wms layer if its not set.

In case MaxScaleDenominator attribute does exist on the container layer in capabilities, recurse the sublayers to stretch resolution range, like it used to be before.

This PR also fixes the problem, that in case when both sublayers and LAYERS param as container layer name are specified on the OL layer LAYERS params is prioritised. It should be the other way - sublayers should be prioritized.

## Related issues or pull requests

https://github.com/hslayers/hslayers-ng/issues/2639

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
