### PR TITLE
Layer scale settings changes in LayerManager when layers are switched

### DIFF
--- a/projects/hslayers/src/components/layermanager/widgets/scale-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/scale-widget.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Component} from '@angular/core';
 
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
 import {HsLayerSelectorService} from '../editor/layer-selector.service';
@@ -9,7 +9,6 @@ import {METERS_PER_UNIT} from 'ol/proj';
 @Component({
   selector: 'hs-scale-widget',
   templateUrl: './scale-widget.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HsScaleWidgetComponent extends HsLayerEditorWidgetBaseComponent {
   name = 'scale-widget';


### PR DESCRIPTION
## Description

changeDetection: ChangeDetectionStrategy.OnPush was causing the scale value to stay the same even when layers where changed without closing the scale widged

## Related issues or pull requests

closes #2629 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
