### PR TITLE
Clear 'Layer not available' on each tile load start (Issue-2632)

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -37,6 +37,7 @@ const METADATA = 'metadata';
 const MINIMUM_TERRAIN_LEVEL = 'minimumTerrainLevel';
 const NAME = 'name';
 const ON_FEATURE_SELECTED = 'onFeatureSelected';
+const ORIG_LAYERS = 'origLayers';
 const PATH = 'path';
 const POPUP = 'popUp';
 const POPUP_CLASS = 'popupClass';
@@ -495,6 +496,21 @@ export function setOnFeatureSelected(
 
 export function getOnFeatureSelected(layer: Layer<Source>): FeatureSelector {
   return layer.get(ON_FEATURE_SELECTED);
+}
+
+/**
+ * Used internaly by hslayers. Store the original LAYERS param
+ * when overriding LAYERS by subLayers property. This is needed for metadata
+ * parsing after page has refreshed and LAYERS are read from cookie or map compositions.
+ * @param layer - OL layer
+ * @param origLayers - Comma separated list of layer names OR 1 container layer name
+ */
+export function setOrigLayers(layer: Layer<Source>, origLayers: string): void {
+  layer.set(ORIG_LAYERS, origLayers);
+}
+
+export function getOrigLayers(layer: Layer<Source>): string {
+  return layer.get(ORIG_LAYERS);
 }
 
 export function setPath(layer: Layer<Source>, path: string): void {

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.ts
@@ -43,7 +43,8 @@ export class HsUrlAddComponent {
 
   add(): void {
     if (this.layers) {
-      this.injectedService.addLayers(true);
+      const layers = this.injectedService.getLayers(true);
+      this.injectedService.addLayers(layers);
     }
     if (this.injectedService.addServices && this.services) {
       this.injectedService.addServices(this.services);

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.ts
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.ts
@@ -79,7 +79,8 @@ export class HsUrlDetailsComponent implements AfterContentInit {
         this.injectedService.isImageService &&
         this.injectedService.isImageService()
       ) {
-        this.injectedService.addLayers();
+        const layers = this.injectedService.getLayers();
+        this.injectedService.addLayers(layers);
       }
     }
   }

--- a/projects/hslayers/src/components/add-data/file/file-base.component.ts
+++ b/projects/hslayers/src/components/add-data/file/file-base.component.ts
@@ -74,6 +74,9 @@ export class HsAddDataFileBaseComponent
     this.setDataToDefault();
   }
 
+  /**
+   * Reset data object to its default values
+   */
   setDataToDefault(): void {
     this.data = {
       abstract: '',

--- a/projects/hslayers/src/components/add-data/url/add-data-ows.service.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-ows.service.ts
@@ -12,7 +12,7 @@ import {HsUrlArcGisService} from './arcgis/arcgis.service';
 import {HsUrlTypeServiceModel} from './models/url-type-service.model';
 import {HsUrlWfsService} from './wfs/wfs.service';
 import {HsUrlWmsService} from './wms/wms.service';
-import {HsUrlWmtsService} from './wmts/wmts-service';
+import {HsUrlWmtsService} from './wmts/wmts.service';
 import {HsWfsGetCapabilitiesService} from '../../../common/get-capabilities/wfs-get-capabilities.service';
 import {HsWmsGetCapabilitiesService} from '../../../common/get-capabilities/wms-get-capabilities.service';
 import {HsWmtsGetCapabilitiesService} from '../../../common/get-capabilities/wmts-get-capabilities.service';
@@ -46,6 +46,7 @@ export class HsAddDataOwsService {
   async connect(opt?: {
     style?: string;
     owrCache?: boolean;
+    getOnly?: boolean;
   }): Promise<Layer<Source>[]> {
     await this.setTypeServices();
     const url = this.hsAddDataCommonService.url;
@@ -86,9 +87,16 @@ export class HsAddDataOwsService {
         wrapper,
         opt?.style
       );
-      if (this.hsUrlArcGisService.isImageService()) {
-        this.hsUrlArcGisService.addLayers();
+      if (!opt?.getOnly) {
+        if (response?.length > 0) {
+          this.typeService.addLayers(response);
+        }
+        if (this.hsUrlArcGisService.isImageService()) {
+          const layers = this.hsUrlArcGisService.getLayers();
+          this.hsUrlArcGisService.addLayers(layers);
+        }
       }
+
       return response;
     }
   }
@@ -105,6 +113,7 @@ export class HsAddDataOwsService {
     return await this.connect({
       style: params.style,
       owrCache: params.owrCache,
+      getOnly: params.getOnly,
     });
   }
 

--- a/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
+++ b/projects/hslayers/src/components/add-data/url/models/url-type-service.model.ts
@@ -19,9 +19,10 @@ export interface HsUrlTypeServiceModel {
     wrapper: CapabilitiesResponseWrapper,
     sld?: string
   ): Promise<Layer<Source>[]>;
-  addLayers(checkedOnly?: boolean, style?: string): Layer<Source>[];
-  addLayer(layer: any, options: addLayerOptions): Layer<Source>;
-  addLayersRecursively?(
+  getLayers(checkedOnly?: boolean, style?: string): Layer<Source>[];
+  addLayers(layers: Layer<Source>[]): void;
+  getLayer(layer: any, options: addLayerOptions): Layer<Source>;
+  getLayersRecursively?(
     layer: any,
     options: addLayersRecursivelyOptions,
     collection: Layer<Source>[]

--- a/projects/hslayers/src/components/add-data/url/public-api.ts
+++ b/projects/hslayers/src/components/add-data/url/public-api.ts
@@ -7,7 +7,7 @@ export * from './wfs/wfs.service';
 export * from './wms/wms.component';
 export * from './wms/wms.module';
 export * from './wms/wms.service';
-export * from './wmts/wmts-service';
+export * from './wmts/wmts.service';
 export * from './wmts/wmts.component';
 export * from './wmts/wmts.module';
 export * from './add-data-url.component';

--- a/projects/hslayers/src/components/add-data/url/types/ows-connection.type.ts
+++ b/projects/hslayers/src/components/add-data/url/types/ows-connection.type.ts
@@ -4,4 +4,5 @@ export type owsConnection = {
   layer?: string;
   style?: string;
   owrCache?: boolean;
+  getOnly?: boolean;
 };

--- a/projects/hslayers/src/components/add-data/url/wmts/wmts.component.ts
+++ b/projects/hslayers/src/components/add-data/url/wmts/wmts.component.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 
 import {HsAddDataCommonService} from '../../common/common.service';
 import {HsAddDataOwsService} from '../add-data-ows.service';
-import {HsUrlWmtsService} from './wmts-service';
+import {HsUrlWmtsService} from './wmts.service';
 
 @Component({
   selector: 'hs-url-wmts',

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
@@ -194,7 +194,9 @@ export class HsAddDataVectorFileComponent implements OnInit, AfterViewInit {
       this.fileInput.nativeElement.value = '';
     }
   }
-
+  /**
+   * Reset data object to its default valuess
+   */
   setDataToDefault(): void {
     this.data = {
       // Not possible to save KML to layman yet

--- a/projects/hslayers/src/components/add-data/vector/vector-url/vector-url.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-url/vector-url.component.ts
@@ -35,7 +35,9 @@ export class HsAddDataVectorUrlComponent {
     this.hsLayoutService.setMainPanel('layermanager');
     this.setDataToDefault();
   }
-
+  /**
+   * Reset data object to its default values
+   */
   setDataToDefault(): void {
     this.data = {
       // Not possible to save KML to layman yet

--- a/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager-metadata.service.ts
@@ -80,7 +80,7 @@ export class HsLayerManagerMetadataService {
     try {
       await this.queryMetadata(layerDescriptor);
     } catch (error) {
-      this.hsLog.warn(`Error while querying metadata${error}`);
+      this.hsLog.warn(`Error while querying metadata ${error}`);
     }
     const subLayers = getCachedCapabilities(layer)?.Layer;
     if (subLayers != undefined && subLayers.length > 0) {
@@ -315,13 +315,12 @@ export class HsLayerManagerMetadataService {
 
       this.parseWmsCaps(layerDescriptor, layerNameInParams, caps);
       if (getSubLayers(layer)) {
-        /* When capabilities have been queried, it's safe to override LAYERS 
-         param now to not render the container layer, but sublayers. */
+        /* When capabilities have been queried, it's safe to override LAYERS
+         param now to not render the container layer, but sublayers.*/
         this.HsLayerUtilsService.updateLayerParams(layer, {
           LAYERS: getSubLayers(layer),
         });
       }
-
       this.fillMetadataUrlsIfNotExist(layer, caps);
       //Identify max resolution of layer. If layer has sublayers the highest value is selected
       setTimeout(() => {
@@ -460,7 +459,7 @@ export class HsLayerManagerMetadataService {
       return {
         Title: caps.mapName,
         Name: 0,
-        Layer: caps.layers.map((l) => {
+        Layer: caps?.layers?.map((l) => {
           return {Title: l.name, Name: l.id};
         }),
       };

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -814,6 +814,7 @@ export class HsLayerManagerService {
         this.changeLoadCounter(olLayer, loadProgress, 1);
       });
       source.on('imageloadend', (event) => {
+        loadProgress.error = false;
         this.changeLoadCounter(olLayer, loadProgress, -1);
       });
       source.on('imageloaderror', (event) => {
@@ -827,6 +828,7 @@ export class HsLayerManagerService {
         this.changeLoadCounter(olLayer, loadProgress, 1);
       });
       source.on('tileloadend', (event) => {
+        loadProgress.error = false;
         this.changeLoadCounter(olLayer, loadProgress, -1);
       });
       source.on('tileloaderror', (event) => {
@@ -918,6 +920,7 @@ export class HsLayerManagerService {
     toToggle: string,
     control: string
   ): void {
+    this.HsLayerManagerMetadata.fillMetadata(layer);
     if (toToggle == 'sublayers' && layer.hasSublayers != true) {
       return;
     }

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -32,6 +32,7 @@ import {
   getLegends,
   getMetadata,
   getName,
+  getOrigLayers,
   getPath,
   getShowInLayerManager,
   getSld,
@@ -358,6 +359,9 @@ export class HsSaveMapService {
           json.projection = src.getProjection().getCode().toLowerCase();
         }
         json.params = this.HsLayerUtilsService.getLayerParams(layer);
+        if (getOrigLayers(layer)) {
+          json.params.LAYERS = getOrigLayers(layer);
+        }
         json.subLayers = getSubLayers(layer);
         json.metadata.styles = src.get('styles');
       }

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -290,6 +290,7 @@ export class HslayersAppComponent {
       },
       enabledLanguages: 'sk, lv, en',
       assetsPath: 'assets',
+      saveMapStateOnReload: true,
       symbolizerIcons: [
         {name: 'bag', url: '/assets/icons/bag1.svg'},
         {name: 'banking', url: '/assets/icons/banking4.svg'},


### PR DESCRIPTION
## Description

By setting loadProgress.error = false; on imageloadstart and tileloadstart, the 'Layer not available' will be removed until all tiles fail to load, then it will be visible. When to connection returns, the message will be removed once again

## Related issues or pull requests

closes #2632

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
