### PR TITLE
Hide save map button, if saveMap panel is disabled (Issue-2946)

### DIFF
--- a/projects/hslayers/src/components/compositions/compositions.component.html
+++ b/projects/hslayers/src/components/compositions/compositions.component.html
@@ -1,11 +1,13 @@
 <div class="card hs-main-panel" [hidden]="!isVisible()">
-    <hs-panel-header name="composition_browser" [title]="'PANEL_HEADER.COMPOSITIONS' | translateHs : data" [app]="data.app">
+    <hs-panel-header name="composition_browser" [title]="'PANEL_HEADER.COMPOSITIONS' | translateHs : data"
+        [app]="data.app">
         <extra-buttons>
-            <button class="but-title-sm hs-extra-buttons" (click)="reload()" [title]="'COMMON.reload' | translateHs : data">
+            <button class="but-title-sm hs-extra-buttons" (click)="reload()"
+                [title]="'COMMON.reload' | translateHs : data">
                 <i class="glyphicon icon-fatredo"></i>
             </button>
             <button class="but-title-sm hs-extra-buttons" [title]="'PANEL_HEADER.SAVECOMPOSITION'|translateHs : data"
-                (click)="openSaveMapPanel()">
+                (click)="openSaveMapPanel()" [hidden]="!saveMapAvailable()">
                 <span class="icon-save-floppy"></span>
             </button>
             <label class="but-title-sm hs-extra-buttons btn-file mb-0" style="font-size: 14px; padding: 1px 6px;"

--- a/projects/hslayers/src/components/compositions/compositions.component.ts
+++ b/projects/hslayers/src/components/compositions/compositions.component.ts
@@ -272,4 +272,10 @@ export class HsCompositionsComponent
       this.data.app
     );
   }
+  /**
+   * Get save map panel status
+   */
+  saveMapAvailable(): boolean {
+    return this.hsLayoutService.panelEnabled('saveMap', this.data.app);
+  }
 }


### PR DESCRIPTION
## Description

Hide save map button, if saveMap panel is disabled

## Related issues or pull requests

closes #2946 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
