### PR TITLE
refactor: Use getter and setter to allow dynamic weight values

### DIFF
--- a/projects/hslayers/src/common/layers/hs.source.interpolated.ts
+++ b/projects/hslayers/src/common/layers/hs.source.interpolated.ts
@@ -12,7 +12,7 @@ export const NORMALIZED_WEIGHT_PROPERTY_NAME = 'hs_normalized_IDW_value';
 
 export interface InterpolatedSourceOptions {
   features?: Feature<Geometry>[];
-  weight?: string | (() => string);
+  weight?: string;
   loader?(params: any): Promise<Feature[]>;
   colorMap?: ((v: number) => number[]) | string;
   strategy?: LoadingStrategy;
@@ -92,10 +92,12 @@ export class InterpolatedSource extends IDW {
     }
   }
 
-  private getWeightString() {
-    return typeof this.options.weight == 'string'
-      ? this.options.weight
-      : this.options.weight();
+  get weight() {
+    return this.options.weight;
+  }
+
+  set weight(value) {
+    this.options.weight = value;
   }
 
   /**
@@ -117,7 +119,7 @@ export class InterpolatedSource extends IDW {
     }
     const countToAdd = cacheLimit ?? Number.MAX_VALUE;
     this.featureCache.addFeatures(features.slice(0, countToAdd));
-    this.normalizeWeight(this.getWeightString());
+    this.normalizeWeight(this.options.weight);
     const src = super.getSource();
     if (extent) {
       src.clear();
@@ -147,7 +149,7 @@ export class InterpolatedSource extends IDW {
         featureProjection: mapProjection,
       });
       collection.features = collection.features.filter((f) => {
-        const value = f.get(this.getWeightString());
+        const value = f.get(this.options.weight);
         if (value && !isNaN(parseInt(value))) {
           return f;
         }

--- a/projects/hslayers/src/common/layers/hs.source.interpolated.ts
+++ b/projects/hslayers/src/common/layers/hs.source.interpolated.ts
@@ -12,7 +12,7 @@ export const NORMALIZED_WEIGHT_PROPERTY_NAME = 'hs_normalized_IDW_value';
 
 export interface InterpolatedSourceOptions {
   features?: Feature<Geometry>[];
-  weight?: string;
+  weight: string;
   loader?(params: any): Promise<Feature[]>;
   colorMap?: ((v: number) => number[]) | string;
   strategy?: LoadingStrategy;

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -11,6 +11,7 @@ import {Tile} from 'ol/layer';
 import {catchError, lastValueFrom, takeUntil} from 'rxjs';
 import {transformExtent} from 'ol/proj';
 
+import CircleStyle from 'ol/style/Circle';
 import {HsConfig} from 'hslayers-ng/src/config.service';
 import {HsEventBusService} from 'hslayers-ng/src/components/core/event-bus.service';
 import {HsQueryPopupWidgetContainerService} from 'hslayers-ng/src/components/query/query-popup-widget-container.service';
@@ -59,9 +60,7 @@ export class HslayersAppComponent {
         maxFeaturesInCache: 500,
         maxFeaturesInExtent: 100,
         features: [],
-        weight: () => {
-          return 'fac2020';
-        },
+        weight: 'fac2020',
         loader: async ({extent, projection}) => {
           interpolatedSource.cancelUrlRequest.next();
           const extentIn4326 = transformExtent(extent, projection, 'EPSG:4326');
@@ -89,6 +88,7 @@ export class HslayersAppComponent {
         source: interpolatedSource as any,
         opacity: 0.5,
       });
+
 
       //Mandatory, otherwise nothing will be loaded with source loader
       const idwVectorLayer = new VectorLayer({
@@ -222,11 +222,11 @@ export class HslayersAppComponent {
             },
           },
           sld: `<?xml version="1.0" encoding="ISO-8859-1"?>
-              <StyledLayerDescriptor version="1.0.0" 
-                  xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-                  xmlns="http://www.opengis.net/sld" 
-                  xmlns:ogc="http://www.opengis.net/ogc" 
-                  xmlns:xlink="http://www.w3.org/1999/xlink" 
+              <StyledLayerDescriptor version="1.0.0"
+                  xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                  xmlns="http://www.opengis.net/sld"
+                  xmlns:ogc="http://www.opengis.net/ogc"
+                  xmlns:xlink="http://www.w3.org/1999/xlink"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <NamedLayer>
                   <Name>Simple point with stroke</Name>


### PR DESCRIPTION
Use getter and setter to allow dynamic weight values

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
