### PR TITLE
fix(print): Provide correct wms layer legend height

### DIFF
--- a/projects/hslayers/src/components/print/print-legend.service.ts
+++ b/projects/hslayers/src/components/print/print-legend.service.ts
@@ -55,7 +55,7 @@ export class HsPrintLegendService {
           subscriber.complete();
         };
         if (
-          svgSource.indexOf('data') !== 0 &&
+          svgSource?.indexOf('data') !== 0 &&
           img.getAttribute('crossOrigin') !== undefined
         ) {
           img.setAttribute('crossOrigin', 'anonymous');
@@ -291,27 +291,34 @@ export class HsPrintLegendService {
         const img = new Image();
         const width = this.legendWidth;
         if (
-          imageUrl.indexOf('data') !== 0 &&
+          imageUrl?.indexOf('data') !== 0 &&
           img.getAttribute('crossOrigin') !== undefined
         ) {
           img.setAttribute('crossOrigin', 'anonymous');
         }
-        img.onload = function () {
+        img.onload = () => {
           const canvas = document.createElement('canvas');
-          canvas.width = img.width;
-          canvas.height = img.height;
-
+          this.hsShareThumbnailService.setCanvasSize(
+            canvas,
+            this.legendWidth,
+            img.height
+          );
           const ctx = canvas.getContext('2d');
           ctx.drawImage(img, 0, 0);
+          ctx.font = '14px sans-serif';
+          const additionalHeight =
+            Math.ceil(ctx.measureText(layerTitle).width) > width ? 40 : 20;
           const dataURL = canvas.toDataURL('image/png');
           const svgSource = `<svg xmlns='http://www.w3.org/2000/svg' width='${width}' height='${
-            canvas.height + 40
+            canvas.height + additionalHeight
           }'>
             <foreignObject width='100%' height='100%'>
                 <div xmlns='http://www.w3.org/1999/xhtml'>
                     ${layerTitle}
                 </div>
-              <svg><image href="${dataURL}"></image></svg>
+              <svg width='${width}' height='${
+            canvas.height
+          }'><image href="${dataURL}"></image></svg>
             </foreignObject>
         </svg>`;
           const svg = 'data:image/svg+xml,' + encodeURIComponent(svgSource);


### PR DESCRIPTION
## Description

Quick fix for print wms layer legend height

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
