### PR TITLE
Ensure Layman username at first login

### DIFF
--- a/projects/hslayers-server/package.json
+++ b/projects/hslayers-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hslayers-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "server.js",
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/projects/hslayers-server/src/layman.js
+++ b/projects/hslayers-server/src/layman.js
@@ -61,7 +61,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use(authnUtil.addIncomingTimestamp);
 
-// Get user profile from Layman instead of Liferay
+// Get user profile from Layman instead of CMS
 OAuth2.prototype.userProfile = (access_token, done) => {
 
   (async () => {
@@ -73,6 +73,9 @@ OAuth2.prototype.userProfile = (access_token, done) => {
           'Authorization': `Bearer ${access_token}`,
         }
       });
+
+      // reserve username in Layman in case it does not exist yet
+      authnUtil.ensureUsername(access_token, response.body);
 
       console.log(response.body);
       done(null, response.body);
@@ -134,7 +137,7 @@ app.get('/logout', (req, res) => {
 
 app.get('/callback', passport.authenticate('oauth2', { failureRedirect: '/error' }), function (req, res) {
   if (req.session.passport && req.session.passport.user && (req.session.passport.user.authenticated || req.session.passport.user.ticket)) {
-    res.send(`Logged in as ${req.session.passport.user.screenName || req.session.passport.user.username}. You can now close this window and return back to the map. <a href="javascript:window.close()">Close</a>
+    res.send(`Logged in as ${req.session.passport.user.username || req.session.passport.user.claims.screen_name}. You can now close this window and return back to the map.
     <script>
     function inIframe () {
         try {


### PR DESCRIPTION
## Description

Add missing username reservation in Layman when logging in from the map.

## Related issues or pull requests

Closes #2923 

## Pull request type

- [X] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [X] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [X] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [X] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [X] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [X] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [X] I'm lost; why do I have to check so many boxes? Please help!
