### PR TITLE
perf: Don't call functions from sidebar template

### DIFF
--- a/projects/hslayers-sensors/src/components/sensors/partials/sensors.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/sensors.component.html
@@ -1,4 +1,4 @@
-<div class="card panel-default hs-main-panel" [hidden]="!isVisible()">
+<div class="card panel-default hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="sensors" [app]="data.app" [title]="'PANEL_HEADER.SENSORS' | translateHs: data">
     </hs-panel-header>
     <div class="card-body">
@@ -30,7 +30,7 @@
             </div>
         </div>
         <ul class="list-group">
-            <li *ngFor="let unit of filterQuery(query)" class="list-group-item">
+            <li *ngFor="let unit of filterQuery(query)" class="list-group-item"><!-- TODO: Remove function call from template -->
                 <hs-sensor-unit-list-item [unit]="unit" [expanded]="viewExpanded" [view-mode]="viewMode"
                     [app]="data.app">
                 </hs-sensor-unit-list-item>

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
@@ -5,7 +5,7 @@
         <div class="modal-content">
             <div class="modal-header" style="padding: 0.2rem 0.3rem;">
                 <h4 class="modal-title">
-                    {{'SENSORS.sensorUnit' | translateHs: data}} {{getUnitDescription()}}
+                    {{'SENSORS.sensorUnit' | translateHs: data}} {{getUnitDescription()}}<!-- TODO: Remove function call from template -->
                 </h4>
                 <button type="button" class="btn-close" (click)="close()" data-dismiss="modal"
                     attr.aria-label="{{'COMMON.close' | translateHs: data}}"></button>
@@ -26,7 +26,7 @@
                         <th>{{'SENSORS.avg' | translateHs: data}}</th>
                     </tr>
                     <tr *ngFor="let aggr of getAggregations()">
-                        <td>{{getTranslation(aggr.sensor_name)}}</td>
+                        <td>{{getTranslation(aggr.sensor_name)}}</td><!-- TODO: Remove function call from template -->
                         <td>{{aggr.min}}</td>
                         <td>{{aggr.max}}</td>
                         <td>{{aggr.avg}}</td>
@@ -36,7 +36,7 @@
             <div class="modal-footer" style="padding: 0.2rem 0.3rem;">
                 <div class="d-flex w-100">
                     <div class="m-1">
-                        <div class="btn-group" role="group">
+                        <div class="btn-group" role="group"><!-- TODO: Remove function call from template -->
                             <button type="button" class="btn btn-"
                                 [ngClass]="{'btn-primary': getCurrentInterval() === interval}"
                                 (click)="timeButtonClicked(interval)" *ngFor="let interval of getIntervals()"

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-list-item.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-list-item.component.html
@@ -3,7 +3,7 @@
     <ul class="list-group" [hidden]="!(expanded || unit.expanded)">
         <div *ngFor="let sensorType of unit.sensorTypes" class="list-group-item p-1">
             <a (click)="sensorType.expanded = !sensorType.expanded" class="hs-sensor-type"
-                style="line-height: 2em;">{{getTranslation(sensorType.name, 'SENSORNAMES')}}</a>
+                style="line-height: 2em;">{{getTranslation(sensorType.name, 'SENSORNAMES')}}</a><!-- TODO: Remove function call from template -->
             <ul class="list-group" [hidden]="!sensorType.expanded">
                 <li *ngFor="let sensor of sensorType.sensors" class="list-group-item p-1">
                     <div class="d-flex ">

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -92,8 +92,7 @@ export class HsSensorsService {
       module: 'hs.sensors',
       order: 6,
       fits: true,
-      title: () =>
-        this.hsLanguageService.getTranslation('PANEL_HEADER.SENSORS'),
+      title: 'PANEL_HEADER.SENSORS',
       description: '',
       icon: 'icon-weightscale',
     });

--- a/projects/hslayers/src/common/layman/layman-current-user.html
+++ b/projects/hslayers/src/common/layman/layman-current-user.html
@@ -1,12 +1,12 @@
 <div *ngIf="endpoint" style="margin-left: 1em; float: right; ">
     <a class="btn btn-primary" style="border-radius: 0.25rem; color: #fff;" (click)="login();"
-        *ngIf="isGuest() && sameDomain()">
+        *ngIf="isGuest() && sameDomain()"> <!-- TODO: Remove function call from template -->
         {{'COMPOSITIONS.loginToCatalogue' | translateHs : {app} }}</a>
     <a class="btn btn-primary" style="border-radius: 0.25rem; color: #fff;" (click)="login();"
-        *ngIf="isGuest() && !sameDomain()" href="{{authUrl()}}" target="_blank">
+        *ngIf="isGuest() && !sameDomain()" href="{{authUrl()}}" target="_blank"><!-- TODO: Remove function call from template -->
         {{'COMPOSITIONS.loginToCatalogue' | translateHs : {app} }}</a>
     <a class="btn btn-primary text-truncate"
         style="border-radius: 0.25rem; color: #fff; max-width:25ch; white-space:nowrap" (click)="logout()"
-        *ngIf="!isGuest()">{{'COMMON.Logout' | translateHs : {app} }}
-        {{endpoint.user}}</a>
+        *ngIf="!isGuest()">{{'COMMON.Logout' | translateHs : {app} }} 
+        {{endpoint.user}}</a><!-- TODO: Remove function call from template -->
 </div>

--- a/projects/hslayers/src/common/pager/pager.component.html
+++ b/projects/hslayers/src/common/pager/pager.component.html
@@ -1,4 +1,4 @@
-<div class="card-footer" *ngIf="resultsVisible()">
+<div class="card-footer" *ngIf="resultsVisible()"> <!-- TODO: Remove function call from template -->
   <ul class="pagination d-flex justify-content-center m-1 align-items-center">
     <li class="page-item" [ngClass]="{'disabled': appRef.listStart === 0 }"
       [ngStyle]="{'color' : appRef.listStart === 0 ? '#555' : '#007bff'}">
@@ -17,7 +17,7 @@
         {{appRef.matchedRecords}}</span>
     </li>
     <li class="page-item" [ngClass]="{'disabled': nextPageAvailable() }"
-      [ngStyle]="{'color' : nextPageAvailable() ? '#555' : '#007bff'}">
+      [ngStyle]="{'color' : nextPageAvailable() ? '#555' : '#007bff'}"> <!-- TODO: Remove function call from template -->
       <a class="page-link" (click)="getNextRecords()"><span aria-hidden="true">&raquo;</span></a>
     </li>
     <li ngbDropdown display="dynamic" placement="top-right" class="pe-3" style="position: absolute;

--- a/projects/hslayers/src/common/widgets/recursive-dd.html
+++ b/projects/hslayers/src/common/widgets/recursive-dd.html
@@ -1,4 +1,4 @@
-<dd *ngIf="!isIterable()">{{value}}</dd>
+<dd *ngIf="!isIterable()">{{value}}</dd><!-- TODO: Remove function call from template -->
 <dl *ngFor="let item of entries">
     <dt>{{item.key || item[0]}}</dt>
     <hs-widgets-recursive-dd [value]="item.value || item[1]" [app]="app"></hs-widgets-recursive-dd>

--- a/projects/hslayers/src/components/add-data/add-data.component.html
+++ b/projects/hslayers/src/components/add-data/add-data.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="datasource_selector" [title]="'PANEL_HEADER.DATASOURCE_SELECTOR' | translateHs : data"
         [app]="data.app">
     </hs-panel-header>

--- a/projects/hslayers/src/components/add-data/add-data.component.ts
+++ b/projects/hslayers/src/components/add-data/add-data.component.ts
@@ -61,7 +61,6 @@ export class HsAddDataComponent extends HsPanelBaseComponent implements OnInit {
   connectServiceFromUrlParam(type: AddDataUrlType): void {
     const url = this.hsShareUrlService.getParamValue(`hs-${type}-to-connect`);
     if (url) {
-      console.log('setparamsfromurl', this.data.app);
       this.hsLayoutService.setMainPanel('addData', this.data.app);
       this.hsAddDataService.get(this.data.app).dsSelected = 'url';
       this.hsAddDataUrlService.get(this.data.app).typeSelected = type;

--- a/projects/hslayers/src/components/add-data/add-data.component.ts
+++ b/projects/hslayers/src/components/add-data/add-data.component.ts
@@ -46,18 +46,8 @@ export class HsAddDataComponent extends HsPanelBaseComponent implements OnInit {
         module: 'hs.addData',
         order: 4,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.ADDLAYERS',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.ADDLAYERS',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.ADDLAYERS',
+        description: 'SIDEBAR.descriptions.ADDLAYERS',
         icon: 'icon-database',
       },
       this.data.app

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -40,7 +40,7 @@
         </div>
     </div>
     <div class="d-none">
-        <div class="p-0" [hidden]='hsAddDataCatalogueService.layerDownload(layer.endpoint,layer) === "#"'>
+        <div class="p-0" [hidden]='hsAddDataCatalogueService.layerDownload(layer.endpoint,layer) === "#"'><!-- TODO: Remove function call from template -->
             <a class="btn btn-sm btn-secondary" [href]='hsAddDataCatalogueService.layerDownload(layer.endpoint, layer)'
                 data-toggle="tooltip" [title]="'COMMON.download' | translateHs: {app} "><i
                     class="icon-download"></i></a>
@@ -81,7 +81,7 @@
         <div class="d-flex">
             <ul class="ms-auto p-2 list-unstyled" [hidden]="!explanationsVisible">
                 <li class="text-secondary small" *ngFor="let type of whatToAddTypes">
-                    {{type}} &ndash; {{translateString('ADDDATA.CATALOGUE.DESC', type)}}
+                    {{type}} &ndash; {{translateString('ADDDATA.CATALOGUE.DESC', type)}}<!-- TODO: Remove function call from template -->
                 </li>
             </ul>
         </div>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
@@ -21,11 +21,11 @@
                     title="GeoDCAT-AP" target="_blank"
                     [hidden]='selectedDS.type!=="micka" || hsAddDataCatalogueService.layerRDF(selectedDS, selectedLayer) === "#"'>
                     <i class="icon-share-alt"></i> RDF
-                </a>
+                </a><!-- TODO: Remove function call from template -->
                 <button type="button" class="btn btn-success"
                     [hidden]="!hsAddDataCatalogueMapService.isZoomable(selectedLayer)"
                     (click)="hsAddDataCatalogueMapService.zoomTo(selectedLayer.bbox, data.app)">{{'COMMON.zoomTo' |
-                    translateHs: data}}</button>
+                    translateHs: data}}</button><!-- TODO: Remove function call from template -->
                 <div *ngIf="selectedDS.type === 'layman'">
                     <button type="button" class="btn btn-primary ms-2" *ngFor="let type of selectedLayer.type"
                         (click)="addLayerToMap(selectedDS, selectedLayer, type)" data-dismiss="modal">

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.component.html
@@ -7,7 +7,7 @@
                 <i class="icon-search icon-primary"></i>
             </button>
         </div>
-        <hs-layman-current-user [app]="app" [endpoint]="hsLaymanService.getLaymanEndpoint()"></hs-layman-current-user>
+        <hs-layman-current-user [app]="app" [endpoint]="hsLaymanService.getLaymanEndpoint()"></hs-layman-current-user><!-- TODO: Remove function call from template -->
     </div>
     <div class="d-flex ms-4 me-3 justify-content-between py-1 ">
         <div class="d-flex">
@@ -17,7 +17,7 @@
                 <span class="ms-1">{{'COMPOSITIONS.filterByMap' | translateHs : {app}  }}</span>
             </div>
             <div class="input-group-text border-0 ms-1"
-                *ngIf="hsLaymanService.getLaymanEndpoint() && !hsLaymanService.isLaymanGuest()">
+                *ngIf="hsLaymanService.getLaymanEndpoint() && !hsLaymanService.isLaymanGuest()"><!-- TODO: Remove function call from template -->
                 <input type="checkbox" [(ngModel)]="data.onlyMine" (ngModelChange)="queryByFilter()" name="onlyMine">
                 <span class="ms-1">{{'COMPOSITIONS.onlyMine' | translateHs : {app}  }}</span>
             </div>
@@ -25,7 +25,7 @@
 
         <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block">
             <button class="btn btn-light hs-white-background hs-custom-toggle" (click)="openOptionsMenu()"
-                ngbDropdownToggle>{{translateString('COMMON',optionsButtonLabel)}}</button>
+                ngbDropdownToggle>{{translateString('COMMON',optionsButtonLabel)}}</button><!-- TODO: Remove function call from template -->
             <div ngbDropdownMenu class="dropdown-menu-right p-2 m-1"
                 style="min-width: 23rem; max-width: 23rem;  overflow: visible" aria-labelledby="filtersDropdown">
                 <table class="p-1 ps-3" style="border-collapse:separate; border-spacing:0.5rem 0.5rem;">
@@ -83,7 +83,7 @@
                                 <button type="button" ngbDropdownToggle
                                     class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
                                     style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{translateString('ADDDATA.CATALOGUE.sortbyTypes', data.query.sortby)}}
+                                    {{translateString('ADDDATA.CATALOGUE.sortbyTypes', data.query.sortby)}}<!-- TODO: Remove function call from template -->
                                 </button>
                                 <ul ngbDropdownMenu aria-labelledby="sortBy" class="ps-2"
                                     style="overflow-y: auto; max-height: 10rem; min-width:10rem">

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
@@ -1,17 +1,17 @@
 <div class="w-100 mt-2" style="display: inline-block;" data-toggle="tooltip" data-placement="top"
-  title="{{hsAddDataCommonFileService.addTooltip(data, app)}}">
+  title="{{hsAddDataCommonFileService.addTooltip(data, app)}}"><!-- TODO: Remove function call from template -->
   <button *ngIf="hsAddDataCommonFileService.isAuthorized()" class="btn btn-primary w-100"
     [disabled]="!data.name || !data.srs" (click)="hsAddDataCommonFileService.addAsWms(data, app)">
     <i class="icon-plus" [hidden]="appRef.loadingToLayman"></i>
     <img [src]="hsUtilsService.getAjaxLoaderIcon(app)" [hidden]="!appRef.loadingToLayman" />
-    {{hsAddDataCommonFileService.getLoadingText(app)}}
+    {{hsAddDataCommonFileService.getLoadingText(app)}}<!-- TODO: Remove function call from template -->
     <ngb-progressbar *ngIf="appRef.loadingToLayman && appRef.asyncLoading" showValue="true" class="rounded-0 mb-1"
       type="secondary" [max]="1" [value]="hsLaymanService.totalProgress">
     </ngb-progressbar>
   </button>
 </div>
 <div *ngIf="!hsAddDataCommonFileService.isAuthorized()"
-  class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
+  class="alert alert-warning d-flex align-items-center mt-2 justify-content-between"><!-- TODO: Remove function call from template -->
   <p class="m-0"> {{'ADDLAYERS.SHP.loginRequired' | translateHs : {app} }}</p>
-  <hs-layman-current-user [app]="app" [endpoint]="hsLaymanService.getLaymanEndpoint()"></hs-layman-current-user>
+  <hs-layman-current-user [app]="app" [endpoint]="hsLaymanService.getLaymanEndpoint()"></hs-layman-current-user><!-- TODO: Remove function call from template -->
 </div>

--- a/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.html
+++ b/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.html
@@ -5,7 +5,7 @@
     <label for="folder" class="capabilities_label control-label">{{'ADDLAYERS.folderName' | translateHs : {app} }}</label>
   </div>
 
-  <div class="form-group" *ngIf="hsAddDataVectorService.isKml(data.type, data.url)">
+  <div class="form-group" *ngIf="hsAddDataVectorService.isKml(data.type, data.url)"><!-- TODO: Remove function call from template -->
     <input type="checkbox" name="extractStyles" [(ngModel)]="data.extract_styles" />
     <label class="capabilities_label control-label ms-1">{{'ADDLAYERS.VECTOR.extractStyles' |
       translateHs : {app} }}</label>

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -39,7 +39,7 @@
     </div>
   </div>
 
-  <ng-container *ngIf="hsAddDataCommonFileService.isAuthorized() && data.saveAvailable">
+  <ng-container *ngIf="hsAddDataCommonFileService.isAuthorized() && data.saveAvailable"><!-- TODO: Remove function call from template -->
     <hs-save-to-layman [data]="data" [app]="app"></hs-save-to-layman>
   </ng-container>
   <ng-container *ngIf="data.type === 'shp' || data.type === 'raster' || data.dataType === 'geojson'">

--- a/projects/hslayers/src/components/add-data/common/target-position/target-position.component.html
+++ b/projects/hslayers/src/components/add-data/common/target-position/target-position.component.html
@@ -5,7 +5,7 @@
             name="addUnder">
             <option [ngValue]="null" selected>{{'ADDLAYERS.none' | translateHs : {app} }}</option>
             <option [ngValue]="layer.layer" *ngFor="let layer of hsLayerManagerService.apps[app].data.layers">
-                {{hsLayerUtilsService.translateTitle(layer.title, app)}}</option>
+                {{hsLayerUtilsService.translateTitle(layer.title, app)}}</option><!-- TODO: Remove function call from template -->
         </select>
     </div>
 </div>

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.html
@@ -1,4 +1,4 @@
-<div [hidden]="!hsAddDataCommonService.get(app).showDetails || hsAddDataCommonService.get(app).loadingInfo">
+<div [hidden]="!hsAddDataCommonService.get(app).showDetails || hsAddDataCommonService.get(app).loadingInfo"><!-- TODO: Remove function call from template -->
   <ng-container>
     <div class="form-group">
       <div class="input-group">

--- a/projects/hslayers/src/components/add-data/common/url/nested-layers-table/nested-layers-table.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/nested-layers-table/nested-layers-table.component.html
@@ -29,7 +29,7 @@
             <td colspan="3">
                 <form class="form">
                     <div class="form-group" *ngFor="let dimension of sub_layer.Dimension">
-                        <ng-container *ngIf="isArray(dimension.values); else unsupported_dim_format">
+                        <ng-container *ngIf="isArray(dimension.values); else unsupported_dim_format"><!-- TODO: Remove function call from template -->
                             <label class="control-label">{{dimension.name}}:</label>
                             <div>
                                 <select class="form-control form-select" [(ngModel)]="dimension.value"

--- a/projects/hslayers/src/components/add-data/common/url/progress/progress.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/progress/progress.component.html
@@ -1,6 +1,6 @@
 <div class="d-flex justify-content-center btn-group w-75 m-auto">
   <button class="btn btn-primary w-75">{{'ADDDATA.CATALOGUE.loading' | translateHs: {app} }}<img class="ms-2"
-      [src]="hsUtilsService.getAjaxLoaderIcon(app)" /></button>
+      [src]="hsUtilsService.getAjaxLoaderIcon(app)" /></button><!-- TODO: Remove function call from template -->
   <button class="btn btn-secondary" (click)="hsAddDataService.cancelUrlRequest.next(app)">&#10006;
   </button>
 </div>

--- a/projects/hslayers/src/components/add-data/file/file.component.html
+++ b/projects/hslayers/src/components/add-data/file/file.component.html
@@ -4,7 +4,7 @@
             <button *ngFor="let type of types" [ngClass]="{'active': type.id === typeSelected }"
                 (click)="selectType(type.id)" style="margin: 3px;"
                 class="btn btn-light btn-outline-secondary rounded btn-sm mt-1 col-sm-3">
-                {{hsLanguageService.getTranslationIgnoreNonExisting('ADDLAYERS', type.text, undefined, app)}}
+                {{hsLanguageService.getTranslationIgnoreNonExisting('ADDLAYERS', type.text, undefined, app)}}<!-- TODO: Remove function call from template -->
             </button>
         </div>
     </div>

--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.component.html
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.component.html
@@ -6,7 +6,7 @@
     <hs-url-progress *ngIf="hsAddDataCommonService.get(app).loadingInfo" [app]="app"></hs-url-progress>
 
     <div *ngIf="hsAddDataCommonService.get(app).showDetails && !hsAddDataCommonService.get(app).loadingInfo"
-        class="card p-2">
+        class="card p-2"><!-- TODO: Remove function call from template -->
 
         <!-- FIXME: unused -->
         <div class="card-title text-center fw-bold">{{title}}</div>

--- a/projects/hslayers/src/components/add-data/url/wms/wms.component.html
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.component.html
@@ -2,6 +2,6 @@
     <hs-common-url type="wms" [app]="app" [(url)]="hsAddDataCommonService.get(app).url"
         (connect)="hsAddDataOwsService.connect(app)">
     </hs-common-url>
-    <hs-url-progress *ngIf="hsAddDataCommonService.get(app).loadingInfo" [app]="app"></hs-url-progress>
+    <hs-url-progress *ngIf="hsAddDataCommonService.get(app).loadingInfo" [app]="app"></hs-url-progress><!-- TODO: Remove function call from template -->
     <hs-url-details [injectedService]="hsUrlWmsService" [app]="app" type="wms"></hs-url-details>
 </form>

--- a/projects/hslayers/src/components/add-data/url/wmts/wmts.component.html
+++ b/projects/hslayers/src/components/add-data/url/wmts/wmts.component.html
@@ -5,7 +5,7 @@
 
     <hs-url-progress *ngIf="hsAddDataCommonService.get(app).loadingInfo" [app]="app"></hs-url-progress>
     <div *ngIf="hsAddDataCommonService.get(app).showDetails && !hsAddDataCommonService.get(app).loadingInfo"
-        class="card">
+        class="card"><!-- TODO: Remove function call from template -->
         <ul class="list-group">
             <li class="list-group-item hs-ows-layerlistheading clearfix bg-white">
                 <div>{{appRef.data.title}}</div>

--- a/projects/hslayers/src/components/compositions/compositions.component.html
+++ b/projects/hslayers/src/components/compositions/compositions.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="composition_browser" [title]="'PANEL_HEADER.COMPOSITIONS' | translateHs : data"
         [app]="data.app">
         <extra-buttons>
@@ -7,7 +7,7 @@
                 <i class="glyphicon icon-fatredo"></i>
             </button>
             <button class="but-title-sm hs-extra-buttons" [title]="'PANEL_HEADER.SAVECOMPOSITION'|translateHs : data"
-                (click)="openSaveMapPanel()" [hidden]="!saveMapAvailable()">
+                (click)="openSaveMapPanel()" [hidden]="!saveMapAvailable()"><!-- TODO: Remove function call from template -->
                 <span class="icon-save-floppy"></span>
             </button>
             <label class="but-title-sm hs-extra-buttons btn-file mb-0" style="font-size: 14px; padding: 1px 6px;"
@@ -37,7 +37,7 @@
                 <i class="icon-search icon-primary"></i>
             </button>
         </div>
-        <hs-layman-current-user [app]="data.app" [endpoint]="getLaymanEndpoint()">
+        <hs-layman-current-user [app]="data.app" [endpoint]="getLaymanEndpoint()"><!-- TODO: Remove function call from template -->
         </hs-layman-current-user>
     </div>
     <div class="d-flex ms-4 me-3 justify-content-between py-1 ">
@@ -47,7 +47,7 @@
                     name="catalogueRef.filterByExtent">
                 <span class="ms-1">{{'COMPOSITIONS.filterByMap' | translateHs : data}}</span>
             </div>
-            <div class="input-group-text border-0 ms-1" *ngIf="getLaymanEndpoint() && !isLaymanGuest()">
+            <div class="input-group-text border-0 ms-1" *ngIf="getLaymanEndpoint() && !isLaymanGuest()"><!-- TODO: Remove function call from template -->
                 <input type="checkbox" [(ngModel)]="catalogueRef.filterByOnlyMine" (change)='loadFilteredCompositions()'
                     name="catalogueRef.filterByOnlyMine">
                 <span class="ms-1">{{'COMPOSITIONS.onlyMine' | translateHs : data}}</span>
@@ -55,7 +55,7 @@
         </div>
         <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block">
             <button class="btn btn-light hs-white-background hs-custom-toggle" (click)="openOptionsMenu()"
-                ngbDropdownToggle>{{translateString('COMMON', optionsButtonLabel)}}</button>
+                ngbDropdownToggle>{{translateString('COMMON', optionsButtonLabel)}}</button><!-- TODO: Remove function call from template -->
             <div ngbDropdownMenu class="dropdown-menu-right p-2 m-1"
                 style="min-width: 23rem; max-width: 23rem;  overflow: visible" aria-labelledby="filtersDropdown">
                 <table class="p-1 ps-3" style="border-collapse:separate; border-spacing:0.5rem 0.5rem;">

--- a/projects/hslayers/src/components/compositions/compositions.component.ts
+++ b/projects/hslayers/src/components/compositions/compositions.component.ts
@@ -25,8 +25,7 @@ import {HsUtilsService} from '../utils/utils.service';
 })
 export class HsCompositionsComponent
   extends HsPanelBaseComponent
-  implements OnDestroy, OnInit
-{
+  implements OnDestroy, OnInit {
   keywordsVisible = false;
   themesVisible = false;
   urlToAdd = '';
@@ -59,18 +58,8 @@ export class HsCompositionsComponent
         module: 'hs.compositions',
         order: 3,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.MAPCOMPOSITIONS',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.MAPCOMPOSITIONS',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.MAPCOMPOSITIONS',
+        description: 'SIDEBAR.descriptions.MAPCOMPOSITIONS',
         icon: 'icon-map',
       },
       this.data.app

--- a/projects/hslayers/src/components/compositions/dialogs/csw-layers-dialog/csw-layers-dialog.component.html
+++ b/projects/hslayers/src/components/compositions/dialogs/csw-layers-dialog/csw-layers-dialog.component.html
@@ -31,7 +31,7 @@
                                     class="accordion-button justify-content-between">{{'COMPOSITIONS.cswDialog.servicesLoading'
                                     |
                                     translateHs:
-                                    data}}<img [src]="hsUtilsService.getAjaxLoaderIcon(data.app)" /></button>
+                                    data}}<img [src]="hsUtilsService.getAjaxLoaderIcon(data.app)" /></button><!-- TODO: Remove function call from template -->
                             </ng-template>
                         </ng-template>
                         <ng-template ngbPanelContent>

--- a/projects/hslayers/src/components/draw/draw-panel/draw-panel.component.html
+++ b/projects/hslayers/src/components/draw/draw-panel/draw-panel.component.html
@@ -35,7 +35,7 @@
                         <a class="dropdown-item text-truncate" *ngFor="let layer of appRef.drawableLayers"
                             data-toggle="tooltip" title="{{HsLayerUtilsService.translateTitle(getTitle(layer), app)}}"
                             (click)="selectLayer(layer)">{{HsLayerUtilsService.translateTitle(getTitle(layer),
-                            app)}}</a>
+                            app)}}</a><!-- TODO: Remove function call from template -->
                     </div>
                     <div class="d-flex align-items-center w-100 flex-column"
                         *ngIf="appRef.drawableLaymanLayers.length > 0">
@@ -135,7 +135,7 @@
                 <button class="btn btn-primary btn-sm hs-draw-selectAll" [disabled]="!appRef.selectedLayer"
                     (click)="HsDrawService.selectAllFeatures(app);selectionTypeDropdown.close()" data-toggle="tooltip"
                     [title]="'DRAW.deselectAllFeatures' | translateHs: {app} ">
-                    {{translateString('DRAW',appRef.toggleSelectionString)}}
+                    {{translateString('DRAW',appRef.toggleSelectionString)}}<!-- TODO: Remove function call from template -->
                 </button>
             </div>
         </div>
@@ -166,7 +166,7 @@
                                 data-toggle="tooltip"
                                 title="{{HsLayerUtilsService.translateTitle(getTitle(layer), app)}}"
                                 (click)="changeSnapSource(layer)">{{HsLayerUtilsService.translateTitle(getTitle(layer),
-                                app)}}</a>
+                                app)}}</a><!-- TODO: Remove function call from template -->
                         </div>
                     </div>
                 </div>

--- a/projects/hslayers/src/components/draw/draw-toolbar/draw-toolbar.html
+++ b/projects/hslayers/src/components/draw/draw-toolbar/draw-toolbar.html
@@ -1,4 +1,4 @@
-<div class="btn-group" [hidden]="!isVisible()">
+<div class="btn-group" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <button class="btn rounded-0 btn-light hs-toolbar-button"
         [ngClass]="appRef.highlightDrawButton ? 'btn-outline-danger' : 'btn-outline-secondary'"
         (click)="toggleDrawToolbar(data.app)">
@@ -104,7 +104,7 @@
                     <button class="btn btn-primary btn-sm hs-draw-selectAll w-100" [disabled]="!appRef.selectedLayer"
                         (click)="HsDrawService.selectAllFeatures(data.app); selectionTypeDropdown.close()"
                         data-toggle="tooltip" [title]="'STYLER.selection' | translateHs: data">
-                        {{translateString('DRAW',appRef.toggleSelectionString)}}
+                        {{translateString('DRAW',appRef.toggleSelectionString)}}<!-- TODO: Remove function call from template -->
                     </button>
                 </div>
             </div>

--- a/projects/hslayers/src/components/draw/draw.component.ts
+++ b/projects/hslayers/src/components/draw/draw.component.ts
@@ -46,18 +46,8 @@ export class HsDrawComponent extends HsPanelBaseComponent implements OnInit {
         module: 'hs.draw',
         order: 16,
         fits: true,
-        title: () =>
-          this.HsLanguageService.getTranslation(
-            'PANEL_HEADER.DRAW',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.HsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.DRAW',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.DRAW',
+        description: 'SIDEBAR.descriptions.DRAW',
         icon: 'icon-pencil',
       },
       this.data.app

--- a/projects/hslayers/src/components/draw/partials/draw.html
+++ b/projects/hslayers/src/components/draw/partials/draw.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="draw" [title]="'PANEL_HEADER.DRAW' | translateHs: data" [app]="data.app">
         <extra-buttons>
             <button class="but-title-sm" data-toggle="tooltip" [title]="'DRAW.drawInfo' | translateHs: data">
@@ -31,7 +31,7 @@
             </ol>
             {{'DRAW.longerLoading' | translateHs: data}}
             <div class="d-flex justify-content-center pt-3">
-                <img [src]="hsUtilsService.getAjaxLoaderIcon(data.app)" />
+                <img [src]="hsUtilsService.getAjaxLoaderIcon(data.app)" /><!-- TODO: Remove function call from template -->
             </div>
         </div>
     </div>

--- a/projects/hslayers/src/components/feature-table/feature-table.component.ts
+++ b/projects/hslayers/src/components/feature-table/feature-table.component.ts
@@ -18,8 +18,7 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsFeatureTableComponent
   extends HsPanelBaseComponent
-  implements OnInit
-{
+  implements OnInit {
   layers: VectorLayer<VectorSource<Geometry>>[] = [];
   name = 'feature_table';
   constructor(
@@ -39,18 +38,8 @@ export class HsFeatureTableComponent
         module: 'hs.feature-table',
         order: 14,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.FEATURE_TABLE',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.FEATURE_TABLE',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.FEATURE_TABLE',
+        description: 'SIDEBAR.descriptions.FEATURE_TABLE',
         icon: 'icon-indexmanager',
       },
       this.data.app

--- a/projects/hslayers/src/components/feature-table/partials/feature-table.component.html
+++ b/projects/hslayers/src/components/feature-table/partials/feature-table.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="feature_table" [title]="'PANEL_HEADER.FEATURE_TABLE' | translateHs : data" [app]="data.app"></hs-panel-header>
     <div class="card-body">
         <div *ngFor="let layer of layers">

--- a/projects/hslayers/src/components/feature-table/partials/layer-features.component.html
+++ b/projects/hslayers/src/components/feature-table/partials/layer-features.component.html
@@ -1,4 +1,4 @@
-<h3 class="mt-1" style="text-align: center">{{translateTitle(layer.title)}}</h3>
+<h3 class="mt-1" style="text-align: center">{{translateTitle(layer.title)}}<!-- TODO: Remove function call from template --></h3>
 <div class="form-group mt-1 mb-1">
     <div class="input-group" style="margin-bottom: 4px">
         <input type="text" class="form-control hs-filter" [placeholder]="'COMMON.filter' | translateHs : {app} "
@@ -8,7 +8,7 @@
 <table style="width:100%;" *ngFor="let feature of appRef.features | featureFilter: searchedFeatures">
     <thead>
         <tr style="text-align: center; background-color: rgba(0,0,0,0.05);">
-            <th colspan="2">{{translate(feature.name)}}
+            <th colspan="2">{{translate(feature.name)}}<!-- TODO: Remove function call from template -->
                 <a style="float: center;" (click)="sortFeaturesBy(feature.name)"
                     [title]="'FEATURE_TABLE.sortFeaturesByValue' | translateHs : {app} ">^</a>
             </th>
@@ -18,7 +18,7 @@
         <tr *ngFor="let attr of feature.attributes" rowspan="3">
             <th class="tdbreak" style="background-color: rgba(0,0,0,0.03);">
                 {{translate(attr.name)}}<a style="float: right;" (click)="sortFeaturesBy(attr.name)"
-                    [title]="'FEATURE_TABLE.sortFeaturesByValue' | translateHs : {app} ">^</a>
+                    [title]="'FEATURE_TABLE.sortFeaturesByValue' | translateHs : {app} ">^</a><!-- TODO: Remove function call from template -->
             </th>
             <td class="tdbreak" style="min-width: 200px; max-width: 200px;">
                 <span *ngIf="!attr.sanitizedValue && !attr.value?.operations">
@@ -28,13 +28,13 @@
                 <div *ngIf="attr.value?.operations">
                     <a *ngFor="let operation of attr.value.operations" (click)="executeOperation(operation)"><span>
                             <i> {{translate(operation.customActionName) ||
-                                translate(operation.action)}};</i></span></a>
+                                translate(operation.action)}};</i></span></a><!-- TODO: Remove function call from template -->
                 </div>
             </td>
         </tr>
         <tr [hidden]="!showFeatureStats" class="tdbreak" *ngFor="let stat of feature.stats">
             <th class="tdbreak" style="background-color: rgba(0,0,0,0.03);">
-                {{translate(stat.name)}}</th>
+                {{translate(stat.name)}}</th><!-- TODO: Remove function call from template -->
             <td class="tdbreak" style="min-width: 200px; max-width: 200px;"><span><i>{{stat.value}}</i></span></td>
         </tr>
     </tbody>

--- a/projects/hslayers/src/components/geolocation/partials/geolocation.component.html
+++ b/projects/hslayers/src/components/geolocation/partials/geolocation.component.html
@@ -1,5 +1,5 @@
 <div class="hs-locate ol-unselectable ol-control hs-locateToggler" [hidden]="!isVisible()"
-    [ngClass]="{'ol-collapsed': collapsed}">
+    [ngClass]="{'ol-collapsed': collapsed}"><!-- TODO: Remove function call from template -->
     <button class="ol-has-tooltip blocate hs-locateToggler" [title]="'GEOLOCATION.locateMe' | translateHs : data"
         *ngIf="!getLocalization()" type="button" (click)="startLocalization()">
         <i class="glyphicon icon-gpsoff-gps hs-locateToggler"></i>
@@ -7,6 +7,6 @@
     <button *ngIf="getLocalization()" class="ol-has-tooltip blocate hs-locateToggler hs-locationButton" type="button"
         (click)="toggleTracking()" [title]="'GEOLOCATION.locateMe' | translateHs : data" (dblclick)="stopLocalization()">
         <i class="glyphicon hs-locateToggler"
-            [ngClass]="(isFollowing() && getLocalization()) ? 'icon-navigation' : 'icon-gpson'"></i>
+            [ngClass]="(isFollowing() && getLocalization()) ? 'icon-navigation' : 'icon-gpson'"></i><!-- TODO: Remove function call from template -->
     </button>
 </div>

--- a/projects/hslayers/src/components/info/partials/info.component.html
+++ b/projects/hslayers/src/components/info/partials/info.component.html
@@ -1,4 +1,4 @@
-<div class="hs-info-container" [hidden]="!isVisible()">
+<div class="hs-info-container" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <div class="hs-info-area">
         <div class="hs-info-composition hs-main-panel" [hidden]="!!compositionLoaded()">
             <div class="hs-info-composition-image" [hidden]="!!composition_loaded">

--- a/projects/hslayers/src/components/language/language.component.ts
+++ b/projects/hslayers/src/components/language/language.component.ts
@@ -11,7 +11,8 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsLanguageComponent
   extends HsPanelBaseComponent
-  implements OnInit {
+  implements OnInit
+{
   available_languages: any;
   name = 'language';
   constructor(
@@ -31,18 +32,8 @@ export class HsLanguageComponent
         module: 'hs.language',
         order: 13,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.LANGUAGE',
-            undefined,
-            app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.LANGUAGE',
-            undefined,
-            app
-          ),
+        title: 'PANEL_HEADER.LANGUAGE',
+        description: 'SIDEBAR.descriptions.LANGUAGE',
         content: () => {
           return this.hsLanguageService
             .getCurrentLanguageCode(app)

--- a/projects/hslayers/src/components/language/partials/language.html
+++ b/projects/hslayers/src/components/language/partials/language.html
@@ -1,11 +1,11 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="language" [title]="'PANEL_HEADER.LANGUAGE' | translateHs : data" [app]="data.app">
     </hs-panel-header>
     <div class="card-body">
         <ul class="m-3 hs-senslog-list list-group">
             <button *ngFor="let lang of available_languages" class="btn m-1"
                 [ngClass]="isCurrentLang(lang.key) ? ' btn-primary' : ' btn-secondary'"
-                (click)="setLanguage(lang.key)">{{lang.name}}</button>
+                (click)="setLanguage(lang.key)">{{lang.name}}</button><!-- TODO: Remove function call from template -->
         </ul>
     </div>
 </div>

--- a/projects/hslayers/src/components/layermanager/dimensions/layer-editor-dimensions.html
+++ b/projects/hslayers/src/components/layermanager/dimensions/layer-editor-dimensions.html
@@ -1,4 +1,4 @@
-<div *ngIf="hsDimensionService.isLayerWithDimensions(olLayer)">
+<div *ngIf="hsDimensionService.isLayerWithDimensions(olLayer)"><!-- TODO: Remove function call from template -->
   <p style="text-align: center; font-weight: bold">
     {{'LAYERMANAGER.dimensions' | translateHs : data}}
   </p>

--- a/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.html
+++ b/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.html
@@ -8,7 +8,7 @@
       {{currentTime | date:timeDisplayFormat:'cs'}}
     </span>
     <span [hidden]="currentTimeDefined()" class="bg-warning text-dark" data-toggle="tooltip" data-container="body" data-placement="auto"
-    [ngbTooltip]="'LAYERMANAGER.time.outOfRangeDescription' | translateHs : {app} " [closeDelay]="hsConfig.get(app).layerTooltipDelay || 0">
+    [ngbTooltip]="'LAYERMANAGER.time.outOfRangeDescription' | translateHs : {app} " [closeDelay]="hsConfig.get(app).layerTooltipDelay || 0"><!-- TODO: Remove function call from template -->
       {{'LAYERMANAGER.time.outOfRange' | translateHs : {app} }}
     </span>
   </button>

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.html
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.html
@@ -31,25 +31,25 @@
             <div class="input-group">
                 <input type="text" class="form-control" [(ngModel)]="title" name="title">
                 <button [hidden]="!titleUnsaved()" (click)="saveTitle()" class="btn btn-outline-secondary"
-                    type="button"><i class="icon-save-floppy"></i></button>
+                    type="button"><i class="icon-save-floppy"></i></button><!-- TODO: Remove function call from template -->
             </div>
         </div>
         <div class="btn-group" role="group" [attr.aria-label]="'LAYERMANAGER.editorButtons' | translateHs : {app} ">
             <button class="btn btn-primary" (click)="zoomToLayer(app)" [disabled]="!layerIsZoomable()"
-                data-toggle="tooltip" [title]="'LAYERMANAGER.layerEditor.zoomToLayer' | translateHs : {app} "><i
+                data-toggle="tooltip" [title]="'LAYERMANAGER.layerEditor.zoomToLayer' | translateHs : {app} "><!-- TODO: Remove function call from template --><i
                     class="icon-search"></i></button>
             <button class="btn btn-primary" (click)="styleLayer()" [disabled]="!layerIsStyleable()"
                 data-toggle="tooltip" [title]="'LAYERMANAGER.layerEditor.styleLayer' | translateHs : {app} "><i
-                    class="icon-brush"></i></button>
+                    class="icon-brush"></i></button><!-- TODO: Remove function call from template -->
             <button class="btn btn-primary" (click)="toggleLayerRename()" data-toggle="tooltip"
                 [title]="'COMMON.renameLayer' | translateHs : {app} "><i class="icon-textfield"></i></button>
             <button class="btn btn-primary" (click)="createSaveDialog()" data-toggle="tooltip"
                 *ngIf="HsLayerEditorService.isLayerVectorLayer(currentLayer.layer)"
-                [title]="'LAYERMANAGER.layerEditor.savegeojson' | translateHs : {app} "><i class="icon-save-floppy"></i></button>
+                [title]="'LAYERMANAGER.layerEditor.savegeojson' | translateHs : {app} "><!-- TODO: Remove function call from template --><i class="icon-save-floppy"></i></button>
             <button class="btn btn-primary" (click)="copyLayer()" data-toggle="tooltip"
                 [title]="'COMMON.copyLayer' | translateHs : {app} "><i class="icon-copy"></i></button>
             <button class="btn btn-danger" (click)="removeLayer()" *ngIf="isLayerRemovable()" data-toggle="tooltip"
-                [title]="'COMMON.removeLayer' | translateHs : {app} "><i class="icon-trash"></i></button>
+                [title]="'COMMON.removeLayer' | translateHs : {app} "><i class="icon-trash"></i></button><!-- TODO: Remove function call from template -->
         </div>
     </div>
 

--- a/projects/hslayers/src/components/layermanager/editor/sub-layer-checkboxes.html
+++ b/projects/hslayers/src/components/layermanager/editor/sub-layer-checkboxes.html
@@ -6,7 +6,7 @@
         <label class="form-check-label">{{subLayer}}</label>
     </div>
     <!-- object -->
-    <div *ngIf="!subLayerIsString(subLayer)" class="w-100">
+    <div *ngIf="!subLayerIsString(subLayer)" class="w-100"><!-- TODO: Remove function call from template -->
         <div class="d-flex">
             <div class="p-0 form-check form-check-inline">
                 <input class="form-check-input" type="checkbox" [(ngModel)]="checkedSubLayers[subLayer.Name]"
@@ -47,7 +47,7 @@
                     <label class="form-check-label" [attr.for]="'hs-sublayers-'+subLayer">{{subLayer}}</label>
                 </div>
                 <hs-layer-editor-sub-layer-checkbox [subLayer]="subLayer" [app]="app"
-                    *ngIf="!subLayerIsString(subLayer)">
+                    *ngIf="!subLayerIsString(subLayer)"><!-- TODO: Remove function call from template -->
                 </hs-layer-editor-sub-layer-checkbox>
             </div>
         </div>

--- a/projects/hslayers/src/components/layermanager/gallery/basemap-gallery.html
+++ b/projects/hslayers/src/components/layermanager/gallery/basemap-gallery.html
@@ -1,4 +1,4 @@
-<div class="basemapGallery" style="z-index: 101;" [hidden]="!isVisible()">
+<div class="basemapGallery" style="z-index: 101;" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <div ngbDropdown placement="bottom-right" class="btn-group btn-group-sm" role="group"
         [attr.data-cy]="'basemap-gallery'" #galleryDropdown="ngbDropdown">
         <button ngbDropdownToggle type="button" class="btn rounded galleryButton pt-0 pb-0" aria-haspopup="true">
@@ -14,7 +14,7 @@
                 </div>
                 <div class="hs-miniMenu" [hidden]="!(layer.galleryMiniMenu === true && layer.active)"
                     [ngStyle]="{'position':'absolute'}"
-                    [ngClass]="{'expanded': hsLayerManagerService.apps[data.app].menuExpanded}">
+                    [ngClass]="{'expanded': hsLayerManagerService.apps[data.app].menuExpanded}"><!-- TODO: Remove function call from template -->
                     <div class="ps-1 w-100" *ngIf="!hsLayerManagerService.apps[data.app].menuExpanded"
                         (click)="hsLayerManagerService.setGreyscale(layer, data.app)">
                         <label class="form-check-label m-0"

--- a/projects/hslayers/src/components/layermanager/layermanager.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.component.ts
@@ -41,8 +41,7 @@ import {
 })
 export class HsLayerManagerComponent
   extends HsPanelBaseComponent
-  implements OnInit, OnDestroy, AfterViewInit
-{
+  implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('layerEditor', {static: false, read: ElementRef})
   layerEditorRef: ElementRef;
   map: any;
@@ -183,18 +182,8 @@ export class HsLayerManagerComponent
         module: 'hs.layermanager',
         order: 0,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.LM',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.LM',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.LM',
+        description: 'SIDEBAR.descriptions.LM',
         icon: 'icon-layers',
       },
       this.data.app

--- a/projects/hslayers/src/components/layermanager/layermanager.html
+++ b/projects/hslayers/src/components/layermanager/layermanager.html
@@ -1,4 +1,4 @@
-<div class="card panel-default hs-main-panel hs-layermanager-card" [hidden]="!isVisible()">
+<div class="card panel-default hs-main-panel hs-layermanager-card" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="layermanager" [title]="'PANEL_HEADER.LM' | translateHs : data" [app]="data.app">
         <extra-buttons>
             <div class="btn-group" ngbDropdown placement="left-top" display="dynamic">
@@ -34,8 +34,8 @@
             <div *ngFor="let box of appRef.data.box_layers" class="col-xs-2 col-md-2 list-group-item-primary"
                 style="padding-right: 2px; padding-left: 2px;">
                 <a [ngClass]="{ 'thumbnail': true, 'alert-info': getActive(box)}" title="{{getTitle(box)}}"
-                    (click)="activateTheme(box)">
-                    <img src="{{getThumbnail(box)}}" alt="{{getTitle(box)}}">
+                    (click)="activateTheme(box)"><!-- TODO: Remove function call from template -->
+                    <img src="{{getThumbnail(box)}}" alt="{{getTitle(box)}}"><!-- TODO: Remove function call from template -->
                 </a>
             </div>
         </div>
@@ -44,7 +44,7 @@
         </div>
 
         <ul *ngIf="!hsLayoutService.componentEnabled('basemapGallery', data.app)"
-            class="list-group hs-lm-baselayerlist">
+            class="list-group hs-lm-baselayerlist"><!-- TODO: Remove function call from template -->
             <li class="list-group-item hs-lm-item hs-lm-header clearfix list-group-item-primary">
                 <div class="d-flex">
                     <div class="p-0 flex-grow-1 hs-lm-item-title">
@@ -73,7 +73,7 @@
                     <div class="align-items-center p-0 flex-grow-1 hs-lm-item-title" style="cursor:context-menu"
                         [ngClass]="{'fw-bold': layer.active, 'text-muted' : layer.grayed}"
                         [ngbTooltip]="layer.abstract ? abstractTooltip : ''"
-                        [closeDelay]="hsConfig.get(data.app).layerTooltipDelay || 0">
+                        [closeDelay]="hsConfig.get(data.app).layerTooltipDelay || 0"><!-- TODO: Remove function call from template -->
                         {{hsLayerUtilsService.translateTitle(layer.title, data.app)}}
                     </div>
                     <div class="ps-1 info_btn" style="cursor: pointer;">
@@ -119,13 +119,13 @@
                     <div class="align-items-center p-0 flex-grow-1 hs-lm-item-title"
                         [ngClass]="{'fw-bold': layer.active, 'text-muted': layer.grayed}"
                         [ngbTooltip]="layer.abstract ? abstractTooltip : ''"
-                        [closeDelay]="hsConfig.get(data.app).layerTooltipDelay || 0">
+                        [closeDelay]="hsConfig.get(data.app).layerTooltipDelay || 0"><!-- TODO: Remove function call from template -->
                         {{hsLayerUtilsService.translateTitle(layer.title, data.app)}}
                     </div>
                 </div>
             </li>
         </ul>
-        <ul class="list-group hs-lm-mapcontentlist">
+        <ul class="list-group hs-lm-mapcontentlist"><!-- TODO: Remove function call from template -->
             <li *ngIf="!hsLayoutService.componentEnabled('basemapGallery', data.app)"
                 class="hs-lm-header hs-lm-item list-group-item-primary hs-lm-map-content-header list-group-item"
                 style="margin-bottom: 0.2em;">
@@ -137,7 +137,7 @@
                 <li class="list-group-item hs-lm-layerlist-header list-group-item-primary"
                     *ngIf="appRef.data.folders.sub_folders.length > 1" (click)="value.visible = !value.visible">
                     <span>{{hsLanguageService.getTranslationIgnoreNonExisting('LAYERMANAGER', value.name, undefined,
-                        data.app)}}&nbsp;</span>
+                        data.app)}}&nbsp;<!-- TODO: Remove function call from template --></span>
                     <span class="glyphicon"
                         [ngClass]="value.visible ? 'icon-chevron-right' : 'icon-chevron-down'"></span>
                 </li>

--- a/projects/hslayers/src/components/layermanager/logical-list/folder.html
+++ b/projects/hslayers/src/components/layermanager/logical-list/folder.html
@@ -1,9 +1,9 @@
 <div>
     <ul class="list-group" *ngFor="let value of folder.sub_folders">
         <a  class="list-group-item list-group-item-warning">
-            <span [ngStyle]="{'padding-left': value.indent*15}">{{HsLanguageService.getTranslationIgnoreNonExisting('LAYERMANAGER', value.name, undefined, app)}}</span>
+            <span [ngStyle]="{'padding-left': value.indent*15}">{{HsLanguageService.getTranslationIgnoreNonExisting('LAYERMANAGER', value.name, undefined, app)}}<!-- TODO: Remove function call from template --></span>
         </a>
-        <li [hidden]="!folderVisible(value)">
+        <li [hidden]="!folderVisible(value)"><!-- TODO: Remove function call from template -->
             <hs-layer-manager-folder [folder]="value" [app]="app"></hs-layer-manager-folder>
         </li>
         <li>

--- a/projects/hslayers/src/components/layermanager/logical-list/layerlist.html
+++ b/projects/hslayers/src/components/layermanager/logical-list/layerlist.html
@@ -1,10 +1,10 @@
 <div class="list-group-item hs-lm-list pb-1" *ngIf="folder.layers.length>0">
-    <ul class="list-group row">
+    <ul class="list-group row"><!-- TODO: Remove function call from template -->
         <li *ngFor="let layer of filtered_layers | filter:layerFilter" id="{{layer.idString()}}"
             class="list-group-item hs-lm-item"
             [ngClass]="{'hs-lm-detail-activated':'currentLayer == layer', 'grayed': layer.grayed === true}">
             <div class="d-flex">
-                <div class="p-0" [ngClass]="getExclusive(layer.layer) ? 'exclusive' : ''">
+                <div class="p-0" [ngClass]="getExclusive(layer.layer) ? 'exclusive' : ''"><!-- TODO: Remove function call from template -->
                     <button type="button" class="btn btn-sm btn-light hs-lm-item-visibility"
                         (click)="hsLayerManagerService.changeLayerVisibility(!layer.visible, layer, app);hsLayerListService.toggleSublayersVisibility(layer,app);$event.stopPropagation()"
                         [ngClass]="layer.visible ? 'hs-checkmark' : 'hs-uncheckmark'"></button>
@@ -56,7 +56,7 @@
                         data-placement="auto"></span>
                 </div>
             </div>
-            <hs-layermanager-time-editor [layer]="layer" class="d-flex" [app]="app" *ngIf="showLayerWmsT(layer)">
+            <hs-layermanager-time-editor [layer]="layer" class="d-flex" [app]="app" *ngIf="showLayerWmsT(layer)"><!-- TODO: Remove function call from template -->
             </hs-layermanager-time-editor>
         </li>
     </ul>

--- a/projects/hslayers/src/components/layermanager/physical-list/physical-layerlist.component.html
+++ b/projects/hslayers/src/components/layermanager/physical-list/physical-layerlist.component.html
@@ -5,7 +5,7 @@
             *ngFor="let layer of layerShiftingAppRef.layersCopy;" cdkDrag>
             <div class="d-flex align-items-center justify-content-between p-0 hs-lm-item-title flex-grow-1"
                 style="word-break:break-all; cursor:move">
-                <p class="m-0">{{translateTitle(layer.title)}}</p>
+                <p class="m-0">{{translateTitle(layer.title)}}<!-- TODO: Remove function call from template --></p>
                 <i class="icon-move text-secondary"></i>
             </div>
             <!-- <div *cdkDragPreview class="mw-100 physical-layerlist-preview">

--- a/projects/hslayers/src/components/layermanager/widgets/cluster-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/cluster-widget.component.html
@@ -3,7 +3,7 @@
   style="border-bottom: 1px solid rgba(0, 0, 0, 0.125)"
 >
   <!-- Cluster features checkbox  -->
-  <div *ngIf="isVectorLayer()" class="form-check flex-fill">
+  <div *ngIf="isVectorLayer()" class="form-check flex-fill"><!-- TODO: Remove function call from template -->
     <input
       name="layer-cluster"
       class="form-check-input"

--- a/projects/hslayers/src/components/layermanager/widgets/legend-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/legend-widget.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="olLayer">
-  <div *ngIf="HsLayerEditorService.legendVisible(data.app)">
+  <div *ngIf="HsLayerEditorService.legendVisible(data.app)"><!-- TODO: Remove function call from template -->
     <p style="text-align: center; font-weight: bold">
       {{ "COMMON.legend" | translateHs : data}}
     </p>

--- a/projects/hslayers/src/components/layermanager/widgets/metadata-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/metadata-widget.component.html
@@ -25,6 +25,6 @@
     <label>{{ "COMMON.abstract" | translateHs : data}}</label>
     <p [innerHtml]="
         HsLayerManagerService.makeSafeAndTranslate('LAYERS', abstract, data.app)
-      "></p>
+      "></p><!-- TODO: Remove function call from template -->
   </div>
 </ng-container>

--- a/projects/hslayers/src/components/layermanager/widgets/scale-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/scale-widget.component.html
@@ -1,4 +1,4 @@
-<div class="form-group" [hidden]="!isScaleVisible()">
+<div class="form-group" [hidden]="!isScaleVisible()"><!-- TODO: Remove function call from template -->
   <label>{{ "COMMON.scale" | translateHs : data}}</label>
   <span *ngIf="minResolutionValid()"><span class="ms-1">{{ "COMMON.from" | translateHs : data}}</span> 1:{{
     minResolution

--- a/projects/hslayers/src/components/layermanager/widgets/type-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/type-widget.component.html
@@ -7,7 +7,7 @@
     undefined,
     data.app
     )
-    }}
+    }}<!-- TODO: Remove function call from template -->
     {{ "LAYERMANAGER.layerEditor.layerFrom" | translateHs : data}}
     <span class="text-truncate mw-100 d-block">
       {{
@@ -17,7 +17,7 @@
       undefined,
       data.app
       )
-      }}
+      }}<!-- TODO: Remove function call from template -->
     </span>
   </small>
 </div>

--- a/projects/hslayers/src/components/layout/partials/layout.html
+++ b/projects/hslayers/src/components/layout/partials/layout.html
@@ -13,7 +13,7 @@
                 <hs-sidebar class="border-0" [app]="app"></hs-sidebar>
                 <div class="hs-panelplace">
                     <hs-mini-sidebar *ngIf="HsLayoutService.apps[app].minisidebar" [app]="app"
-                        [hidden]="!panelVisible('sidebar',app, this)">
+                        [hidden]="!panelVisible('sidebar',app, this)"><!-- TODO: Remove function call from template -->
                     </hs-mini-sidebar>
                     <hs-panel-container [service]="HsPanelContainerService" class="hs-panelplace" [app]="app">
                     </hs-panel-container>

--- a/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.html
+++ b/projects/hslayers/src/components/legend/legend-layer/legend-layer.component.html
@@ -7,7 +7,7 @@
             onload="if(this.height<6) { this.parentNode.removeChild(this); }">
     </div>
     <div *ngIf="layer.type === 'vector'">
-        <p *ngFor="let category of layer.lyr.getSource().legend_categories"><span
+        <p *ngFor="let category of layer.lyr.getSource().legend_categories"><!-- TODO: Remove function call from template --><span
                 [ngStyle]="{'background-color': category.color}">&nbsp;&nbsp;&nbsp;</span>&nbsp;{{category.name}}
         </p>
     </div>

--- a/projects/hslayers/src/components/legend/legend.component.html
+++ b/projects/hslayers/src/components/legend/legend.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="legend" [title]="'PANEL_HEADER.LEGEND' | translateHs : data" [app]="data.app">
     </hs-panel-header>
     <div class="card-body">
@@ -9,9 +9,9 @@
         </span>
         <ul class="list-group">
             <li *ngFor="let layer of filterDescriptors() | filter:legendFilter" class="list-group-item"
-                [hidden]="!hsLegendService.legendValid(layer)">
+                [hidden]="!hsLegendService.legendValid(layer)"><!-- TODO: Remove function call from template -->
                 <div>
-                    {{hsLayerUtilsService.translateTitle(layer.title, data.app)}}
+                    {{hsLayerUtilsService.translateTitle(layer.title, data.app)}}<!-- TODO: Remove function call from template -->
                     <hs-legend-layer-directive [app]="data.app" [layer]="layer"></hs-legend-layer-directive>
                 </div>
 

--- a/projects/hslayers/src/components/legend/legend.component.ts
+++ b/projects/hslayers/src/components/legend/legend.component.ts
@@ -43,18 +43,8 @@ export class HsLegendComponent extends HsPanelBaseComponent implements OnInit {
         module: 'hs.legend',
         order: 1,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.LEGEND',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.LEGEND',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.LEGEND',
+        description: 'SIDEBAR.descriptions.LEGEND',
         icon: 'icon-dotlist',
       },
       this.data.app

--- a/projects/hslayers/src/components/map-swipe/map-swipe.component.ts
+++ b/projects/hslayers/src/components/map-swipe/map-swipe.component.ts
@@ -25,7 +25,8 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsMapSwipeComponent
   extends HsPanelBaseComponent
-  implements OnDestroy, OnInit {
+  implements OnDestroy, OnInit
+{
   private ngUnsubscribe = new Subject<void>();
   swipeSide = SwipeSide;
   placeholders = {
@@ -54,18 +55,8 @@ export class HsMapSwipeComponent
         module: 'hs.mapSwipe',
         order: 18,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.MAP_SWIPE',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.MAP_SWIPE',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.MAP_SWIPE',
+        description: 'SIDEBAR.descriptions.MAP_SWIPE',
         icon: 'icon-resizehorizontalalt',
       },
       this.data.app

--- a/projects/hslayers/src/components/measure/measure.component.ts
+++ b/projects/hslayers/src/components/measure/measure.component.ts
@@ -17,7 +17,8 @@ import {HsUtilsService} from '../utils/utils.service';
 })
 export class HsMeasureComponent
   extends HsPanelBaseComponent
-  implements OnDestroy, OnInit {
+  implements OnDestroy, OnInit
+{
   type: string;
   name = 'measure';
   appRef;
@@ -91,18 +92,8 @@ export class HsMeasureComponent
           module: 'hs.measure',
           order: 2,
           fits: true,
-          title: () =>
-            this.hsLanguageService.getTranslation(
-              'PANEL_HEADER.MEASURE',
-              undefined,
-              app
-            ),
-          description: () =>
-            this.hsLanguageService.getTranslation(
-              'SIDEBAR.descriptions.MEASURE',
-              undefined,
-              app
-            ),
+          title: 'PANEL_HEADER.MEASURE',
+          description: 'SIDEBAR.descriptions.MEASURE',
           icon: 'icon-design',
           condition: true,
         },

--- a/projects/hslayers/src/components/measure/partials/measure-toolbar.html
+++ b/projects/hslayers/src/components/measure/partials/measure-toolbar.html
@@ -1,4 +1,4 @@
-<div class="nav-item" [hidden]="!isVisible()">
+<div class="nav-item" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <div class="btn-group">
         <button class="btn rounded-0 hs-toolbar-button btn-light btn-outline-secondary" [title]="'TOOLBAR.measureLinesAndPolygon' | translateHs : data" (click)="measureButtonClicked()">
             <i class="icon-design"></i>

--- a/projects/hslayers/src/components/measure/partials/measure.html
+++ b/projects/hslayers/src/components/measure/partials/measure.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
   <hs-panel-header name="measure" [title]="'PANEL_HEADER.MEASURE' | translateHs : data" [app]="data.app">
     <extra-title>&nbsp;<span [hidden]="!appRef.data.multipleShapeMode">{{'MEASURE.multipleShapes' |
         translateHs : data}}</span></extra-title>

--- a/projects/hslayers/src/components/permalink/partials/share.component.html
+++ b/projects/hslayers/src/components/permalink/partials/share.component.html
@@ -1,4 +1,4 @@
-<div class="card panel-default hs-main-panel" [hidden]="!isVisible()">
+<div class="card panel-default hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="permalink" [title]="'PANEL_HEADER.PERMALINK' | translateHs : data" [app]="data.app">
     </hs-panel-header>
     <div class="card-body">

--- a/projects/hslayers/src/components/permalink/share.component.ts
+++ b/projects/hslayers/src/components/permalink/share.component.ts
@@ -63,18 +63,8 @@ export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
         module: 'hs.permalink',
         order: 11,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.PERMALINK',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.PERMALINK',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.PERMALINK',
+        description: 'SIDEBAR.descriptions.PERMALINK',
         icon: 'icon-share-alt',
       },
       this.data.app

--- a/projects/hslayers/src/components/print/legend-styler/legend-styler.component.html
+++ b/projects/hslayers/src/components/print/legend-styler/legend-styler.component.html
@@ -24,7 +24,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="legendObj.posX"
       [ngModelOptions]="{standalone: true}">
       <option [ngValue]="positionX" *ngFor="let positionX of positionOptions.positionsX">
-        {{getTranslation('PRINT',positionX)}}
+        {{getTranslation('PRINT',positionX)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>
@@ -35,7 +35,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="legendObj.posY"
       [ngModelOptions]="{standalone: true}">
       <option [ngValue]="positionY" *ngFor="let positionY of positionOptions.positionsY">
-        {{getTranslation('PRINT',positionY)}}
+        {{getTranslation('PRINT',positionY)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>

--- a/projects/hslayers/src/components/print/print.component.html
+++ b/projects/hslayers/src/components/print/print.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="print" [title]="'PANEL_HEADER.PRINT' | translateHs : data">
         <extra-buttons>
             <button class="but-title-sm hs-extra-buttons mt-1" (click)="setToDefault()"
@@ -50,28 +50,28 @@
                 {{'PRINT.titleStylingOptions' | translateHs : data}}
             </button>
             <hs-print-text-styler *ngIf="getStylerVisible('title')" [app]="data.app" [textStyle]="print.titleObj.textStyle"
-                [objectName]="'title'">
+                [objectName]="'title'"><!-- TODO: Remove function call from template -->
             </hs-print-text-styler>
             <button type="button" [disabled]="!print.legendObj.include" (click)="setStylerVisible('legend')"
                 class="btn w-100 mb-2 btn-outline-secondary dropdown-toggle dropdown-toggle-split">
                 {{'PRINT.legendStylingOptions' | translateHs : data}}
             </button>
             <hs-print-legend-styler *ngIf="getStylerVisible('legend') && print.legendObj.include" [app]="data.app"
-                [legendObj]="print.legendObj">
+                [legendObj]="print.legendObj"><!-- TODO: Remove function call from template -->
             </hs-print-legend-styler>
             <button [disabled]="!print.imprintObj.include" type="button" (click)="setStylerVisible('imprint')"
                 class="btn w-100 mb-2 btn-outline-secondary dropdown-toggle dropdown-toggle-split">
                 {{'PRINT.imprintStylingOptions' | translateHs : data}}
             </button>
             <hs-print-imprint-styler *ngIf="getStylerVisible('imprint') && print.imprintObj.include" [app]="data.app"
-                [imprintObj]="print.imprintObj">
+                [imprintObj]="print.imprintObj"><!-- TODO: Remove function call from template -->
             </hs-print-imprint-styler>
             <button [disabled]="!print.scaleObj.include" type="button" (click)="setStylerVisible('scale')"
                 class="btn w-100 mb-2 btn-outline-secondary dropdown-toggle dropdown-toggle-split">
                 {{'PRINT.scaleStylingOptions' | translateHs : data}}
             </button>
             <hs-print-scale-styler *ngIf="getStylerVisible('scale') && print.scaleObj.include" [app]="data.app"
-                [scaleObj]="print.scaleObj">
+                [scaleObj]="print.scaleObj"><!-- TODO: Remove function call from template -->
             </hs-print-scale-styler>
             <div class="mb-2 mt-2 d-flex justify-content-start" *ngIf="!isLoading()">
                 <button type="button" class="btn btn-primary me-2 w-50" (click)="printLayout(true)">{{'COMMON.print' |
@@ -83,7 +83,7 @@
             </div>
             <div class="d-flex justify-content-center btn-group w-75 m-auto" *ngIf="isLoading()">
                 <button class="btn btn-primary w-75">{{'ADDDATA.CATALOGUE.loading' | translateHs : data}}...<img class="ms-2"
-                        [src]="hsUtilsService.getAjaxLoaderIcon(data.app)" /></button>
+                        [src]="hsUtilsService.getAjaxLoaderIcon(data.app)" /></button><!-- TODO: Remove function call from template -->
                 <button class="btn btn-secondary" (click)="cancelLoading()">&#10006;
                 </button>
             </div>

--- a/projects/hslayers/src/components/print/print.component.ts
+++ b/projects/hslayers/src/components/print/print.component.ts
@@ -44,18 +44,8 @@ export class HsPrintComponent extends HsPanelBaseComponent implements OnInit {
         module: 'hs.print',
         order: 10,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.PRINT',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.PRINT',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.PRINT',
+        description: 'SIDEBAR.descriptions.PRINT',
         icon: 'icon-print',
       },
       this.data.app

--- a/projects/hslayers/src/components/print/scale-styler/scale-styler.component.html
+++ b/projects/hslayers/src/components/print/scale-styler/scale-styler.component.html
@@ -4,7 +4,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="scaleObj.scaleType"
       [ngModelOptions]="{standalone: true}" style="flex-grow: 1;" (ngModelChange)="scaleObjChanged()">
       <option [ngValue]="scaleType" *ngFor="let scaleType of stylingOptions.scaleType">
-        {{getTranslation('PRINT',scaleType)}}
+        {{getTranslation('PRINT',scaleType)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>
@@ -21,7 +21,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="scaleObj.scaleUnits"
       (ngModelChange)="scaleObjChanged()" [ngModelOptions]="{standalone: true}" style="flex-grow: 1;">
       <option [ngValue]="scaleUnits.value" *ngFor="let scaleUnits of stylingOptions.scaleUnits">
-        {{getTranslation('PRINT',scaleUnits.name)}}
+        {{getTranslation('PRINT',scaleUnits.name)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>

--- a/projects/hslayers/src/components/print/text-styler/text-styler.component.html
+++ b/projects/hslayers/src/components/print/text-styler/text-styler.component.html
@@ -12,7 +12,7 @@
   <div class="p-1 w-100">
     <input class="form-control form-select-sm" (click)="setColorPickerVisible('background')"
       [ngStyle]="getColorPickerStyle('background')" [ngModelOptions]="{standalone: true}"
-      [(ngModel)]="textStyle.bcColor" />
+      [(ngModel)]="textStyle.bcColor" /><!-- TODO: Remove function call from template -->
     <color-sketch *ngIf="bcPickerVisible" (onChangeComplete)="onPick($event, 'background')" width="320px">
     </color-sketch>
   </div>
@@ -43,7 +43,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="textStyle.fontStyle"
       [ngModelOptions]="{standalone: true}">
       <option [ngValue]="fontStyle" *ngFor="let fontStyle of stylingOptions.fontStyles">
-        {{getTranslation('PRINT',fontStyle)}}
+        {{getTranslation('PRINT',fontStyle)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>
@@ -54,7 +54,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="textStyle.textDraw"
       [ngModelOptions]="{standalone: true}">
       <option [ngValue]="textDraw" *ngFor="let textDraw of stylingOptions.textDrawTypes">
-        {{getTranslation('COMMON',textDraw)}}
+        {{getTranslation('COMMON',textDraw)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>
@@ -65,7 +65,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="textStyle.posX"
       [ngModelOptions]="{standalone: true}">
       <option [ngValue]="positionX" *ngFor="let positionX of positionOptions.positionsX">
-        {{getTranslation('PRINT',positionX)}}
+        {{getTranslation('PRINT',positionX)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>
@@ -77,7 +77,7 @@
     <select class="form-control form-select-sm form-select" [(ngModel)]="textStyle.posY"
       [ngModelOptions]="{standalone: true}">
       <option [ngValue]="positionY" *ngFor="let positionY of positionOptions.positionsY">
-        {{getTranslation('PRINT',positionY)}}
+        {{getTranslation('PRINT',positionY)}}<!-- TODO: Remove function call from template -->
       </option>
     </select>
   </div>

--- a/projects/hslayers/src/components/query/query.component.html
+++ b/projects/hslayers/src/components/query/query.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="info" [title]="'PANEL_HEADER.INFO' | translateHs : data" [app]="data.app"></hs-panel-header>
     <div class="card hs-main-panel" *ngIf="noFeatureSelected()">
         <div class="d-flex flex-column align-items-center p-4">

--- a/projects/hslayers/src/components/query/query.component.ts
+++ b/projects/hslayers/src/components/query/query.component.ts
@@ -23,8 +23,7 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsQueryComponent
   extends HsPanelBaseComponent
-  implements OnDestroy, OnInit
-{
+  implements OnDestroy, OnInit {
   popup = new Popup();
   popupOpens: Subject<any> = new Subject();
   name = 'info';
@@ -54,18 +53,8 @@ export class HsQueryComponent
         module: 'hs.query',
         order: 7,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.INFO',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.INFO',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.INFO',
+        description: 'SIDEBAR.descriptions.INFO',
         icon: 'icon-info-sign',
       },
       this.data.app

--- a/projects/hslayers/src/components/query/widgets/clear-layer.component.html
+++ b/projects/hslayers/src/components/query/widgets/clear-layer.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-center">
   <button class="btn btn-danger btn-block btn-sm" (click)="clearLayer(layerDescriptor.layer)"
     *ngIf="isLayerEditable(layerDescriptor.layer)" data-toggle="tooltip"
-    [title]="'QUERY.featurePopup.clearLayer'| translateHs : data">
+    [title]="'QUERY.featurePopup.clearLayer'| translateHs : data"><!-- TODO: Remove function call from template -->
     {{'QUERY.featurePopup.clearLayer' | translateHs : data}}
   </button>
 </div>

--- a/projects/hslayers/src/components/query/widgets/dynamic-text.component.html
+++ b/projects/hslayers/src/components/query/widgets/dynamic-text.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngFor="let feature of layerDescriptor.features">
-    <div [innerHtml]="generateContent(feature)"></div>
+    <div [innerHtml]="generateContent(feature)"></div><!-- TODO: Remove function call from template -->
 </ng-container>

--- a/projects/hslayers/src/components/query/widgets/feature-info.component.html
+++ b/projects/hslayers/src/components/query/widgets/feature-info.component.html
@@ -1,7 +1,7 @@
 <!-- Feature header template -->
 <ng-template #featureHeader let-feature="feature" let-type="type">
   <div class="d-flex flex-row">
-    <div class="p-1 flex-grow-1"><em>{{serializeFeatureName(feature)}}</em></div>
+    <div class="p-1 flex-grow-1"><em>{{serializeFeatureName(feature)}}</em></div><!-- TODO: Remove function call from template -->
     <a class="p-1" *ngIf="isFeatureRemovable(feature) && type" (click)="removeFeature(feature)" data-toggle="tooltip"
       [title]="'QUERY.featurePopup.' + type | translateHs : data">
       <i class="icon-remove-circle" style="color: rgb(228, 99, 99)"></i>
@@ -21,7 +21,7 @@
       </div>
     </ng-container>
     <ng-container *ngIf="attribute.displayFunction">
-      <div class="p-1" [innerHtml]="attribute.displayFunction(attribute.value)"></div>
+      <div class="p-1" [innerHtml]="attribute.displayFunction(attribute.value)"></div><!-- TODO: Remove function call from template -->
     </ng-container>
   </div>
 </ng-template>
@@ -29,13 +29,13 @@
 <!-- Layout for clustered layers -->
 <ng-container *ngFor="let feature of layerDescriptor.features">
   <div *ngIf="isClustered(feature); else nonClusteredPopUp"
-    style="font-size: small; line-height: 1; margin-bottom: 2px; border-bottom: 2px solid rgb(199, 199, 199)">
+    style="font-size: small; line-height: 1; margin-bottom: 2px; border-bottom: 2px solid rgb(199, 199, 199)"><!-- TODO: Remove function call from template -->
     <div class="d-flex flex-column">
       <ng-container *ngTemplateOutlet="featureHeader;context:{feature: feature}"></ng-container>
       <div [hidden]="!(attributesForHover.length > 0)" class="ms-1 mt-1">
         <ng-container *ngFor="let attribute of attributesForHover">
           <div *ngIf="attribute.feature"
-            [ngClass]="{'d-flex flex-column hs-hover-popup-feature' : hasMultipleSubFeatures(feature)}">
+            [ngClass]="{'d-flex flex-column hs-hover-popup-feature' : hasMultipleSubFeatures(feature)}"><!-- TODO: Remove function call from template -->
             <ng-container
               *ngTemplateOutlet="featureHeader;context:{feature: attribute.feature, type: 'removeClusterPart'}">
             </ng-container>
@@ -52,7 +52,7 @@
       <ng-container *ngTemplateOutlet="featureHeader;context:{feature: feature, type: 'removeFeature'}">
       </ng-container>
       <ng-container
-        *ngTemplateOutlet="featureAttribute;context:{attributes: data.service.serializeFeatureAttributes(feature, data.app)}">
+        *ngTemplateOutlet="featureAttribute;context:{attributes: data.service.serializeFeatureAttributes(feature, data.app)}"><!-- TODO: Remove function call from template -->
       </ng-container>
     </div>
   </ng-template>

--- a/projects/hslayers/src/components/query/widgets/layer-name.component.html
+++ b/projects/hslayers/src/components/query/widgets/layer-name.component.html
@@ -1,1 +1,1 @@
-<strong style="font-size: small;">{{translateTitle(layerDescriptor.title)}}</strong>
+<strong style="font-size: small;">{{translateTitle(layerDescriptor.title)}}<!-- TODO: Remove function call from template --></strong>

--- a/projects/hslayers/src/components/save-map/form/form.component.html
+++ b/projects/hslayers/src/components/save-map/form/form.component.html
@@ -100,7 +100,7 @@
                         <input type="checkbox" class="form-check-input mt-0" name="hs-stclayer-{{i}}"
                             id="hs-stclayer-{{i}}" [(ngModel)]="layer.checked" [ngModelOptions]="{standalone: true}">
                         <label for="hs-stclayer-{{i}}" title="{{translateTitle(layer.title)}}"
-                            class="form-check-label mw-100 text-truncate">{{translateTitle(layer.title)}}</label>
+                            class="form-check-label mw-100 text-truncate">{{translateTitle(layer.title)}}<!-- TODO: Remove function call from template --></label>
                     </div>
                 </li>
                 <li class="list-group-item" style="padding: 3px">
@@ -194,7 +194,7 @@
     </div>
     <div class="mb-2 d-flex justify-content-end">
         <button type="button" class="btn btn-primary me-2" id="stc-saveas" [hidden]="!(isAllowed())"
-            (click)="initiateSave(true)">{{'COMMON.save' | translateHs : {app} }}</button>
+            (click)="initiateSave(true)"><!-- TODO: Remove function call from template -->{{'COMMON.save' | translateHs : {app} }}</button>
         <a type="button" class="btn btn-secondary" (click)="saveCompoJson()" id="stc-download">{{'COMMON.download'
             |
             translateHs: this}}</a>

--- a/projects/hslayers/src/components/save-map/save-map.component.html
+++ b/projects/hslayers/src/components/save-map/save-map.component.html
@@ -1,4 +1,4 @@
-<div class="card panel-default hs-main-panel mainpanel hs-stc-mainpanel" [hidden]="!isVisible()">
+<div class="card panel-default hs-main-panel mainpanel hs-stc-mainpanel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="saveMap" [title]="'PANEL_HEADER.SAVECOMPOSITION' | translateHs : data" [app]="data.app">
     </hs-panel-header>
     <div class="card-body">

--- a/projects/hslayers/src/components/save-map/save-map.component.ts
+++ b/projects/hslayers/src/components/save-map/save-map.component.ts
@@ -20,7 +20,8 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsSaveMapComponent
   extends HsPanelBaseComponent
-  implements OnDestroy, OnInit {
+  implements OnDestroy, OnInit
+{
   endpoint: HsEndpoint = null;
   endpoints: HsEndpoint[];
   isAuthorized = false;
@@ -49,18 +50,8 @@ export class HsSaveMapComponent
         module: 'hs.save-map',
         order: 12,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.SAVECOMPOSITION',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.SAVECOMPOSITION',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.SAVECOMPOSITION',
+        description: 'SIDEBAR.descriptions.SAVECOMPOSITION',
         icon: 'icon-save-floppy',
       },
       this.data.app

--- a/projects/hslayers/src/components/search/partials/search-toolbar.component.html
+++ b/projects/hslayers/src/components/search/partials/search-toolbar.component.html
@@ -1,4 +1,4 @@
-<div class="nav-item" [hidden]="!isVisible()">
+<div class="nav-item" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <div>
         <hs-search-input [app]="data.app"></hs-search-input>
         <hs-search-results [app]="data.app"></hs-search-results>

--- a/projects/hslayers/src/components/search/partials/search.component.html
+++ b/projects/hslayers/src/components/search/partials/search.component.html
@@ -1,4 +1,4 @@
-<div [hidden]="!isVisible()">
+<div [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="Search" [title]="'PANEL_HEADER.SEARCH' | translateHs : data" [app]="data.app"></hs-panel-header>
     <div class="input-group search-panel hs-search-address pt-1 pb-1 d-flex">
         <hs-search-input [app]="data.app"></hs-search-input>

--- a/projects/hslayers/src/components/search/search.component.ts
+++ b/projects/hslayers/src/components/search/search.component.ts
@@ -14,8 +14,7 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 })
 export class HsSearchComponent
   extends HsPanelBaseComponent
-  implements OnInit, OnDestroy
-{
+  implements OnInit, OnDestroy {
   replace = false;
   clearVisible = false;
   searchInputVisible: boolean;
@@ -45,18 +44,8 @@ export class HsSearchComponent
         module: 'hs.search',
         order: 15,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.SEARCH',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.SEARCH',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.SEARCH',
+        description: 'SIDEBAR.descriptions.SEARCH',
         icon: 'icon-search',
       },
       this.data.app

--- a/projects/hslayers/src/components/sidebar/mini-sidebar.component.ts
+++ b/projects/hslayers/src/components/sidebar/mini-sidebar.component.ts
@@ -13,7 +13,7 @@ import {Subject, delay, startWith, takeUntil} from 'rxjs';
 export class HsMiniSidebarComponent implements OnInit {
   @Input() app = 'default';
   buttons: HsButton[] = [];
-  miniSidebarButton: {title: () => string};
+  miniSidebarButton: {title: string};
   ngUnsubscribe = new Subject<void>();
   constructor(
     public HsCoreService: HsCoreService,
@@ -30,12 +30,7 @@ export class HsMiniSidebarComponent implements OnInit {
         this.buttons = buttons;
       });
     this.miniSidebarButton = {
-      title: () =>
-        this.HsLanguageService.getTranslation(
-          'SIDEBAR.additionalPanels',
-          undefined,
-          this.app
-        ),
+      title: 'SIDEBAR.additionalPanels',
     };
   }
 

--- a/projects/hslayers/src/components/sidebar/partials/impressum.html
+++ b/projects/hslayers/src/components/sidebar/partials/impressum.html
@@ -4,7 +4,7 @@
     <div class="hs-logo">
       <a href="https://ng.hslayers.org/" target="_blank">
         <img [src]="hsUtilsService.getAssetsPath(app) + 'img/hslayers-ng-logo.png'" alt="HSLayers-NG"
-          [hidden]="logoDisabled">
+          [hidden]="logoDisabled"><!-- TODO: Remove function call from template -->
       </a>
     </div>
     <div class="text-end">

--- a/projects/hslayers/src/components/sidebar/partials/sidebar.html
+++ b/projects/hslayers/src/components/sidebar/partials/sidebar.html
@@ -8,16 +8,16 @@
             [ngClass]="HsLayoutService.get(app).sidebarExpanded ? (HsConfig.get(app).sidebarPosition === 'left' ? 'icon-chevron-left' : 'icon-chevron-right') : (HsConfig.get(app).sidebarPosition === 'left' ? 'icon-chevron-right' : 'icon-chevron-left')"></i>
     </span>
 
-    <span *ngFor="let button of buttons | sortBy: 'asc': 'order'" class="hs-sidebar-item list-group-item"
+    <span *ngFor="let button of buttons" class="hs-sidebar-item list-group-item"
         [hidden]="!button.visible" (click)="HsSidebarService.buttonClicked(button, app)"
         [ngClass]="{'active': HsLayoutService.get(app).mainpanel === button.panel,  'hs-panel-hidden' : !button.fits}"
-        title="{{HsSidebarService.getButtonDescription(button)}}">
+        title="{{button.description | translateHs: {app} }}">
         <i *ngIf="button.icon" class="menu-icon {{button.icon}}" data-toggle="tooltip" data-container="body"
             data-placement="auto"></i>
         <span *ngIf="button.content" data-toggle="tooltip" data-container="body" data-placement="auto" class=""
-            title="{{HsSidebarService.getButtonDescription(button)}}">{{button.content()}}</span>
+            title="{{button.description | translateHs: {app} }}">{{button.content()}}</span>
         <span [ngStyle]="{'margin-left' : button.panel === 'language' ? '14px' : '20px'}" [attr.data-cy]="button.panel"
-            class="hs-sidebar-item-title">{{HsSidebarService.getButtonTitle(button)}}</span>
+            class="hs-sidebar-item-title">{{button.title | translateHs: {app} }}</span>
     </span>
 
     <span class="hs-sidebar-item  list-group-item" *ngIf="HsLayoutService.get(app).minisidebar"
@@ -25,7 +25,7 @@
         [ngClass]="{'active': HsLayoutService.get(app).mainpanel === 'sidebar'}">
         <i class="menu-icon icon-equals" data-toggle="tooltip" data-container="body" data-placement="auto" title="Menu"
             style="margin-left: 0px !important;"></i>
-        <span class="hs-sidebar-item-title">{{HsSidebarService.getButtonTitle(miniSidebarButton)}}</span>
+        <span class="hs-sidebar-item-title">{{miniSidebarButton.title | translateHs: {app} }}</span>
     </span>
     <hs-impressum class="mt-auto" [app]="app"></hs-impressum>
 </div>

--- a/projects/hslayers/src/components/sidebar/partials/sidebar.html
+++ b/projects/hslayers/src/components/sidebar/partials/sidebar.html
@@ -6,12 +6,12 @@
         (click)="toggleSidebar()">
         <i class="menu-icon"
             [ngClass]="HsLayoutService.get(app).sidebarExpanded ? (HsConfig.get(app).sidebarPosition === 'left' ? 'icon-chevron-left' : 'icon-chevron-right') : (HsConfig.get(app).sidebarPosition === 'left' ? 'icon-chevron-right' : 'icon-chevron-left')"></i>
-    </span>
+    </span><!-- TODO: Remove function call from template -->
 
     <span *ngFor="let button of buttons" class="hs-sidebar-item list-group-item"
         [hidden]="!button.visible" (click)="HsSidebarService.buttonClicked(button, app)"
         [ngClass]="{'active': HsLayoutService.get(app).mainpanel === button.panel,  'hs-panel-hidden' : !button.fits}"
-        title="{{button.description | translateHs: {app} }}">
+        title="{{button.description | translateHs: {app} }}"><!-- TODO: Remove function call from template -->
         <i *ngIf="button.icon" class="menu-icon {{button.icon}}" data-toggle="tooltip" data-container="body"
             data-placement="auto"></i>
         <span *ngIf="button.content" data-toggle="tooltip" data-container="body" data-placement="auto" class=""
@@ -19,7 +19,7 @@
         <span [ngStyle]="{'margin-left' : button.panel === 'language' ? '14px' : '20px'}" [attr.data-cy]="button.panel"
             class="hs-sidebar-item-title">{{button.title | translateHs: {app} }}</span>
     </span>
-
+<!-- TODO: Remove function call from template -->
     <span class="hs-sidebar-item  list-group-item" *ngIf="HsLayoutService.get(app).minisidebar"
         (click)="HsLayoutService.setMainPanel('sidebar', app, true)"
         [ngClass]="{'active': HsLayoutService.get(app).mainpanel === 'sidebar'}">

--- a/projects/hslayers/src/components/sidebar/sidebar.component.ts
+++ b/projects/hslayers/src/components/sidebar/sidebar.component.ts
@@ -19,7 +19,7 @@ export class HsSidebarComponent implements OnInit, OnDestroy {
   configChangesSubscription: Subscription;
   @Input() app = 'default';
   buttons: HsButton[] = [];
-  miniSidebarButton: {title: () => string};
+  miniSidebarButton: {title: string};
   constructor(
     public HsLayoutService: HsLayoutService,
     public HsCoreService: HsCoreService,
@@ -36,17 +36,21 @@ export class HsSidebarComponent implements OnInit, OnDestroy {
     this.HsSidebarService.get(this.app)
       .buttons.pipe(startWith([]), delay(0))
       .subscribe((buttons) => {
-        this.buttons = buttons;
-        this.HsSidebarService.setPanelState(buttons, this.app);
-        this.HsSidebarService.setButtonVisibility(buttons, this.app);
+        this.buttons = buttons.map((button) => {
+          if (typeof button.title == 'function') {
+            button.title = button.title();
+          }
+          if (typeof button.description == 'function') {
+            button.description = button.description();
+          }
+          return button;
+        });
+        this.buttons.sort((a, b) => a.order - b.order);
+        this.HsSidebarService.setPanelState(this.buttons, this.app);
+        this.HsSidebarService.setButtonVisibility(this.buttons, this.app);
       });
     this.miniSidebarButton = {
-      title: () =>
-        this.HsLanguageService.getTranslation(
-          'SIDEBAR.additionalPanels',
-          undefined,
-          this.app
-        ),
+      title: 'SIDEBAR.additionalPanels',
     };
     if (panel) {
       setTimeout(() => {

--- a/projects/hslayers/src/components/sidebar/sidebar.service.ts
+++ b/projects/hslayers/src/components/sidebar/sidebar.service.ts
@@ -109,15 +109,6 @@ export class HsSidebarService {
       });
   }
 
-  getButtonTitle(button): any {
-    return typeof button.title == 'function' ? button.title() : button.title;
-  }
-  getButtonDescription(button): any {
-    return typeof button.description == 'function'
-      ? button.description()
-      : button.description;
-  }
-
   /**
    * Function to set if a button is important and always visible
    * or only when the sidebar buttons are expanded

--- a/projects/hslayers/src/components/styles/filters/filter.component.html
+++ b/projects/hslayers/src/components/styles/filters/filter.component.html
@@ -1,7 +1,7 @@
 <div>
-  <div *ngIf="hsFiltersService.isLogOp(filter)" class="card m-2">
+  <div *ngIf="hsFiltersService.isLogOp(filter)" class="card m-2"><!-- TODO: Remove function call from template -->
     <div class="d-flex flex-row card-header p-0">
-      <div class="p-2">{{hsFiltersService.humanReadableLogOp(filter[0])}}</div>
+      <div class="p-2">{{hsFiltersService.humanReadableLogOp(filter[0])}}</div><!-- TODO: Remove function call from template -->
       <hs-add-filter-button (clicks)="hsFiltersService.add($event.kind, true, filter)" [app]="app"></hs-add-filter-button>
       <button class="btn btn-outline-danger btn-sm m-1" [title]="'STYLER.removeFilter' | translateHs : {app} " (click)="remove()">
         <span class="icon-trash"></span>
@@ -12,5 +12,5 @@
     </div>
   </div>
   <hs-comparison-filter *ngIf="filter.length > 1 && !(hsFiltersService.isLogOp(filter))" [app]="app" [filter]="filter"
-    (changes)="emitChange()" [parent]="parent"></hs-comparison-filter>
+    (changes)="emitChange()" [parent]="parent"></hs-comparison-filter><!-- TODO: Remove function call from template -->
 </div>

--- a/projects/hslayers/src/components/styles/filters/filters.component.html
+++ b/projects/hslayers/src/components/styles/filters/filters.component.html
@@ -2,10 +2,10 @@
   <div class="d-flex flex-row justify-content-end">
     <hs-add-filter-button (clicks)="add($event.kind, false)" [app]="app"></hs-add-filter-button>
   </div>
-  <div *ngIf="hsFiltersService.isLogOp(rule.filter)" class="card">
+  <div *ngIf="hsFiltersService.isLogOp(rule.filter)" class="card"><!-- TODO: Remove function call from template -->
     <div class="d-flex flex-row card-header p-0">
       <div class="p-2">
-        {{hsFiltersService.humanReadableLogOp(rule.filter[0])}}
+        {{hsFiltersService.humanReadableLogOp(rule.filter[0])}}<!-- TODO: Remove function call from template -->
       </div>
       <hs-add-filter-button (clicks)="add($event.kind, true)" [app]="app"></hs-add-filter-button>
       <button class="btn btn-outline-danger btn-sm m-1" [title]="'STYLER.removeFilter'" (click)="remove()">
@@ -17,5 +17,5 @@
     </div>
   </div>
   <hs-comparison-filter *ngIf="rule.filter?.length > 0 && !(hsFiltersService.isLogOp(rule.filter))" [app]="app"
-    (changes)="emitChange()" [filter]="rule.filter"></hs-comparison-filter>
+    (changes)="emitChange()" [filter]="rule.filter"></hs-comparison-filter><!-- TODO: Remove function call from template -->
 </div>

--- a/projects/hslayers/src/components/styles/styler.component.html
+++ b/projects/hslayers/src/components/styles/styler.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
   <div class="card-header d-flex align-items-center justify-content-between">
     <span class="panel-title">
       {{'LAYERMANAGER.layerEditor.styleLayer' | translateHs : data}}

--- a/projects/hslayers/src/components/styles/symbolizers/color-picker/color-picker.component.html
+++ b/projects/hslayers/src/components/styles/symbolizers/color-picker/color-picker.component.html
@@ -6,6 +6,7 @@
         [ngModelOptions]="{standalone: true}" [(ngModel)]="symbolizer[attribute]" />
     </div>
   </div>
+  <!-- TODO: Remove function call from template -->
   <color-sketch [color]="hsColorPickerService.addAlpha(symbolizer[attribute], symbolizer[opacityAttribute])"
   width="320px"
     *ngIf="pickerVisible && symbolizer[attribute] !== undefined" (onChangeComplete)="onPick($event)"></color-sketch>

--- a/projects/hslayers/src/components/styles/symbolizers/select-icon-dialog/select-icon-dialog.component.html
+++ b/projects/hslayers/src/components/styles/symbolizers/select-icon-dialog/select-icon-dialog.component.html
@@ -11,7 +11,7 @@
       <div class="modal-body" style="max-height: 400px; overflow-y: auto">
         <div class="d-flex flex-wrap">
           <div *ngFor="let icon of hsConfig.get(data.app).symbolizerIcons" [ngClass]="{'bg-primary': data.selectedIcon === icon}"
-            class="p-1" (click)="iconSelected(icon)">
+            class="p-1" (click)="iconSelected(icon)"><!-- TODO: Remove function call from template -->
             <img [src]="icon.url" />
           </div>
         </div>

--- a/projects/hslayers/src/components/styles/symbolizers/symbolizer-list-item/symbolizer-list-item.component.html
+++ b/projects/hslayers/src/components/styles/symbolizers/symbolizer-list-item/symbolizer-list-item.component.html
@@ -5,7 +5,7 @@
     <button type="button" style="border: none; background-color: transparent; cursor: move">
       <i class="icon-move text-secondary"></i>
     </button>
-    <span>{{getSymbolizerName(symbolizer) | translateHs : {app} }}&nbsp;</span>
+    <span>{{getSymbolizerName(symbolizer) | translateHs : {app} }}&nbsp;</span><!-- TODO: Remove function call from template -->
   </div>
   <div>
     <span class="glyphicon me-2" [ngClass]="symbolizerVisible ? 'icon-chevron-right' : 'icon-chevron-down'"></span>

--- a/projects/hslayers/src/components/toolbar/partials/toolbar.html
+++ b/projects/hslayers/src/components/toolbar/partials/toolbar.html
@@ -1,4 +1,4 @@
-<div class="hs-toolbar" [hidden]="!isVisible()">
+<div class="hs-toolbar" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <nav class="navbar navbar-expand p-0">
         <hs-panel-container 
             class="navbar-nav"

--- a/projects/hslayers/src/components/trip-planner/layer-selector.html
+++ b/projects/hslayers/src/components/trip-planner/layer-selector.html
@@ -20,7 +20,7 @@
       [attr.aria-expanded]="layersExpanded"
     >
       <div class="text-truncate" *ngIf="selectedwrapper !== undefined">
-        {{HsLayerUtilsService.translateTitle(selectedwrapper.title, app)}}
+        {{HsLayerUtilsService.translateTitle(selectedwrapper.title, app)}}<!-- TODO: Remove function call from template -->
       </div>
     </button>
     <div
@@ -35,7 +35,7 @@
           data-toggle="tooltip"
           title="{{HsLayerUtilsService.translateTitle(layer.title, app)}}"
           (click)="HsTripPlannerService.selectLayer(layer, usage, app); layersExpanded = false"
-          >{{HsLayerUtilsService.translateTitle(layer.title, app)}}</a
+          >{{HsLayerUtilsService.translateTitle(layer.title, app)}}<!-- TODO: Remove function call from template --></a
         >
       </div>
     </div>

--- a/projects/hslayers/src/components/trip-planner/trip-planner.component.ts
+++ b/projects/hslayers/src/components/trip-planner/trip-planner.component.ts
@@ -18,7 +18,8 @@ import {setHighlighted} from '../../common/feature-extensions';
 })
 export class HsTripPlannerComponent
   extends HsPanelBaseComponent
-  implements OnInit {
+  implements OnInit
+{
   loaderImage: string;
   timer: any;
   name = 'tripPlanner';
@@ -43,18 +44,8 @@ export class HsTripPlannerComponent
         module: 'hs-trip-planner',
         order: 17,
         fits: true,
-        title: () =>
-          this.hsLanguageService.getTranslation(
-            'PANEL_HEADER.TRIP_PLANNER',
-            undefined,
-            this.data.app
-          ),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.TRIP_PLANNER',
-            undefined,
-            this.data.app
-          ),
+        title: 'PANEL_HEADER.TRIP_PLANNER',
+        description: 'SIDEBAR.descriptions.TRIP_PLANNER',
         icon: 'icon-sextant',
       },
       this.data.app

--- a/projects/hslayers/src/components/trip-planner/trip_planner.html
+++ b/projects/hslayers/src/components/trip-planner/trip_planner.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
   <hs-panel-header name="tripPlaner" [title]="'PANEL_HEADER.TRIP_PLANNER' | translateHs : data" [app]="data.app">
   </hs-panel-header>
   <div class="card-body">
@@ -18,10 +18,10 @@
           [hidden]="!waypoint.editMode" (blur)="toggleEdit(waypoint)" />
       </div>
       <div class="p-1">
-        <img [hidden]="!waypoint.loading" [src]="HsUtilsService.getAjaxLoaderIcon(data.app)" />
+        <img [hidden]="!waypoint.loading" [src]="HsUtilsService.getAjaxLoaderIcon(data.app)" /><!-- TODO: Remove function call from template -->
       </div>
       <div class="p-1" style="height: 1.7em">
-        <div style="margin-top: 1em">{{ formatDistance(waypoint) }}</div>
+        <div style="margin-top: 1em">{{ formatDistance(waypoint) }}<!-- TODO: Remove function call from template --></div>
       </div>
       <div class="p-1">
         <a class="p-1" (click)="HsTripPlannerService.removeWaypoint(waypoint, data.app)" data-toggle="tooltip"

--- a/projects/test-statistics-app/src/lib/statistics-panel.component.html
+++ b/projects/test-statistics-app/src/lib/statistics-panel.component.html
@@ -1,4 +1,4 @@
-<div class="card hs-main-panel" [hidden]="!isVisible()">
+<div class="card hs-main-panel" [hidden]="!isVisible()"><!-- TODO: Remove function call from template -->
     <hs-panel-header name="statistics" [app]="data.app" [title]="'PANEL_HEADER.STATISTICS' | translateHs : data">
     </hs-panel-header>
     <div class="card-body">

--- a/projects/test-statistics-app/src/lib/statistics-panel.component.ts
+++ b/projects/test-statistics-app/src/lib/statistics-panel.component.ts
@@ -21,8 +21,7 @@ import {HsStatisticsToMapDialogComponent} from './to-map-dialog.component';
 })
 export class HsStatisticsPanelComponent
   extends HsPanelBaseComponent
-  implements OnInit
-{
+  implements OnInit {
   public title = '';
   name = 'statistics';
   appRef;
@@ -45,12 +44,8 @@ export class HsStatisticsPanelComponent
         order: 10,
         fits: true,
         visible: true,
-        title: () =>
-          this.hsLanguageService.getTranslation('PANEL_HEADER.STATISTICS'),
-        description: () =>
-          this.hsLanguageService.getTranslation(
-            'SIDEBAR.descriptions.STATISTICS'
-          ),
+        title: 'PANEL_HEADER.STATISTICS',
+        description: 'SIDEBAR.descriptions.STATISTICS',
         icon: 'icon-barchartasc',
       },
       this.data.app

--- a/projects/test-statistics-app/src/lib/to-map-dialog.component.html
+++ b/projects/test-statistics-app/src/lib/to-map-dialog.component.html
@@ -21,7 +21,7 @@
                       mw-100
                     " aria-haspopup="true">
                             <div class="text-truncate" *ngIf="selectedLayer !== undefined">
-                                {{HsLayerUtilsService.translateTitle(selectedLayer.title, data.app)}}
+                                {{HsLayerUtilsService.translateTitle(selectedLayer.title, data.app)}}<!-- TODO: Remove function call from template -->
                             </div>
                         </button>
                         <div ngbDropdownMenu style="transform: translateX(25%); width: 15em">


### PR DESCRIPTION
## Description

This PR solves layer manager button dropping to last position even if its order is set to 0 meaning it should be first.

Calling functions from templates is bad practice  https://medium.com/showpad-engineering/why-you-should-never-use-function-calls-in-angular-template-expressions-e1a50f9c0496

We can observe variables directly, use pipes or observables with `async` pipe instead.

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
