### PR TITLE
Fixed multiple layer removal

### DIFF
--- a/projects/hslayers/src/common/layman/types/delete-layer-response.type.ts
+++ b/projects/hslayers/src/common/layman/types/delete-layer-response.type.ts
@@ -6,10 +6,22 @@ export type DeleteAllLayersResponse = {
   title?: string;
   uuid?: string;
   url?: string;
+  code?: number;
+  detail?: any;
+  error?: {
+    message: string;
+  };
+  message?: string;
 };
 
 export type DeleteSingleLayerResponse = {
   name?: string;
   uuid?: string;
   url?: string;
+  code?: number;
+  detail?: any;
+  error?: {
+    message: string;
+  };
+  message?: string;
 };

--- a/projects/hslayers/src/components/draw/draw.service.ts
+++ b/projects/hslayers/src/components/draw/draw.service.ts
@@ -756,7 +756,7 @@ export class HsDrawService {
       (definition?.format?.toLowerCase().includes('wfs') && definition?.url) ||
       !isLayer
     ) {
-      await this.hsLaymanService.removeLayer(layerToRemove.name);
+      await this.hsLaymanService.removeLayer(app, layerToRemove);
     }
   }
 

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -27,6 +27,7 @@ import {
   DeleteSingleLayerResponse,
 } from '../../common/layman/types/delete-layer-response.type';
 import {HsCommonEndpointsService} from '../../common/endpoints/endpoints.service';
+import {HsCommonLaymanService} from '../../common/layman/layman.service';
 import {HsEndpoint} from '../../common/endpoints/endpoint.interface';
 import {HsLanguageService} from '../language/language.service';
 import {HsLaymanLayerDescriptor} from './interfaces/layman-layer-descriptor.interface';
@@ -87,7 +88,8 @@ export class HsLaymanService implements HsSaverService {
     private hsLogService: HsLogService,
     private hsCommonEndpointsService: HsCommonEndpointsService,
     private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService
+    private hsLanguageService: HsLanguageService,
+    private hsCommonLaymanService: HsCommonLaymanService
   ) {
     this.hsCommonEndpointsService.endpointsFilled.subscribe(async (data) => {
       if (data) {
@@ -749,21 +751,32 @@ export class HsLaymanService implements HsSaverService {
                     ),
                     app
                   );
-                  let message = 'LAYMAN.layerSuccessfullyRemoved';
-                  if (!layer) {
-                    message = 'LAYMAN.allLayersSuccessfullyRemoved';
+                  const response = Array.isArray(res) ? res[0] : res;
+                  if (response?.code) {
+                    this.hsCommonLaymanService.displayLaymanError(
+                      ds,
+                      'LAYMAN.deleteLayersRequest',
+                      response,
+                      app
+                    );
+                  } else {
+                    let message = 'LAYMAN.layerSuccessfullyRemoved';
+                    if (!layer) {
+                      message = 'LAYMAN.allLayersSuccessfullyRemoved';
+                    }
+                    const details = Array.isArray(res)
+                      ? res.map((item) => item.name)
+                      : [res.name];
+                    this.hsToastService.createToastPopupMessage(
+                      'LAYMAN.deleteLayersRequest',
+                      message,
+                      {
+                        toastStyleClasses: 'bg-success text-light',
+                        details,
+                      },
+                      app
+                    );
                   }
-                  this.hsToastService.createToastPopupMessage(
-                    'LAYMAN.deleteLayersRequest',
-                    message,
-                    {
-                      toastStyleClasses: 'bg-success text-light',
-                      details: (res as DeleteSingleLayerResponse)?.name
-                        ? [(res as DeleteSingleLayerResponse).name]
-                        : null,
-                    },
-                    app
-                  );
                 }
               ),
               catchError((e) => {


### PR DESCRIPTION
## Description

When trying to delete multiple layers using the multiple layer removal dialog, we were passing function params incorrecly, which led to all layers being deleted from Layman and HSLayers.

Also fixed toast messeges when deleting

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
