### PR TITLE
CreatePanel and createOverlay app should be optional

### DIFF
--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -484,11 +484,11 @@ export class HsLayoutService {
     });
   }
 
-  createPanel(panelComponent: Type<any>, app: string, data?: any): void {
+  createPanel(panelComponent: Type<any>, app?: string, data?: any): void {
     this.hsPanelContainerService.create(panelComponent, data || {}, app);
   }
 
-  createOverlay(panelComponent: Type<any>, app: string, data?: any): void {
+  createOverlay(panelComponent: Type<any>, app?: string, data?: any): void {
     this.hsOverlayPanelContainerService.create(panelComponent, data || {}, app);
   }
 }

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -484,7 +484,7 @@ export class HsLayoutService {
     });
   }
 
-  createPanel(panelComponent: Type<any>, app?: string, data?: any): void {
+createPanel(panelComponent: Type<any>, app = 'default', data?: any): void {
     this.hsPanelContainerService.create(panelComponent, data || {}, app);
   }
 


### PR DESCRIPTION
## Description

When creating panel or overlay using Layout service, app property should be optional as it is for the container service

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
