### PR TITLE
fix: Hide popup for layers where it's not configured

### DIFF
--- a/projects/hslayers/src/components/query/query-popup-base.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-base.service.ts
@@ -40,21 +40,23 @@ export class HsQueryPopupBaseService {
           ),
           'title'
         );
-        this.featureLayersUnderMouse = layersFound.map((l) => {
-          const needSpecialWidgets =
-            getPopUp(l)?.widgets || getPopUp(l)?.displayFunction;
-          const layer = {
-            title: getTitle(l),
-            layer: l,
-            features: this.featuresUnderMouse.filter(
-              (f) => this.hsMapService.getLayerForFeature(f) == l
-            ),
-            panelObserver: needSpecialWidgets
-              ? new ReplaySubject<HsPanelItem>()
-              : undefined,
-          };
-          return layer;
-        });
+        this.featureLayersUnderMouse = layersFound
+          .filter((l) => getPopUp(l)) //Only list the layers which have popUp defined
+          .map((l) => {
+            const needSpecialWidgets =
+              getPopUp(l)?.widgets || getPopUp(l)?.displayFunction;
+            const layer = {
+              title: getTitle(l),
+              layer: l,
+              features: this.featuresUnderMouse.filter(
+                (f) => this.hsMapService.getLayerForFeature(f) == l
+              ),
+              panelObserver: needSpecialWidgets
+                ? new ReplaySubject<HsPanelItem>()
+                : undefined,
+            };
+            return layer;
+          });
         for (const layer of this.featureLayersUnderMouse) {
           if (layer.panelObserver) {
             const popupDef = getPopUp(layer.layer);


### PR DESCRIPTION
## Description

Hide popup for layers where it's not configured

## Related issues or pull requests

fixes #2672


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
