### PR TITLE
feat: Widget for setting bounds and colormap for IDW layer

### DIFF
--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -139,6 +139,7 @@
     "advancedOptions": "Advanced options",
     "all": "All",
     "application": "Application",
+    "apply": "Apply",
     "area": "Area",
     "attribute": "Attribute",
     "attributes": "Attributes",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -550,7 +550,11 @@
       "vector (GeoJSON)": "Vector (GeoJSON)",
       "vector (KML)": "Vector (KML)",
       "vector (TopoJSON)": "Vector (TopoJSON)",
-      "zoomToLayer": "Zoom to layer"
+      "zoomToLayer": "Zoom to layer",
+      "interpolatedAttribute": "Interpolated attribute",
+      "colorMap": "Color map",
+      "min": "Min",
+      "max": "Max"
     },
     "layerList": {
       "layerIsQueryable": "This layer is queryable",

--- a/projects/hslayers/src/common/layers/hs.source.interpolated.ts
+++ b/projects/hslayers/src/common/layers/hs.source.interpolated.ts
@@ -70,45 +70,67 @@ export class InterpolatedSource extends IDW {
       weight: NORMALIZED_WEIGHT_PROPERTY_NAME,
     });
     if (options.colorMap) {
-      if (typeof options.colorMap == 'string') {
-        super.getColor = (v) => {
-          const black = [0, 0, 0, 255];
-          if (isNaN(v)) {
-            return black;
-          }
-          if (v > 99) {
-            v = 99;
-          }
-          if (v < 0) {
-            v = 0;
-          }
-          v = Math.floor(v);
-          return colorMaps[options.colorMap as string][v];
-        };
-      } else {
-        super.getColor = options.colorMap;
-      }
+      this.setColorMapFromOptions(options);
     }
     if (options.features) {
       this.fillFeatures(options.features);
     }
   }
 
-  get min() {
+  /**
+   * Uses colorMap property of options object. 
+   * Creates a function to return value from predefined color maps if name of color map is provided  
+   * or uses the passed function directly.
+   * @param options
+   */
+  private setColorMapFromOptions(options: InterpolatedSourceOptions) {
+    if (typeof options.colorMap == 'string') {
+      super.getColor = (v) => {
+        const black = [0, 0, 0, 255];
+        if (isNaN(v)) {
+          return black;
+        }
+        if (v > 99) {
+          v = 99;
+        }
+        if (v < 0) {
+          v = 0;
+        }
+        v = Math.floor(v);
+        return colorMaps[options.colorMap as string][v];
+      };
+    } else {
+      super.getColor = options.colorMap;
+    }
+  }
+
+  /**
+   * Get Minimum boundary used in normalization. Values under this minimum are set to it (clamped)
+   */
+  get min(): number {
     return this.options.min;
   }
 
-  set min(value) {
+  /**
+   * Set Minimum boundary used in normalization. Values under this minimum are set to it (clamped)
+   */
+  set min(value: number) {
     this.options.min = value;
     this.normalizeWeight(this.weight);
     super.changed();
   }
 
-  get max() {
+  /**
+   * Get Maximum boundary used in normalization. Values over this minimum are set to it (clamped)
+   */
+  get max(): number {
     return this.options.max;
   }
 
-  set max(value) {
+  /**
+   * Set Maximum boundary used in normalization. Values over this minimum are set to it (clamped)
+   */
+  set max(value: number) {
     this.options.max = value;
     this.normalizeWeight(this.weight);
     super.changed();
@@ -118,17 +140,23 @@ export class InterpolatedSource extends IDW {
     return this.options.colorMap;
   }
 
-  set colorMap(value) {
+  set colorMap(value: ((v: number) => number[]) | string) {
     this.options.colorMap = value;
-    super.getColor = this.options.colorMap;
+    this.setColorMapFromOptions(this.options);
     super.changed();
   }
 
-  get weight() {
+  /**
+   * Get the feature attribute used to get the values interpolated
+   */
+  get weight(): string {
     return this.options.weight;
   }
 
-  set weight(value) {
+  /**
+   * Set the feature attribute used to get the values interpolated
+   */
+  set weight(value: string) {
     this.options.weight = value;
     this.normalizeWeight(this.weight);
     super.changed();

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
@@ -13,6 +13,7 @@ import {HsDialogContainerService} from '../../layout/dialogs/dialog-container.se
 import {HsDimensionTimeService} from '../../../common/get-capabilities/dimension-time.service';
 import {HsDrawService} from '../../draw/draw.service';
 import {HsEventBusService} from '../../core/event-bus.service';
+import {HsIdwWidgetComponent} from '../widgets/idw-widget.component';
 import {HsLanguageService} from './../../language/language.service';
 import {HsLayerDescriptor} from './../layer-descriptor.interface';
 import {HsLayerEditorDimensionsComponent} from '../dimensions/layer-editor-dimensions.component';
@@ -83,6 +84,7 @@ export class HsLayerEditorComponent {
       HsLegendWidgetComponent,
       HsLayerEditorDimensionsComponent,
       HsOpacityWidgetComponent,
+      HsIdwWidgetComponent,
     ];
     for (const widgetClass of widgets) {
       this.hsWidgetContainerService.create(widgetClass, {}, this.app);

--- a/projects/hslayers/src/components/layermanager/layermanager.module.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.module.ts
@@ -11,6 +11,7 @@ import {
 import {HsClusterWidgetComponent} from './widgets/cluster-widget.component';
 import {HsCopyLayerDialogComponent} from './dialogs/copy-layer-dialog.component';
 import {HsGetCapabilitiesModule} from '../../common/get-capabilities/get-capabilities.module';
+import {HsIdwWidgetComponent} from './widgets/idw-widget.component';
 import {HsLanguageModule} from '../language/language.module';
 import {HsLayerEditorComponent} from './editor/layer-editor.component';
 import {HsLayerEditorDimensionsComponent} from './dimensions/layer-editor-dimensions.component';
@@ -54,6 +55,7 @@ import {HsUiExtensionsModule} from '../../common/widgets/ui-extensions.module';
     HsMetadataWidgetComponent,
     HsScaleWidgetComponent,
     HsClusterWidgetComponent,
+    HsIdwWidgetComponent,
     HsLegendWidgetComponent,
     HsOpacityWidgetComponent,
   ],
@@ -90,6 +92,7 @@ import {HsUiExtensionsModule} from '../../common/widgets/ui-extensions.module';
     HsClusterWidgetComponent,
     HsLegendWidgetComponent,
     HsOpacityWidgetComponent,
+    HsIdwWidgetComponent
   ],
 })
 export class HsLayerManagerModule {}

--- a/projects/hslayers/src/components/layermanager/public-api.ts
+++ b/projects/hslayers/src/components/layermanager/public-api.ts
@@ -21,6 +21,7 @@ export * from './dialogs/remove-all-dialog.component';
 export * from './dialogs/remove-layer-dialog.component';
 export * from './dialogs/copy-layer-dialog.component';
 export * from './widgets/cluster-widget.component';
+export * from './widgets/idw-widget.component';
 export * from './widgets/layer-editor-widget-base.component';
 export * from './widgets/layer-editor-widget-container.service';
 export * from './widgets/legend-widget.component';

--- a/projects/hslayers/src/components/layermanager/widgets/idw-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/idw-widget.component.html
@@ -1,0 +1,39 @@
+<div class="form-group" *ngIf="(layerDescriptor | async).type === 'IDW'">
+  <div class="form-inline">
+    <label class="control-label" style="width: 100%; justify-content: left">{{
+      "LAYERMANAGER.layerEditor.interpolatedAttribute" | translateHs : {app: data.app} }}:</label>
+
+    <select class="form-control form-select" style="width: 100%" [(ngModel)]="weightAttribute"
+      [ngModelOptions]="{standalone: true}" (change)="setWeight()">
+      <option [ngValue]="attr" *ngFor="let attr of attributes">
+        {{attr}}
+      </option>
+    </select>
+  </div>
+
+  <div class="form-inline">
+    <label class="control-label" style="width: 100%; justify-content: left">{{
+      "LAYERMANAGER.layerEditor.colorMap" | translateHs : {app: data.app} }}:</label>
+
+    <select class="form-control form-select" style="width: 100%" [(ngModel)]="colorMap"
+      [ngModelOptions]="{standalone: true}" (change)="setColorMap()">
+      <option [ngValue]="cm" *ngFor="let cm of colorMaps">
+        {{cm}}
+      </option>
+    </select>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label" for="hsIdwMin">{{
+        "LAYERMANAGER.layerEditor.min" | translateHs : {app: data.app} }}:</label>
+      <input class="form-control inline" (change)="setBounds()" [(ngModel)]="min" name="hsIdwMin" id="hsIdwMin"/>
+
+    </div>
+    <div class="col-md-6">
+      <label class="form-label" for="hsIdwMax">{{
+        "LAYERMANAGER.layerEditor.max" | translateHs : {app: data.app} }}:</label>
+      <input class="form-control" (change)="setBounds()" [(ngModel)]="max" name="hsIdwMax" for="hsIdwMax" />
+    </div>
+  </div>
+</div>

--- a/projects/hslayers/src/components/layermanager/widgets/idw-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/idw-widget.component.ts
@@ -4,6 +4,7 @@ import VectorSource from 'ol/source/Vector';
 import colorScales from 'colormap/colorScale';
 import colormap from 'colormap';
 
+import {Feature} from 'ol';
 import {HsLanguageService} from '../../language/language.service';
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
 import {HsLayerSelectorService} from '../editor/layer-selector.service';
@@ -37,17 +38,18 @@ export class HsIdwWidgetComponent
     const srcAsIDW = this.getIdwSource();
     const underSource = srcAsIDW.featureCache as VectorSource;
     const features = underSource.getFeatures();
-    this.attributes =
-      features.length > 0
-        ? Object.keys(features[0].getProperties()).filter(
-            (attr) => {
-              return (
-                attr != 'geometry' && !isNaN(Number(features[0].get(attr)))
-              );
-            } //Check if number
-          )
-        : [];
+    this.attributes = this.listNumericAttributes(features);
     this.weightAttribute = srcAsIDW.weight;
+  }
+
+  listNumericAttributes(features: Feature[]): string[] {
+    return features.length > 0
+      ? Object.keys(features[0].getProperties()).filter(
+          (attr) => {
+            return attr != 'geometry' && !isNaN(Number(features[0].get(attr)));
+          } //Check if number
+        )
+      : [];
   }
 
   getIdwSource(): InterpolatedSource {
@@ -69,15 +71,7 @@ export class HsIdwWidgetComponent
 
   setColorMap(): void {
     const srcAsIDW = this.getIdwSource();
-    const generatedColorMap = colormap({
-      colormap: this.colorMap,
-      nshades: 100,
-      format: 'rgb',
-      alpha: 255,
-    }).map((v) => {
-      v[3] = 255;
-      return v;
-    });
+    const generatedColorMap = this.generateColormap(100);
 
     srcAsIDW.colorMap = (v) => {
       const black = [0, 0, 0, 255];
@@ -93,5 +87,17 @@ export class HsIdwWidgetComponent
       v = Math.floor(v);
       return generatedColorMap[v];
     };
+  }
+
+  generateColormap(nshades: number) {
+    return colormap({
+      colormap: this.colorMap,
+      nshades,
+      format: 'rgb',
+      alpha: 255,
+    }).map((v) => {
+      v[3] = 255;
+      return v;
+    });
   }
 }

--- a/projects/hslayers/src/components/layermanager/widgets/idw-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/idw-widget.component.ts
@@ -1,0 +1,97 @@
+import {Component, OnInit} from '@angular/core';
+
+import VectorSource from 'ol/source/Vector';
+import colorScales from 'colormap/colorScale';
+import colormap from 'colormap';
+
+import {HsLanguageService} from '../../language/language.service';
+import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
+import {HsLayerSelectorService} from '../editor/layer-selector.service';
+import {InterpolatedSource} from '../../../common/layers/hs.source.interpolated';
+
+@Component({
+  selector: 'hs-idw-widget',
+  templateUrl: './idw-widget.component.html',
+})
+export class HsIdwWidgetComponent
+  extends HsLayerEditorWidgetBaseComponent
+  implements OnInit
+{
+  weightAttribute: string;
+  attributes: string[];
+  name = 'idw-widget';
+  colorMaps = Object.keys(colorScales);
+  colorMap;
+  min: number | string = '';
+  max: number | string = '';
+
+  constructor(
+    public HsLanguageService: HsLanguageService,
+    hsLayerSelectorService: HsLayerSelectorService
+  ) {
+    super(hsLayerSelectorService);
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    const srcAsIDW = this.getIdwSource();
+    const underSource = srcAsIDW.featureCache as VectorSource;
+    const features = underSource.getFeatures();
+    this.attributes =
+      features.length > 0
+        ? Object.keys(features[0].getProperties()).filter(
+            (attr) => {
+              return (
+                attr != 'geometry' && !isNaN(Number(features[0].get(attr)))
+              );
+            } //Check if number
+          )
+        : [];
+    this.weightAttribute = srcAsIDW.weight;
+  }
+
+  getIdwSource(): InterpolatedSource {
+    const srcAsAny = this.olLayer.getSource() as any;
+    const srcAsIDW = srcAsAny as InterpolatedSource;
+    return srcAsIDW;
+  }
+
+  setWeight(): void {
+    const srcAsIDW = this.getIdwSource();
+    srcAsIDW.weight = this.weightAttribute;
+  }
+
+  setBounds(): void {
+    const srcAsIDW = this.getIdwSource();
+    srcAsIDW.min = this.min == '' ? undefined : parseFloat(this.min.toString());
+    srcAsIDW.max = this.max == '' ? undefined : parseFloat(this.max.toString());
+  }
+
+  setColorMap(): void {
+    const srcAsIDW = this.getIdwSource();
+    const generatedColorMap = colormap({
+      colormap: this.colorMap,
+      nshades: 100,
+      format: 'rgb',
+      alpha: 255,
+    }).map((v) => {
+      v[3] = 255;
+      return v;
+    });
+
+    srcAsIDW.colorMap = (v) => {
+      const black = [0, 0, 0, 255];
+      if (isNaN(v)) {
+        return black;
+      }
+      if (v > 99) {
+        v = 99;
+      }
+      if (v < 0) {
+        v = 0;
+      }
+      v = Math.floor(v);
+      return generatedColorMap[v];
+    };
+  }
+}

--- a/projects/hslayers/src/components/layout/layout.component.ts
+++ b/projects/hslayers/src/components/layout/layout.component.ts
@@ -52,17 +52,6 @@ export class HsLayoutComponent implements AfterViewInit, OnInit {
 
     this.HsLayoutService.get(this.app).contentWrapper =
       this.elementRef.nativeElement.querySelector('.hs-content-wrapper');
-    if (this.HsConfig.get(this.app).sidebarPosition === 'left') {
-      this.HsLayoutService.get(this.app).contentWrapper.classList.add(
-        'flex-reverse'
-      );
-      this.HsLayoutService.get(this.app).sidebarRight = false;
-      this.HsConfig.get(this.app).sidebarPosition = 'left';
-      this.sidebarPosition = 'left';
-    } else if (this.HsConfig.get(this.app).sidebarPosition != 'invisible') {
-      this.HsConfig.get(this.app).sidebarPosition = 'right';
-      this.sidebarPosition = 'right';
-    }
 
     this.HsLayoutService.init(this.app);
 
@@ -91,6 +80,12 @@ export class HsLayoutComponent implements AfterViewInit, OnInit {
     this.HsLayoutService.sidebarPosition.subscribe(({app, position}) => {
       if (this.app == app) {
         this.sidebarPosition = position;
+        if (position === 'left') {
+          this.HsLayoutService.get(this.app).contentWrapper.classList.add(
+            'flex-reverse'
+          );
+          this.HsLayoutService.get(this.app).sidebarRight = false;
+        }
       }
     });
     this.HsLayoutService.sidebarVisible.subscribe(({app, visible}) => {

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -29,7 +29,7 @@ const defaultLayoutParams = {
   sidebarPosition: 'left',
 };
 
-type HsLayoutParams = {
+export type HsLayoutParams = {
   /**
    * Storage of default main panel.
    * This panel is opened during initialization of app and also when other panel than default is closed.
@@ -217,15 +217,20 @@ export class HsLayoutService {
   parseConfig(app: string) {
     const appRef = this.get(app);
     appRef.panel_enabled = {};
-    for (const key of Object.keys(this.HsConfig.get(app).panelsEnabled)) {
-      this.panelEnabled(key, app, this.getPanelEnableState(key, app));
+    const configRef = this.HsConfig.get(app);
+    if (configRef) {
+      for (const key of Object.keys(configRef.panelsEnabled)) {
+        this.panelEnabled(key, app, this.getPanelEnableState(key, app));
+      }
+      appRef.sidebarToggleable = configRef.hasOwnProperty('sidebarToggleable')
+        ? configRef.sidebarToggleable
+        : true;
     }
 
-    appRef.sidebarToggleable = this.HsConfig.get(app).hasOwnProperty(
-      'sidebarToggleable'
-    )
-      ? this.HsConfig.get(app).sidebarToggleable
-      : true;
+    this.sidebarPosition.next({
+      app,
+      position: configRef?.sidebarPosition ?? 'left',
+    });
   }
 
   getPanelEnableState(panel, app: string): boolean {

--- a/projects/hslayers/src/components/layout/panels/panel-container.component.ts
+++ b/projects/hslayers/src/components/layout/panels/panel-container.component.ts
@@ -88,14 +88,16 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
     const componentRef = viewContainerRef.createComponent(componentFactory);
     const componentRefInstance = <HsPanelComponent>componentRef.instance;
     componentRefInstance.viewRef = componentRef.hostView;
-    /**
-     * Assign panel width class to a component host first child
-     * Used to define panelSpace panel width
-     */
-    this.service.setPanelWidth(
-      this.HsConfig.get(this.app).panelWidths,
-      componentRefInstance
-    );
+    if (this.HsConfig.get(this.app)) {
+      /**
+       * Assign panel width class to a component host first child
+       * Used to define panelSpace panel width
+       */
+      this.service.setPanelWidth(
+        this.HsConfig.get(this.app).panelWidths,
+        componentRefInstance
+      );
+    }
 
     /* When component doesn't create its own data object 
     set data by merging two sources: html attribute (this.data) and parameter passed 

--- a/projects/hslayers/src/components/sidebar/mini-sidebar.component.ts
+++ b/projects/hslayers/src/components/sidebar/mini-sidebar.component.ts
@@ -2,8 +2,7 @@ import {Component, Input, OnInit} from '@angular/core';
 import {HsButton} from './button.interface';
 import {HsConfig} from './../../config.service';
 import {HsCoreService} from '../core/core.service';
-import {HsLanguageService} from '../language/language.service';
-import {HsLayoutService} from '../layout/layout.service';
+import {HsLayoutParams, HsLayoutService} from '../layout/layout.service';
 import {HsSidebarService} from './sidebar.service';
 import {Subject, delay, startWith, takeUntil} from 'rxjs';
 @Component({
@@ -15,6 +14,7 @@ export class HsMiniSidebarComponent implements OnInit {
   buttons: HsButton[] = [];
   miniSidebarButton: {title: string};
   ngUnsubscribe = new Subject<void>();
+  layoutAppRef: HsLayoutParams;
   constructor(
     public HsCoreService: HsCoreService,
     public HsSidebarService: HsSidebarService,
@@ -22,6 +22,7 @@ export class HsMiniSidebarComponent implements OnInit {
     public HsConfig: HsConfig
   ) {}
   ngOnInit() {
+    this.layoutAppRef = this.HsLayoutService.get(this.app);
     this.HsSidebarService.apps[this.app].buttons
       .pipe(takeUntil(this.ngUnsubscribe))
       .pipe(startWith([]), delay(0))

--- a/projects/hslayers/src/components/sidebar/partials/sidebar.html
+++ b/projects/hslayers/src/components/sidebar/partials/sidebar.html
@@ -1,16 +1,16 @@
 <div class="hs-sidebar-list hs-main-panel list-group">
-    <hs-panel-header class="sidebar-header w-100" *ngIf="HsLayoutService.get(app).minisidebar" name="additional"
+    <hs-panel-header class="sidebar-header w-100" *ngIf="layoutAppRef.minisidebar" name="additional"
         [title]="'SIDEBAR.additionalPanels' | translateHs: {app} " [app]="app"></hs-panel-header>
 
-    <span class="hs-sidebar-item list-group-item border-top-0" *ngIf="HsLayoutService.get(app).sidebarToggleable"
+    <span class="hs-sidebar-item list-group-item border-top-0" *ngIf="layoutAppRef.sidebarToggleable"
         (click)="toggleSidebar()">
         <i class="menu-icon"
-            [ngClass]="HsLayoutService.get(app).sidebarExpanded ? (HsConfig.get(app).sidebarPosition === 'left' ? 'icon-chevron-left' : 'icon-chevron-right') : (HsConfig.get(app).sidebarPosition === 'left' ? 'icon-chevron-right' : 'icon-chevron-left')"></i>
+            [ngClass]="layoutAppRef.sidebarExpanded ? (layoutAppRef.sidebarPosition === 'left' ? 'icon-chevron-left' : 'icon-chevron-right') : (layoutAppRef.sidebarPosition === 'left' ? 'icon-chevron-right' : 'icon-chevron-left')"></i>
     </span><!-- TODO: Remove function call from template -->
 
     <span *ngFor="let button of buttons" class="hs-sidebar-item list-group-item"
         [hidden]="!button.visible" (click)="HsSidebarService.buttonClicked(button, app)"
-        [ngClass]="{'active': HsLayoutService.get(app).mainpanel === button.panel,  'hs-panel-hidden' : !button.fits}"
+        [ngClass]="{'active': layoutAppRef.mainpanel === button.panel,  'hs-panel-hidden' : !button.fits}"
         title="{{button.description | translateHs: {app} }}"><!-- TODO: Remove function call from template -->
         <i *ngIf="button.icon" class="menu-icon {{button.icon}}" data-toggle="tooltip" data-container="body"
             data-placement="auto"></i>
@@ -20,9 +20,9 @@
             class="hs-sidebar-item-title">{{button.title | translateHs: {app} }}</span>
     </span>
 <!-- TODO: Remove function call from template -->
-    <span class="hs-sidebar-item  list-group-item" *ngIf="HsLayoutService.get(app).minisidebar"
+    <span class="hs-sidebar-item  list-group-item" *ngIf="layoutAppRef.minisidebar"
         (click)="HsLayoutService.setMainPanel('sidebar', app, true)"
-        [ngClass]="{'active': HsLayoutService.get(app).mainpanel === 'sidebar'}">
+        [ngClass]="{'active': layoutAppRef.mainpanel === 'sidebar'}">
         <i class="menu-icon icon-equals" data-toggle="tooltip" data-container="body" data-placement="auto" title="Menu"
             style="margin-left: 0px !important;"></i>
         <span class="hs-sidebar-item-title">{{miniSidebarButton.title | translateHs: {app} }}</span>

--- a/projects/hslayers/src/components/sidebar/sidebar.component.ts
+++ b/projects/hslayers/src/components/sidebar/sidebar.component.ts
@@ -7,7 +7,7 @@ import {HsButton} from './button.interface';
 import {HsConfig} from '../../config.service';
 import {HsCoreService} from './../core/core.service';
 import {HsEventBusService} from '../core/event-bus.service';
-import {HsLayoutService} from '../layout/layout.service';
+import {HsLayoutParams, HsLayoutService} from '../layout/layout.service';
 import {HsShareUrlService} from '../permalink/share-url.service';
 import {HsSidebarParams, HsSidebarService} from './sidebar.service';
 
@@ -22,6 +22,7 @@ export class HsSidebarComponent implements OnInit, OnDestroy {
   miniSidebarButton: {title: string};
   private end = new Subject<void>();
   private serviceAppRef: HsSidebarParams;
+  layoutAppRef: HsLayoutParams;
 
   constructor(
     public HsLayoutService: HsLayoutService,
@@ -37,6 +38,7 @@ export class HsSidebarComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     const panel = this.HsPermalinkUrlService.getParamValue(HS_PRMS.panel);
     this.serviceAppRef = this.HsSidebarService.get(this.app);
+    this.layoutAppRef = this.HsLayoutService.get(this.app);
     this.serviceAppRef.buttons
       .pipe(startWith([]), delay(0))
       .pipe(takeUntil(this.end))

--- a/projects/hslayers/src/components/styles/add-colormap.component.ts
+++ b/projects/hslayers/src/components/styles/add-colormap.component.ts
@@ -1,0 +1,67 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import colorScales from 'colormap/colorScale';
+
+import {HsLanguageService} from '../language/language.service';
+import {HsLayerEditorWidgetBaseComponent} from '../../components/layermanager/widgets/layer-editor-widget-base.component';
+import {HsLayerSelectorService} from '../../components/layermanager/editor/layer-selector.service';
+import {HsStylerService} from './styler.service';
+import {listNumericAttributes} from '../layermanager/widgets/idw-widget.component';
+
+@Component({
+  selector: 'add-colormap',
+  templateUrl: './add-colormap.html',
+})
+export class HsAddColormapComponent implements OnInit {
+  name = 'add-colormap';
+  @Input() layer: VectorLayer<VectorSource>;
+  weightAttribute: string;
+  attributes: string[];
+  colorMaps = Object.keys(colorScales);
+  colorMap: string;
+  min: number | string = '';
+  max: number | string = '';
+  @Output() canceled = new EventEmitter<void>();
+  @Input() data: {app: string};
+
+  constructor(
+    public HsLanguageService: HsLanguageService,
+    private hsStylerService: HsStylerService
+  ) {}
+
+  ngOnInit(): void {
+    const src = this.layer.getSource();
+    const features = src.getFeatures();
+    this.attributes = listNumericAttributes(features);
+  }
+
+  changeAttrib() {
+    const values = this.layer
+      .getSource()
+      .getFeatures()
+      .map((f) => parseFloat(f.get(this.weightAttribute)));
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    if (!isNaN(min)) {
+      this.min = min;
+    }
+    if (!isNaN(max)) {
+      this.max = max;
+    }
+  }
+
+  save(): void {
+    this.hsStylerService.addRule('ColorMap', this.data.app, {
+      colorMapName: this.colorMap,
+      min: this.min ? parseFloat(this.min.toString()) : undefined,
+      max: this.max ? parseFloat(this.max.toString()) : undefined,
+      attribute: this.weightAttribute,
+    });
+  }
+
+  cancel(): void {
+    this.canceled.emit();
+  }
+}

--- a/projects/hslayers/src/components/styles/add-colormap.html
+++ b/projects/hslayers/src/components/styles/add-colormap.html
@@ -1,0 +1,48 @@
+<div class="form-group">
+  <div class="form-inline">
+    <label class="control-label" style="width: 100%; justify-content: left">{{
+      "LAYERMANAGER.layerEditor.interpolatedAttribute" | translateHs : {app: data.app} }}:</label>
+
+    <select class="form-control form-select" style="width: 100%" [(ngModel)]="weightAttribute"
+      [ngModelOptions]="{standalone: true}" (change)="changeAttrib()">
+      <option [ngValue]="attr" *ngFor="let attr of attributes">
+        {{attr}}
+      </option>
+    </select>
+  </div>
+
+  <div class="form-inline">
+    <label class="control-label" style="width: 100%; justify-content: left">{{
+      "LAYERMANAGER.layerEditor.colorMap" | translateHs : {app: data.app} }}:</label>
+
+    <select class="form-control form-select" style="width: 100%" [(ngModel)]="colorMap"
+      [ngModelOptions]="{standalone: true}">
+      <option [ngValue]="cm" *ngFor="let cm of colorMaps">
+        {{cm}}
+      </option>
+    </select>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label">{{
+        "LAYERMANAGER.layerEditor.min" | translateHs : {app: data.app} }}:</label>
+      <input class="form-control inline" [(ngModel)]="min" name="hsIdwMin"/>
+
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">{{
+        "LAYERMANAGER.layerEditor.max" | translateHs : {app: data.app} }}:</label>
+      <input class="form-control" [(ngModel)]="max" name="hsIdwMax" />
+    </div>
+  </div>
+
+  <div class="row g-3 p-2">
+    <div class="col-md-6">
+        <button (click)="save()" class="btn btn-primary">{{"COMMON.apply" | translateHs : {app: data.app} }}</button>
+    </div>
+    <div class="col-md-6">
+      <button (click)="cancel()" class="btn btn-outline-secondary">{{"COMMON.close" | translateHs : {app: data.app} }}</button>
+  </div>
+  </div>
+</div>

--- a/projects/hslayers/src/components/styles/public-api.ts
+++ b/projects/hslayers/src/components/styles/public-api.ts
@@ -22,3 +22,4 @@ export * from './styles';
 export * from './styles.module';
 export * from './symbolizers/symbolizer-list-item/symbolizer-list-item.component';
 export * from './rule/rule-list-item/rule-list-item.component';
+export * from './add-colormap.component';

--- a/projects/hslayers/src/components/styles/styler.component.html
+++ b/projects/hslayers/src/components/styles/styler.component.html
@@ -26,21 +26,14 @@
             <button ngbDropdownItem (click)="hsStylerService.addRule('Cluster',data.app)">
               {{'STYLER.clusterRule' | translateHs : {app: data.app} }}
             </button>
-
-            <div ngbDropdown>
-              <div class="align-items-center d-flex justify-content-between" style="padding: 0.25rem 1rem;" id="dropdownAddColorMapRule" ngbDropdownToggle [title]="'STYLER.colorMap' | translateHs : data">
-                {{'STYLER.colorMap' | translateHs : {app: data.app} }}
-              </div>
-        
-              <div ngbDropdownMenu aria-labelledby="dropdownAddColorMapRule">
-                <button *ngFor="let colormap of colormaps" class="dropdown-item" type="button" (click)="hsStylerService.addRule('ColorMap',data.app, colormap)">{{colormap}}</button>
-              </div>
-            </div>
-
+            <button ngbDropdownItem (click)="appRef.colorMapDialogVisible = !appRef.colorMapDialogVisible">
+              {{'STYLER.colorMap' | translateHs : {app: data.app} }}
+            </button>
           </div>
         </div>
       </div>
     </div>
+    <add-colormap [layer] = "appRef.layer" [data]="data" (canceled)="appRef.colorMapDialogVisible = false" *ngIf="appRef.colorMapDialogVisible"></add-colormap>
     <ng-container *ngIf="appRef.styleObject">
       <ul class="list-group hs-styler-content-list" cdkDropList (cdkDropListDropped)="drop($event)"
         [cdkDropListData]="appRef.styleObject.rules">

--- a/projects/hslayers/src/components/styles/styles.module.ts
+++ b/projects/hslayers/src/components/styles/styles.module.ts
@@ -6,6 +6,7 @@ import {FormsModule} from '@angular/forms';
 import {ColorSketchModule} from 'ngx-color/sketch';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 
+import {HsAddColormapComponent} from './add-colormap.component';
 import {HsAddFilterButtonComponent} from './filters/add-filter-button.component';
 import {HsColorPickerComponent} from './symbolizers/color-picker/color-picker.component';
 import {HsComparisonFilterComponent} from './filters/comparison-filter.component';
@@ -52,6 +53,7 @@ import {HsUploadModule} from '../../common/upload/upload.module';
     HsStylerPartBaseComponent,
     HsRuleListItemComponent,
     HsSymbolizerListItemComponent,
+    HsAddColormapComponent,
   ],
   imports: [
     CommonModule,
@@ -83,6 +85,7 @@ import {HsUploadModule} from '../../common/upload/upload.module';
     HsScaleDenominatorComponent,
     HsSelectIconDialogComponent,
     HsRuleListItemComponent,
+    HsAddColormapComponent,
   ],
 })
 export class HsStylerModule {}

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -294,6 +294,9 @@ export class HsConfig {
   }
 
   get(app: string = 'default'): HsConfigObject {
+    if (this.apps[app] == undefined) {
+      return this.apps['default'];
+    }
     return this.apps[app];
   }
 

--- a/projects/hslayers/src/hslayers.component.ts
+++ b/projects/hslayers/src/hslayers.component.ts
@@ -75,7 +75,10 @@ export class HslayersComponent implements OnInit {
     app: string,
     data?: any
   ): void {
-    if (this.hsConfig.apps[this.id].panelsEnabled[name]) {
+    if (
+      this.hsConfig.apps[this.id] == undefined ||
+      this.hsConfig.apps[this.id].panelsEnabled[name]
+    ) {
       this.HsPanelContainerService.create(panelComponent, data || {}, app);
     }
   }


### PR DESCRIPTION
## Description

A widget in layer editor which allows setting attribute which to visualize, color map and value interval in which to visualize
![image](https://user-images.githubusercontent.com/395514/171065889-05fb974c-e3a2-4cad-b0fb-ed0f6a00c284.png)

Min, max options now can be added to InterpolatedSource constructor

## Related issues or pull requests


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
