### PR TITLE
fix: Render font in styler imediately after change

### DIFF
--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -392,6 +392,7 @@ export class HsStylerService {
             {
               kind: 'Text',
               label: '{{features}}',
+              size: 12,
               haloColor: '#fff',
               color: '#000',
               offset: [0, 0],

--- a/projects/hslayers/src/components/styles/symbolizers/text-symbolizer/text-symbolizer.component.html
+++ b/projects/hslayers/src/components/styles/symbolizers/text-symbolizer/text-symbolizer.component.html
@@ -13,7 +13,7 @@
   <div class="d-flex flex-row">
     <div class="p-1 w-25">{{'STYLER.font' | translate}}:</div>
     <div class="p-1 w-75">
-      <select class="form-control form-select-sm form-select" [ngModelOptions]="{standalone: true}" [(ngModel)]="symbolizer.font"
+      <select class="form-control form-select-sm form-select" (change)="emitChange()" [ngModelOptions]="{standalone: true}" [(ngModel)]="symbolizer.font"
         multiple>
         <option *ngFor="let font of fonts" [ngValue]="font">{{font}}</option>
       </select>


### PR DESCRIPTION
## Description

emitChange and rerender on selecting font in styler->text-symbolizer

## Related issues or pull requests

fixes #2637

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
