### PR TITLE
feat: Update dimension from TIME param im WMS sources

### DIFF
--- a/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/dimensions/layermanager-time-editor.component.ts
@@ -48,7 +48,7 @@ export class HsLayerManagerTimeEditorComponent implements OnInit, OnDestroy {
           return;
         }
         if (!this.availableTimes) {
-          this.fillAvailableTimes(layerDescriptor);
+          this.fillAvailableTimes(layerDescriptor, time);
         }
         this.setCurrentTimeIfAvailable(time);
       });
@@ -75,7 +75,7 @@ export class HsLayerManagerTimeEditorComponent implements OnInit, OnDestroy {
     this.selectVisible = false;
     this.timesInSync = false;
     if (this.layer.time) {
-      this.fillAvailableTimes(this.layer);
+      this.fillAvailableTimes(this.layer, undefined);
     }
   }
 
@@ -203,11 +203,11 @@ export class HsLayerManagerTimeEditorComponent implements OnInit, OnDestroy {
    * This gets called from subscriber and also OnInit because
    * subscriber could have been set up after the event was broadcasted
    */
-  private fillAvailableTimes(layer: HsLayerDescriptor) {
+  private fillAvailableTimes(layer: HsLayerDescriptor, defaultTime: string) {
     this.availableTimes = layer.time.timePoints;
     this.setDateTimeFormatting();
-    this.setCurrentTimeIfAvailable(this.layer.time.default);
-    if (!this.currentTime) {
+    this.setCurrentTimeIfAvailable(defaultTime ?? this.layer.time.default);
+    if (!this.currentTime && this.availableTimes.length > 0) {
       this.currentTime = this.availableTimes[0];
       this.currentTimeIdx = this.availableTimes.indexOf(this.currentTime);
     }

--- a/projects/hslayers/src/components/query/attribute-row/attribute-row.component.ts
+++ b/projects/hslayers/src/components/query/attribute-row/attribute-row.component.ts
@@ -20,7 +20,11 @@ export class HsQueryAttributeRowComponent implements OnInit {
   change(): void {
     if (this.feature?.feature) {
       const feature = this.feature.feature;
-      feature.set(this.attribute.name, JSON.parse(this.tmpObjectValue));
+      if (this.isObject) {
+        feature.set(this.attribute.name, JSON.parse(this.tmpObjectValue));
+      } else {
+        feature.set(this.attribute.name, this.attribute.value);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR introduces monitoring of TIME parameter in TileWMS and ImageWMS source objects accessed through getParams(). This is needed for map-whiteboard to synchronize time layers between users and we don't want to use Hslayers classes to do that - just map whiteboard library.

TIME request parameter in layer definition takes precedence over dimension definitions when calculating default initial time.

## Related issues or pull requests


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
