### PR TITLE
fix: Look for wms layers with name recursively

### DIFF
--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -304,7 +304,9 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
     return boundingbox; // TODO: ?? serviceLayer.BoundingBox; (is more complex, contains SRS definition etc.)
   }
 
-  //TODO: what is the reason to do such things?
+  /**
+   * Filters out layers without 'Name' parameter
+   */
   filterCapabilitiesLayers(layers: WmsLayer | Array<WmsLayer>): Array<any> {
     if (Array.isArray(layers)) {
       return layers;
@@ -317,9 +319,7 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
           return layersWithNameParam;
         }
         for (const layer of layers.Layer) {
-          if (Array.isArray(layer?.Layer)) {
-            tmp.push(...layer.Layer.filter((layer) => layer.Name));
-          }
+          tmp.push(...this.filterCapabilitiesLayers(layer));
         }
       } else {
         tmp = [layers];
@@ -327,7 +327,6 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
     }
     return tmp;
   }
-
   /**
    * Removes extra port which is added to the getMap request when
    * GetCapabilities is queried through proxy. <GetMap><DCPType><HTTP><Get>


### PR DESCRIPTION
## Description
Look for wms layers with 'Name' parameter without the 'depth' limit . 
Example service which we were not able to correctly parse layer from :
https://geoportal.gov.cz/arcgis/services/CENIA/cenia_copernicus_land/MapServer/WmsServer?request=GetCapabilities&service=WMS&version=1.3.0
**Structure:** 
Capabilities -> Layer -> Layer (title: Lokalni kompnenta) -> Layer (title: Natura 2000) ->  Layer (name:0)

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
