### PR TITLE
Map swipe state in url, swipe control properties stored to local storage (Issue 2633)

### DIFF
--- a/projects/hslayers/src/components/add-data/vector/vector-layer-options.type.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-layer-options.type.ts
@@ -15,4 +15,5 @@ export type HsVectorLayerOptions = {
   access_rights?: accessRightsModel;
   queryCapabilities?: boolean;
   sld?: string;
+  saveToLayman?: boolean;
 };

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -97,16 +97,19 @@ export class HsAddDataVectorService {
         TODO: Should have set definition property with protocol inside 
         so layer synchronizer would know if to sync 
         */
-        if (this.hsUtilsService.undefineEmptyString(url) !== undefined) {
-          setDefinition(lyr, {
-            format: 'hs.format.WFS',
-            url: url,
-          });
-        } else {
-          setDefinition(lyr, {
-            format: 'hs.format.WFS',
-          });
+        if (options.saveToLayman) {
+          if (this.hsUtilsService.undefineEmptyString(url) !== undefined) {
+            setDefinition(lyr, {
+              format: 'hs.format.WFS',
+              url: url,
+            });
+          } else {
+            setDefinition(lyr, {
+              format: 'hs.format.WFS',
+            });
+          }
         }
+
         if (this.hsMapService.map) {
           this.hsAddDataService.addLayer(lyr, addUnder);
         }
@@ -177,12 +180,10 @@ export class HsAddDataVectorService {
         ? new sourceDescriptor.sourceClass(sourceDescriptor.sourceParams)
         : new sourceDescriptor.sourceClass(sourceDescriptor);
     descriptor.layerParams.source = src;
-    if (descriptor.layerParams.style) {
-      Object.assign(
-        descriptor.layerParams,
-        await this.hsStylerService.parseStyle(descriptor.layerParams.style)
-      );
-    }
+    Object.assign(
+      descriptor.layerParams,
+      await this.hsStylerService.parseStyle(descriptor.layerParams.style)
+    );
     const lyr = new VectorLayer(descriptor.layerParams);
     return lyr;
   }
@@ -239,6 +240,7 @@ export class HsAddDataVectorService {
           data.dataType != 'kml' &&
           data.dataType != 'gpx' &&
           !data.url?.endsWith('json'),
+        saveToLayman: data.saveToLayman,
       },
       data.addUnder
     );

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -25,6 +25,7 @@ import {
   getFromComposition,
   getTitle,
   setMetadata,
+  setSwipeSide,
 } from '../../common/layer-extensions';
 import {parseExtent, transformExtentValue} from '../../common/extent-utils';
 
@@ -477,6 +478,7 @@ export class HsCompositionsParserService {
     }
     if (resultLayer) {
       setMetadata(resultLayer, lyr_def.metadata);
+      setSwipeSide(resultLayer, lyr_def.swipeSide);
     }
     return resultLayer;
   }

--- a/projects/hslayers/src/components/map-swipe/map-swipe.service.mock.ts
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.service.mock.ts
@@ -1,6 +1,10 @@
 export function mockHsMapSwipeService() {
   return jasmine.createSpyObj('HsMapSwipeService', [
-    'init',
+    'setInitCtrlActive',
+    'setInitOri',
+    'updateUrlParam',
+    'updateStorageOri',
+    'initSwipeControl',
     'layersAvailable',
     'setOrientation',
     'fillSwipeLayers',

--- a/projects/hslayers/src/components/map-swipe/map-swipe.service.spec.ts
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.service.spec.ts
@@ -8,6 +8,7 @@ import {HsLayerShiftingService} from '../../common/layer-shifting/layer-shifting
 import {HsMapService} from '../map/map.service';
 import {HsMapServiceMock} from '../map/map.service.mock';
 import {HsMapSwipeService} from './map-swipe.service';
+import {HsShareUrlService} from '../permalink/share-url.service';
 import {HsToastService} from '../layout/toast/toast.service';
 import {mockHsLayerShiftingService} from '../../common/layer-shifting/layer-shifting.service.mock';
 
@@ -41,6 +42,13 @@ describe('HsMapSwipeService', () => {
         {
           provide: HsLayerShiftingService,
           useValue: mockHsLayerShiftingService(),
+        },
+        {
+          provide: HsShareUrlService,
+          useValue: {
+            getParamValue: () => undefined,
+            updateCustomParams: () => undefined,
+          },
         },
         {provide: HsEventBusService, useValue: new HsEventBusServiceMock()},
         {

--- a/projects/hslayers/src/components/map-swipe/swipe-control/swipe.control.class.ts
+++ b/projects/hslayers/src/components/map-swipe/swipe-control/swipe.control.class.ts
@@ -53,7 +53,7 @@ export class SwipeControl extends Control {
     if (options?.rightLayers) {
       this.addLayers(options.rightLayers, true);
     }
-
+    const storagePos = localStorage.getItem('hs_map_swipe_pos');
     this.on('propertychange', () => {
       if (this.getMap()) {
         try {
@@ -74,9 +74,10 @@ export class SwipeControl extends Control {
       }
       this.element.classList.remove('horizontal', 'vertical');
       this.element.classList.add(this.get('orientation'));
+      localStorage.setItem('hs_map_swipe_pos', this.get('position'));
     });
 
-    this.set('position', options?.position || 0.5);
+    this.set('position', storagePos ?? options?.position ?? 0.5);
     this.set('orientation', options?.orientation || 'vertical');
   }
 

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -37,6 +37,7 @@ import {
   getShowInLayerManager,
   getSld,
   getSubLayers,
+  getSwipeSide,
   getTitle,
   getWfsUrl,
   getWorkspace,
@@ -293,6 +294,7 @@ export class HsSaveMapService {
 
     // options
     json.visibility = layer.getVisible();
+    json.swipeSide = getSwipeSide(layer);
     json.opacity = layer.getOpacity();
     json.base = getBase(layer) ?? false;
     json.title = getTitle(layer);

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -244,6 +244,9 @@ export class HsStylerService {
   async parseStyle(
     style: any
   ): Promise<{sld?: string; qml?: string; style: StyleLike}> {
+    if (!style) {
+      return {style: await this.sldToOlStyle(defaultStyle)};
+    }
     if (
       typeof style == 'string' &&
       (style as string).includes('StyledLayerDescriptor')
@@ -252,9 +255,14 @@ export class HsStylerService {
     }
     if (typeof style == 'string' && (style as string).includes('<qgis')) {
       return {qml: style, style: await this.qmlToOlStyle(style)};
-    } else if (typeof style == 'object') {
+    } else if (
+      typeof style == 'object' &&
+      !this.hsUtilsService.instOf(style, Style)
+    ) {
       //Backwards compatibility with style encoded in custom JSON object
       return parseStyle(style);
+    } else {
+      return {style};
     }
   }
 

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -10,7 +10,8 @@ import {Vector as VectorLayer} from 'ol/layer';
 
 import {HsConfig} from 'hslayers-ng/src/config.service';
 import {HsEventBusService} from 'hslayers-ng/src/components/core/event-bus.service';
-import {HsQueryPopupWidgetContainerService} from 'hslayers-ng/src/public-api';
+import {HsQueryPopupWidgetContainerService} from 'hslayers-ng/src/components/query/query-popup-widget-container.service';
+
 import {PopupWidgetComponent} from './popup-widget.component';
 
 @Component({
@@ -341,7 +342,6 @@ export class HslayersAppComponent {
         {name: 'wifi', url: '/assets/icons/wifi8.svg'},
       ],
       status_manager_url: 'http://localhost:8086',
-
       popUpDisplay: 'hover',
       default_layers: [
         new Tile({


### PR DESCRIPTION
## Description

This PR provides requested features from the feature issue, such as, map-swipe custom URL parameter, that is used to check the state of the swipe control state.

Map swipe control position and orientation is now stored to local storage.
When the map composition is being shared or stored to local storage, swipeSide property is set for each layer, so it can be obtained.

## Related issues or pull requests

closes #2633 
closes #2655 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
