### PR TITLE
Use name property in UI for layer upload and composition saving, + other fixes

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -35,7 +35,7 @@
     "file": "Soubor",
     "FILE": {
       "onlyOneZipFileCan": "Lze nahrát pouze jeden soubor ZIP najednou",
-      "someOfTheUploadedFiles": "Nahrávaný soubor přesahuje maximální povolenou velikost",
+      "someOfTheUploadedFiles": "Nahrávaný soubor přesahuje maximální povolenou velikost 20MB",
       "zipFileCannotBeUploaded": "Soubor archivu nemůže být nahrát současně s běžnými soubory"
     },
     "requestServiceLayers": "Vyžádat vrstvy",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -36,7 +36,8 @@
     "FILE": {
       "onlyOneZipFileCan": "Only one zip file can be uploaded at once",
       "someOfTheUploadedFiles": "Uploaded file exceeded maximum allowed size",
-      "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files"
+      "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files",
+      "zipFileContainsAFile": "Zip file contains files, that exeeds maximum allowed file size that can be stored on the database"
     },
     "requestServiceLayers": "Request service layers",
     "saveToDatabase": "Save to database",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -35,9 +35,9 @@
     "file": "File",
     "FILE": {
       "onlyOneZipFileCan": "Only one zip file can be uploaded at once",
-      "someOfTheUploadedFiles": "Uploaded file exceeded maximum allowed size",
+      "someOfTheUploadedFiles": "Uploaded file exceeded maximum allowed size of 20MB",
       "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files",
-      "zipFileContainsAFile": "Zip file contains files, that exeeds maximum allowed file size that can be stored on the database"
+      "zipFileContainsAFile": "Zip file contains files, that exeeds maximum allowed file size of 20MB, that can be stored on the database"
     },
     "requestServiceLayers": "Request service layers",
     "saveToDatabase": "Save to database",
@@ -92,9 +92,10 @@
     "SHP": {
       "loginRequired": "User login is required before layer can be loaded",
       "maximumNumberOf": "Maximum number of {{allowed}} files allowed, but {{length}} selected",
-      "missingOneOrMore": "Missing one or more Shape files. Load files with extensions *.shp, *.shx, *.dbf",
+      "missingOneOrMore": "Missing one or more Shape files. Load files with extensions *.shp, *.shx, *.dbf or zip containing these files.",
       "shapeFile": "Shape file (shp+dbf+shx)",
-      "SLDStyleFile": "Style file"
+      "SLDStyleFile": "Style file",
+      "neededFiles": "Load files with extensions *.shp, *.shx, *.dbf or zip file containing these files."
     },
     "srs": "SRS",
     "SRSRequired": "'SRS' field required to proceed!",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -36,7 +36,8 @@
     "FILE": {
       "onlyOneZipFileCan": "Vienlaikus var augšupielādēt tikai vienu ZIP failu",
       "someOfTheUploadedFiles": "Augšupielādētais fails pārsniedz maksimālo atļauto lielumu",
-      "zipFileCannotBeUploaded": "Arhīva failu nevar augšupielādēt kopā ar parastajiem failiem"
+      "zipFileCannotBeUploaded": "Arhīva failu nevar augšupielādēt kopā ar parastajiem failiem",
+      "zipFileContainsAFile": "Arhivētais fails satur failus, kas pārsniedz maksimālo atļauto faila lielumu, ko var glabāt datu bāzē"
     },
     "requestServiceLayers": "Pieprasīt pakalpojumu slāņus",
     "saveToDatabase": "Saglabāt datubāzē",
@@ -64,7 +65,8 @@
       "someErrorHappened": "Radās kļūda vai trūkst ievades",
       "srsNotSupported": "Atlasītās koordinātu atskaites sistēmas (CRS/SRS) netiek atbalstītas. Lai turpinātu, lūdzu, norādiet failu EPSG: 3857 vai EPSG: 4326 projekcijā.",
       "thereWasErrorWhile": "Parsējot (Capabilities) atbildi no norādītās hipersaites, radās kļūda",
-      "urlInvalid": "Nav pieejama vai ari nav derīga pieprasītā slāņa URL adrese!"
+      "urlInvalid": "Nav pieejama vai ari nav derīga pieprasītā slāņa URL adrese!",
+      "unsupportedDatasourceType": "Neatbalstīts datu avota veids"
     },
     "externalDataSource": "Ārējais datu avots (hipersaite)",
     "featureCount": "Grafisko objektu skaits",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -35,7 +35,7 @@
     "file": "Fails",
     "FILE": {
       "onlyOneZipFileCan": "Vienlaikus var augšupielādēt tikai vienu ZIP failu",
-      "someOfTheUploadedFiles": "Augšupielādētais fails pārsniedz maksimālo atļauto lielumu",
+      "someOfTheUploadedFiles": "Augšupielādētais fails pārsniedz maksimālo atļauto lielumu 20MB",
       "zipFileCannotBeUploaded": "Arhīva failu nevar augšupielādēt kopā ar parastajiem failiem",
       "zipFileContainsAFile": "Arhivētais fails satur failus, kas pārsniedz maksimālo atļauto faila lielumu, ko var glabāt datu bāzē"
     },

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -35,7 +35,7 @@
     "file": "Súbor",
     "FILE": {
       "onlyOneZipFileCan": "Súbory ZIP je možné nahrávať len po jednom",
-      "someOfTheUploadedFiles": "Nahrávaný súbor prekročil maximálnu povolenú veľkosť",
+      "someOfTheUploadedFiles": "Nahrávaný súbor prekročil maximálnu povolenú veľkosť 20MB",
       "zipFileCannotBeUploaded": "Súbor archívu nie je možné nahrať spolu s bežnými súbormi"
     },
     "requestServiceLayers": "Vyžiadať vrstvy služby",

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -549,7 +549,7 @@ export class HsAddDataCommonFileService {
    */
   setDataName(data: FileDataObject, app: string): void {
     data.name = data.files[0].name.slice(0, -4);
-    data.title = data.files[0].name.slice(0, -4);
+    data.title = data.name;
     this.get(app).dataObjectChanged.next(data);
   }
 }

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -1,6 +1,6 @@
 <div>
 
-  <p><sub class="text-danger">{{'ADDLAYERS.Vector.note' | translateHs : {app} }}</sub></p>
+  <p [hidden]="data?.srs"><sub class="text-danger">{{'ADDLAYERS.Vector.note' | translateHs : {app} }}</sub></p>
 
   <div *ngIf="data.type === 'raster'"
     class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -8,9 +8,9 @@
   </div>
 
   <div class="form-floating mb-3">
-    <input [placeholder]="'ADDDATA.URL.submitLayerTitle' | translateHs : {app} " class="form-control" name="title"
-      [(ngModel)]="data.title" />
-    <label for="title" class="capabilities_label control-label">{{'COMMON.title' | translateHs : {app} }}</label>
+    <input [placeholder]="'ADDDATA.URL.submitLayerName' | translateHs : {app} " class="form-control" name="name"
+      [(ngModel)]="data.name" (ngModelChange)="data.title = data.name" />
+    <label for="name" class="capabilities_label control-label">{{'COMMON.name' | translateHs : {app} }}</label>
 
   </div>
   <div class="form-floating mb-3">

--- a/projects/hslayers/src/components/add-data/file/shp/shp.component.html
+++ b/projects/hslayers/src/components/add-data/file/shp/shp.component.html
@@ -4,6 +4,10 @@
             [uploader]="'shpdbfshx-'+app">
         </hs-file-upload>
     </div>
+    <div *ngIf="data.files?.length === 0"
+        class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
+        <p class="m-0"> {{'ADDLAYERS.SHP.neededFiles' | translateHs : {app} }}</p>
+    </div>
     <div *ngIf="hsAddDataCommonService.get(app).showDetails">
         <div class="d-flex flex-row justify-content-around">
             <div class="d-flex flex-column justify-content-center">

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -331,9 +331,11 @@ export class HsAddDataVectorService {
     let upsertReq: PostPatchLayerResponse;
     const commonFileRef = this.hsAddDataCommonFileService.get(app);
     commonFileRef.loadingToLayman = true;
-    const fiendlyName = getLaymanFriendlyLayerName(data.name);
-    const descriptor = await this.lookupLaymanLayer(fiendlyName, app);
-    if (!descriptor || descriptor?.name != fiendlyName) {
+    const exists = await this.hsAddDataCommonFileService.lookupLaymanLayer(
+      data.name,
+      app
+    );
+    if (!exists) {
       return OverwriteResponse.add;
     } else {
       const result =
@@ -349,7 +351,7 @@ export class HsAddDataVectorService {
           );
           const layerDesc: UpsertLayerObject = {
             title: data.title,
-            name: fiendlyName,
+            name: getLaymanFriendlyLayerName(data.name),
             crs: this.hsMapService.getCurrentProj(app).getCode(),
             workspace: commonFileRef.endpoint.user,
             access_rights: data.access_rights,
@@ -597,33 +599,5 @@ export class HsAddDataVectorService {
     } catch (e) {
       console.error('Uploaded file is not supported' + e);
     }
-  }
-
-  /**
-   * Try to find layer in Layman's database using Layman friendly layer name
-   * @param name - Layman friendly layer name to search by
-   * @param app - App identifier
-   */
-  async lookupLaymanLayer(
-    name: string,
-    app: string
-  ): Promise<HsLaymanLayerDescriptor> {
-    const commonFileRef = this.hsAddDataCommonFileService.get(app);
-    let descriptor: HsLaymanLayerDescriptor;
-    if (this.hsAddDataCommonFileService.isAuthorized()) {
-      this.hsAddDataCommonFileService.pickEndpoint(app);
-      try {
-        descriptor = await this.hsLaymanService.describeLayer(
-          commonFileRef.endpoint,
-          name,
-          commonFileRef.endpoint.user,
-          true
-        );
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
-    }
-    return descriptor;
   }
 }

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -519,7 +519,14 @@ export class HsAddDataVectorService {
     const object = {
       name: json.name,
       title: json.name,
-      srs: projection,
+      srs: epsg4326Aliases
+        .map((proj) => proj.getCode())
+        .some((code) => code === projection.getCode())
+        ? getProjection('EPSG:4326')
+        : this.hsLaymanService.supportedCRRList.indexOf(projection.getCode()) >
+          -1
+        ? projection
+        : getProjection('EPSG:4326'),
       features,
     };
     return object;

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -609,7 +609,8 @@ export class HsAddDataVectorService {
         descriptor = await this.hsLaymanService.describeLayer(
           commonFileRef.endpoint,
           name,
-          commonFileRef.endpoint.user
+          commonFileRef.endpoint.user,
+          true
         );
       } catch (error) {
         console.error(error);

--- a/projects/hslayers/src/components/map/map.service.ts
+++ b/projects/hslayers/src/components/map/map.service.ts
@@ -305,10 +305,13 @@ export class HsMapService {
    */
   setDefaultView = function (e, app): void {
     const appRef = this.hsConfig.get(app);
+    if (!appRef.default_view) {
+      return;
+    }
     const mapRef = this.getMap(app);
-    const center = appRef.default_view.getCenter();
+    const center = appRef.default_view?.getCenter();
     mapRef.getView().setCenter(center);
-    const zoom = appRef.default_view.getZoom();
+    const zoom = appRef.default_view?.getZoom();
     mapRef.getView().setZoom(zoom);
   };
   /**

--- a/projects/hslayers/src/components/save-map/dialog-save/dialog-save.component.html
+++ b/projects/hslayers/src/components/save-map/dialog-save/dialog-save.component.html
@@ -13,13 +13,13 @@
                     {{'SAVECOMPOSITION.dialogSave.areYouAttempting' | translateHs : {app: data.app} }}
                 </div>
                 <div>
-                    <b>{{appRef.compoData.title}}</b>
+                    <b>{{appRef.compoData.name}}</b>
                 </div>
                 <div
                     *ngIf="!appRef.statusData?.titleFree && appRef.statusData?.hasPermission && !appRef.statusData?.changeTitle">
                     <div>
                         {{'SAVECOMPOSITION.dialogSave.wantToOverwrite' | translateHs : {app: data.app} }}
-                        <b>{{appRef.compoData.title}}</b>
+                        <b>{{appRef.compoData.name}}</b>
                     </div>
                     <p>
                         <button type="button" class="btn btn-secondary btn-lg" data-dismiss="modal"
@@ -28,7 +28,7 @@
                     </p>
                     <p>
                         <button type="button" class="btn btn-secondary btn-lg"
-                            (click)="selectNewTitle()">{{'SAVECOMPOSITION.dialogSave.noSaveAs'
+                            (click)="selectNewName()">{{'SAVECOMPOSITION.dialogSave.noSaveAs'
                             | translateHs : {app: data.app} }}</button>
                     </p>
                 </div>
@@ -37,7 +37,7 @@
                     *ngIf="!appRef.statusData?.titleFree && appRef.statusData?.hasPermission && appRef.statusData?.changeTitle">
                     <div>{{'SAVECOMPOSITION.dialogSave.selectNewNameForMap' | translateHs : {app: data.app} }}</div>
                     <p>
-                        <input type="text" class="form-control hs-stc-title" [(ngModel)]="appRef.compoData.title">
+                        <input type="text" class="form-control hs-stc-title" [(ngModel)]="appRef.compoData.name">
                     </p>
                     <p>
                         <button type="button" class="btn btn-secondary btn-lg" data-dismiss="modal"

--- a/projects/hslayers/src/components/save-map/dialog-save/dialog-save.component.ts
+++ b/projects/hslayers/src/components/save-map/dialog-save/dialog-save.component.ts
@@ -42,8 +42,8 @@ export class HsSaveMapDialogComponent implements HsDialogComponent, OnInit {
   /**
    * Select new composition's title
    */
-  selectNewTitle(): void {
-    this.hsSaveMapManagerService.selectNewTitle(this.data.app);
+  selectNewName(): void {
+    this.hsSaveMapManagerService.selectNewName(this.data.app);
   }
 
   /**

--- a/projects/hslayers/src/components/save-map/form/form.component.html
+++ b/projects/hslayers/src/components/save-map/form/form.component.html
@@ -1,16 +1,7 @@
 <div class="form">
     <div class="form-floating mb-2">
-        <input type="text" class="form-control"
-            [ngStyle]="{'border-color': appRef.missingTitle ? '#ff0000' : '#ced4da'}" name="hs-save-map-title"
-            placeholder="'COMMON.title' | translateHs : {app} " [(ngModel)]="appRef.compoData.title"
-            (ngModelChange)="titleChanged()">
-        <label for="hs-save-map-title">{{'COMMON.title' | translateHs : {app} }} *</label>
-        <span class="d-flex justify-content-end text-danger" *ngIf="appRef.missingTitle">{{'COMMON.required' |
-            translateHs : {app} }}</span>
-    </div>
-    <div class="form-floating mb-2">
         <input type="text" class="form-control" [ngStyle]="{'border-color': appRef.missingName ? '#ff0000' : '#ced4da'}"
-            name="hs-save-map-name" [(ngModel)]="appRef.compoData.name" (ngModelChange)="titleChanged()"
+            name="hs-save-map-name" [(ngModel)]="appRef.compoData.name" (ngModelChange)="nameChanged()"
             placeholder="'COMMON.name' | translateHs : {app} ">
         <label for="hs-save-map-name">{{'COMMON.name' | translateHs : {app} }} *</label>
         <span class="d-flex justify-content-end text-danger" *ngIf="appRef.missingName">{{'COMMON.required' |
@@ -100,7 +91,8 @@
                         <input type="checkbox" class="form-check-input mt-0" name="hs-stclayer-{{i}}"
                             id="hs-stclayer-{{i}}" [(ngModel)]="layer.checked" [ngModelOptions]="{standalone: true}">
                         <label for="hs-stclayer-{{i}}" title="{{layer.title | translateHs : {app, module: 'LAYERS'} }}"
-                            class="form-check-label mw-100 text-truncate">{{layer.title | translateHs : {app, module: 'LAYERS'} }}</label>
+                            class="form-check-label mw-100 text-truncate">{{layer.title | translateHs : {app, module:
+                            'LAYERS'} }}</label>
                     </div>
                 </li>
                 <li class="list-group-item" style="padding: 3px">
@@ -194,7 +186,9 @@
     </div>
     <div class="mb-2 d-flex justify-content-end">
         <button type="button" class="btn btn-primary me-2" id="stc-saveas" [hidden]="!(isAllowed())"
-            (click)="initiateSave(true)"><!-- TODO: Remove function call from template -->{{'COMMON.save' | translateHs : {app} }}</button>
+            (click)="initiateSave(true)">
+            <!-- TODO: Remove function call from template -->{{'COMMON.save' | translateHs : {app} }}
+        </button>
         <a type="button" class="btn btn-secondary" (click)="saveCompoJson()" id="stc-download">{{'COMMON.download'
             |
             translateHs: this}}</a>

--- a/projects/hslayers/src/components/save-map/form/form.component.ts
+++ b/projects/hslayers/src/components/save-map/form/form.component.ts
@@ -116,9 +116,8 @@ export class HsSaveMapAdvancedFormComponent implements OnDestroy, OnInit {
   /**
    * Triggered when composition's title input field receives user's input
    */
-  titleChanged(): void {
+  nameChanged(): void {
     this.overwrite = false;
-    this.appRef.missingTitle = false;
     this.appRef.missingName = false;
   }
 

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -305,6 +305,7 @@ export class HsLaymanService implements HsSaverService {
     layerName: string,
     overwrite?: boolean
   ): Promise<PostPatchLayerResponse> {
+    layerName = getLaymanFriendlyLayerName(layerName);
     try {
       let data = await lastValueFrom(
         this.http[!overwrite ? 'post' : 'patch']<PostPatchLayerResponse>(

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -163,7 +163,7 @@ export class HsLaymanService implements HsSaverService {
           'blob.json'
         );
         formdata.append('name', compoData.name);
-        formdata.append('title', compoData.title);
+        formdata.append('title', compoData.name);
         formdata.append('abstract', compoData.abstract);
         const headers = new HttpHeaders();
         headers.append('Content-Type', null);

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -71,7 +71,7 @@ export class HsLaymanService implements HsSaverService {
   laymanLayerPending: Subject<string[]> = new Subject();
   totalProgress = 0;
   deleteQuery: Subscription;
-  supportedCRRList: string[];
+  supportedCRRList = SUPPORTED_SRS_LIST.slice(0, 2);
   constructor(
     private hsUtilsService: HsUtilsService,
     private http: HttpClient,
@@ -120,8 +120,6 @@ export class HsLaymanService implements HsSaverService {
           );
           laymanEP.version = laymanVersion.about.applications.layman.version;
           this.supportedCRRList = getSupportedSrsList(laymanEP);
-        } else {
-          this.supportedCRRList = SUPPORTED_SRS_LIST.slice(0, 2);
         }
       }
     });

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -281,7 +281,7 @@ export class HsLaymanService implements HsSaverService {
         endpoint,
         formData,
         asyncUpload,
-        layerDesc?.name,
+        layerDesc?.name ? description.name : '',
         exists
       );
       return res;
@@ -308,9 +308,9 @@ export class HsLaymanService implements HsSaverService {
     layerName = getLaymanFriendlyLayerName(layerName);
     try {
       let data = await lastValueFrom(
-        this.http[!overwrite ? 'post' : 'patch']<PostPatchLayerResponse>(
+        this.http[overwrite ? 'patch' : 'post']<PostPatchLayerResponse>(
           `${endpoint.url}/rest/workspaces/${endpoint.user}/layers${
-            !overwrite ? `?${Math.random()}` : `/${layerName}`
+            overwrite ? `/${layerName}` : `?${Math.random()}`
           }`,
           formData,
           {withCredentials: true}

--- a/projects/hslayers/src/components/save-map/save-map-manager.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map-manager.service.ts
@@ -33,7 +33,6 @@ export class HsSaveMapManagerParams {
     groups: [],
   };
   compoData: CompoData = {
-    title: '',
     name: '',
     abstract: '',
     keywords: '',
@@ -66,7 +65,6 @@ export class HsSaveMapManagerParams {
   preSaveCheckCompleted: Subject<{endpoint; app: string}> = new Subject();
   changeTitle: boolean;
   currentUser: string;
-  missingTitle = false;
   missingName = false;
   missingAbstract = false;
 
@@ -101,12 +99,11 @@ export class HsSaveMapManagerService {
         const responseData = data.data ?? data;
         appRef.compoData.id = responseData.id;
         appRef.compoData.abstract = responseData.abstract;
-        appRef.compoData.title = responseData.title;
         appRef.compoData.name = responseData.name;
         appRef.compoData.keywords = responseData.keywords;
         appRef.compoData.currentComposition = responseData;
         appRef.compoData.workspace = responseData.workspace;
-        appRef.compoData.currentCompositionTitle = appRef.compoData.title;
+        appRef.compoData.currentCompositionTitle = appRef.compoData.name;
         if (Object.keys(data).length !== 0) {
           this.validateForm(app);
         }
@@ -206,7 +203,7 @@ export class HsSaveMapManagerService {
       const response: any = await lastValueFrom(
         this.http.post(this.hsStatusManagerService.endpointUrl(app), {
           project: this.hsConfig.get(app).project_name,
-          title: appRef.compoData.title,
+          title: appRef.compoData.name,
           request: 'rightToSave',
         })
       );
@@ -394,12 +391,12 @@ export class HsSaveMapManagerService {
   }
 
   /**
-   * Callback for saving with new title
+   * Callback for saving with new name
    * @param app - App identifier
    */
-  selectNewTitle(app: string): void {
+  selectNewName(app: string): void {
     const appRef = this.get(app);
-    appRef.compoData.title = appRef.statusData.guessedTitle;
+    appRef.compoData.name = appRef.statusData.guessedTitle;
     appRef.changeTitle = true;
   }
 
@@ -410,14 +407,9 @@ export class HsSaveMapManagerService {
    */
   validateForm(app: string): boolean {
     const appRef = this.get(app);
-    appRef.missingTitle = !appRef.compoData.title;
     appRef.missingName = !appRef.compoData.name;
     appRef.missingAbstract = !appRef.compoData.abstract;
-    return (
-      !!appRef.compoData.title &&
-      !!appRef.compoData.name &&
-      !!appRef.compoData.abstract
-    );
+    return !!appRef.compoData.name && !!appRef.compoData.abstract;
   }
 
   /**
@@ -428,7 +420,6 @@ export class HsSaveMapManagerService {
     const appRef = this.get(app);
     appRef.compoData.id = '';
     appRef.compoData.abstract = '';
-    appRef.compoData.title = '';
     appRef.compoData.name = '';
     appRef.compoData.currentCompositionTitle = '';
     appRef.compoData.keywords = '';
@@ -490,7 +481,7 @@ export class HsSaveMapManagerService {
   focusTitle(app: string) {
     const appRef = this.get(app);
     if (appRef.statusData.guessedTitle) {
-      appRef.compoData.title = appRef.statusData.guessedTitle;
+      appRef.compoData.name = appRef.statusData.guessedTitle;
     }
     //TODO Check if this works and input is focused
     this.hsLayoutService

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -96,7 +96,7 @@ export class HsSaveMapService {
     const bbox = this.getBboxFromObject(compoData.bbox);
     const json: MapComposition = {
       abstract: compoData.abstract,
-      title: compoData.title,
+      title: compoData.name,
       keywords: compoData.keywords,
       nativeExtent: transformExtent(
         bbox,

--- a/projects/hslayers/src/components/save-map/types/compo-data.type.ts
+++ b/projects/hslayers/src/components/save-map/types/compo-data.type.ts
@@ -4,7 +4,6 @@ import {BoundingBoxObject} from './bounding-box-object.type';
 import {accessRightsModel} from '../../add-data/common/access-rights.model';
 
 export type CompoData = {
-  title?: string;
   name?: string;
   abstract?: string;
   keywords?: string;


### PR DESCRIPTION
## Description

For better user experience changed layer upload input form and map compostion saving form, going from title to name property instead. Layer title gets updated to the same name in case of any change.

Check if default_view is defined, when trying to get center and zoom.

Find 4326 proj. from aliases when uploading geojson file and check for supported SRS.

Don't wait for prev. uploaded vector layer to finish, if User tries to overwrite it instantly.
## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
