### PR TITLE
fix: Sidebar button order after layout resize

### DIFF
--- a/projects/hslayers/src/components/sidebar/mini-sidebar.component.ts
+++ b/projects/hslayers/src/components/sidebar/mini-sidebar.component.ts
@@ -19,15 +19,14 @@ export class HsMiniSidebarComponent implements OnInit {
     public HsCoreService: HsCoreService,
     public HsSidebarService: HsSidebarService,
     public HsLayoutService: HsLayoutService,
-    public HsConfig: HsConfig,
-    private HsLanguageService: HsLanguageService
+    public HsConfig: HsConfig
   ) {}
   ngOnInit() {
     this.HsSidebarService.apps[this.app].buttons
       .pipe(takeUntil(this.ngUnsubscribe))
       .pipe(startWith([]), delay(0))
       .subscribe((buttons) => {
-        this.buttons = buttons;
+        this.buttons = this.HsSidebarService.prepareForTemplate(buttons);
       });
     this.miniSidebarButton = {
       title: 'SIDEBAR.additionalPanels',

--- a/projects/hslayers/src/components/sidebar/sidebar.service.ts
+++ b/projects/hslayers/src/components/sidebar/sidebar.service.ts
@@ -9,7 +9,7 @@ import {HsLanguageService} from './../language/language.service';
 import {HsLayoutService} from '../layout/layout.service';
 import {HsUtilsService} from '../utils/utils.service';
 
-class HsSidebarParams {
+export class HsSidebarParams {
   extraButtons: Array<HsButton> = [];
   buttonsSubject: BehaviorSubject<HsButton[]> = new BehaviorSubject([]);
   /**
@@ -68,13 +68,20 @@ export class HsSidebarService {
         this.HsCoreService.updateMapSize(app);
       }, 550);
     });
+  }
 
-    this.HsEventBusService.layoutResizes.subscribe(() => {
-      for (const [appId, appObj] of Object.entries(this.apps)) {
-        const buttons = appObj.buttonsSubject.getValue();
-        this.setButtonVisibility(buttons, appId);
+  prepareForTemplate(buttons: HsButton[]): HsButton[] {
+    const tmp = buttons.map((button) => {
+      if (typeof button.title == 'function') {
+        button.title = button.title();
       }
+      if (typeof button.description == 'function') {
+        button.description = button.description();
+      }
+      return button;
     });
+    tmp.sort((a, b) => a.order - b.order);
+    return tmp;
   }
 
   setButtonVisibility(buttons: HsButton[], app: string) {


### PR DESCRIPTION
## Description

Small fix fix for broken button order after window is resized

Important part is

```
this.HsEventBusService.layoutResizes
      .pipe(takeUntil(this.end))
      .subscribe(() => {
        this.HsSidebarService.setButtonVisibility(this.buttons, this.app);
      });
```
where visibility is set on the already subscribed, sorted, and title-function handled buttons not the ones which reside in the buttonSubject which is later not even propagated from service to components. The rest is just styling.

## Related issues or pull requests

https://github.com/hslayers/hslayers-ng/issues/2971

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
