### PR TITLE
fix: Formatt time by config instead of hardcoded cs

### DIFF
--- a/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.html
+++ b/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.html
@@ -2,10 +2,10 @@
   <button type="button" class="btn btn-sm text-info" (click)="previousTime()" [disabled]="!hasPreviousTime">
     <i class="glyphicon icon-chevron-left"></i>
   </button>
-  <button class="btn btn-sm text-info px-0" (click)="$event.preventDefault();showTimeSelect()" [hidden]="selectVisible"
-    *ngIf="availableTimesFetched; else loading">
-    <span *ngIf="currentTime; else outOfRange">
-      {{currentTime | date:timeDisplayFormat:'cs'}}
+  <button class="btn btn-sm text-info px-0" (click)="$event.preventDefault();showTimeSelect()"
+    [hidden]="selectVisible">
+    <span [hidden]="!currentTimeDefined()">
+      {{currentTime | date:timeDisplayFormat:timeDisplayFormat}}
     </span>
   </button>
   <ng-template #loading>
@@ -23,7 +23,7 @@
   <select #hstimeselector [hidden]="!selectVisible" [(ngModel)]="currentTime" (change)="selectTime();hideTimeSelect();"
     (blur)="hideTimeSelect()">
     <option *ngFor="let time of availableTimes" [ngValue]="time">
-      {{time | date:timeDisplayFormat:timeDisplayLocale}}
+      {{time | date:timeDisplayFormat:timeDisplayFormat}}
     </option>
   </select>
   <button type="button" class="btn btn-sm text-info" (click)="followingTime()" [disabled]="!hasFollowingTime">

--- a/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.ts
@@ -29,12 +29,6 @@ export class HsLayerManagerTimeEditorComponent implements OnInit, OnDestroy {
   @ViewChild('hstimeselector') selectElement;
   selectVisible: boolean;
   timeDisplayFormat = 'yyyy-MM-dd HH:mm:ss z';
-  /**
-   * currently hard-coded and not changes
-   * TODO: needs to load locale data via registerLocaleData() from '\@angular/common'
-   * see https://stackoverflow.com/questions/34904683/how-to-set-locale-in-datepipe-in-angular-2
-   */
-  timeDisplayLocale = 'en-US';
   timesInSync: boolean;
   private ngUnsubscribe = new Subject<void>();
 

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -601,6 +601,7 @@ export class HslayersAppComponent {
             idwLayer,
             idwVectorLayer,
           ],
+          timeDisplayFormat: 'dd.MM.yyyy.',
           translationOverrides: {
             lv: {
               LAYERS: {


### PR DESCRIPTION
## Description

Don't use hardcoded 'cs' locale which isn't even a valid value for timeFormat. Use HsConfig.timeDisplayFormat instead

## Related issues or pull requests

#3126 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
