### PR TITLE
Create queryFilter for layer when mapSwipe is enabled (Issue-2902)

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -641,7 +641,7 @@ export function setWfsUrl(layer: Layer<Source>, url: string): void {
   layer.set(WFS_URL, url);
 }
 
-export function getSwipeSide(layer: Layer<Source>): string {
+export function getSwipeSide(layer: Layer<Source>): 'left' | 'right' {
   return layer.get(SWIPE_SIDE);
 }
 

--- a/projects/hslayers/src/components/map-swipe/swipe-control/swipe.control.class.ts
+++ b/projects/hslayers/src/components/map-swipe/swipe-control/swipe.control.class.ts
@@ -278,10 +278,10 @@ export class SwipeControl extends Control {
               window.pageXOffset -
               document.documentElement.clientLeft;
 
-            l = this.getMap().getSize()[0];
-            const w = l - Math.min(Math.max(0, l - pageX), l);
-            l = w / l;
-            this.set('position', l);
+            this.set(
+              'position',
+              this.getPosValue(this.getMap().getSize()[0], pageX)
+            );
             this.dispatchEvent('moving');
           } else {
             let pageY =
@@ -297,11 +297,10 @@ export class SwipeControl extends Control {
               this.getMap().getTargetElement().getBoundingClientRect().top +
               window.pageYOffset -
               document.documentElement.clientTop;
-
-            l = this.getMap().getSize()[1];
-            const h = l - Math.min(Math.max(0, l - pageY), l);
-            l = h / l;
-            this.set('position', l);
+            this.set(
+              'position',
+              this.getPosValue(this.getMap().getSize()[1], pageY)
+            );
             this.dispatchEvent('moving');
           }
         }
@@ -394,5 +393,17 @@ export class SwipeControl extends Control {
     } else {
       e.context.restore();
     }
+  }
+
+  /** Get the position of an element or event action relative to the map
+   *	@param mapSize - OL Map size (width or height)
+   *  @param coord - Coordinate provided (X or Y)
+   * @returns Position relative to map size
+   */
+  getPosValue(mapSize: number, coord: number): number {
+    let l = mapSize;
+    const w = l - Math.min(Math.max(0, l - coord), l);
+    l = w / l;
+    return l;
   }
 }

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -529,6 +529,9 @@ export class HslayersAppComponent {
             new Tile({
               properties: {
                 title: 'Latvian municipalities (parent layer)',
+                queryFilter: (map, layer, pixel) => {
+                  return true;
+                },
               },
               source: new TileWMS({
                 url: 'https://lvmgeoserver.lvm.lv/geoserver/ows',


### PR DESCRIPTION

## Description

This PR resolves issue, when map swipe is active, the info tool is querying layers no matter in which panel they are.

## Related issues or pull requests

closes #2902 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
