### PR TITLE
fix: Show dialogs also when they are created on startup

### DIFF
--- a/projects/hslayers/src/components/layout/dialogs/dialog-container.service.ts
+++ b/projects/hslayers/src/components/layout/dialogs/dialog-container.service.ts
@@ -1,13 +1,13 @@
 import {Injectable, Type} from '@angular/core';
 
-import {Subject} from 'rxjs';
+import {ReplaySubject, Subject} from 'rxjs';
 
 import {HsDialogComponent} from './dialog-component.interface';
 import {HsDialogItem} from './dialog-item';
 
 class HsDialogContainerParams {
   dialogs: Array<any> = [];
-  dialogObserver: Subject<HsDialogItem> = new Subject();
+  dialogObserver: ReplaySubject<HsDialogItem> = new ReplaySubject();
   dialogDestroyObserver: Subject<any> = new Subject();
 }
 

--- a/projects/test-statistics-app/src/app/app.component.ts
+++ b/projects/test-statistics-app/src/app/app.component.ts
@@ -8,6 +8,7 @@ import {Vector as VectorLayer} from 'ol/layer';
 import vidzeme from '../assets/vidzeme.json';
 import {
   HsConfig,
+  HsDialogContainerService,
   HsLayerManagerComponent,
   HsLayoutService,
   HsQueryComponent,
@@ -18,6 +19,7 @@ import {
   HsToolbarPanelContainerService,
 } from 'hslayers-ng';
 import {HsStatisticsPanelComponent} from '../lib/statistics-panel.component';
+import {InfoDialogComponent} from './info.component';
 
 @Component({
   selector: 'hslayers-app',
@@ -30,7 +32,8 @@ export class HslayersAppComponent {
     public HsConfig: HsConfig,
     hsLayoutService: HsLayoutService,
     hsQueryPopupService: HsQueryPopupService,
-    hsToolbarPanelContainerService: HsToolbarPanelContainerService
+    hsToolbarPanelContainerService: HsToolbarPanelContainerService,
+    hsDialogContainerService: HsDialogContainerService
   ) {
     this.HsConfig.update(
       {
@@ -204,6 +207,7 @@ export class HslayersAppComponent {
     hsLayoutService.createOverlay(HsQueryPopupComponent, this.app, {
       service: hsQueryPopupService,
     });
+    hsDialogContainerService.create(InfoDialogComponent, {}, this.app);
   }
   title = 'hslayers-workspace';
 }

--- a/projects/test-statistics-app/src/app/app.module.ts
+++ b/projects/test-statistics-app/src/app/app.module.ts
@@ -9,9 +9,10 @@ import {HsSearchModule} from 'hslayers-ng';
 import {HsLayerManagerModule, HsQueryModule, HsStylerModule} from 'hslayers-ng';
 import {HsStatisticsModule} from '../lib/statistics.module';
 import {HslayersAppComponent} from './app.component';
+import {InfoDialogComponent} from './info.component';
 
 @NgModule({
-  declarations: [HslayersAppComponent],
+  declarations: [HslayersAppComponent, InfoDialogComponent],
   imports: [
     BrowserModule,
     HsCoreModule,

--- a/projects/test-statistics-app/src/app/info-dialog.component.html
+++ b/projects/test-statistics-app/src/app/info-dialog.component.html
@@ -1,0 +1,34 @@
+<div class="modal in" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">
+                    About
+                </h4>
+                <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
+                    attr.aria-label="{{'COMMON.close' | translateHs: {app: data.app} }}">
+                </button>
+            </div>
+            <div class="modal-body" style="overflow-y:auto">
+                This tool allows to easily visualize statistical data in <a
+                    href="https://support.microsoft.com/en-us/office/save-a-workbook-to-text-format-txt-or-csv-3e9a9d6c-70da-4255-aa28-fcacf1f081e6">CSV
+                    format</a>, calculate <a href="https://en.wikipedia.org/wiki/Correlation">correlations</a> between
+                variables as well as create and run predictive models calculated using linear and <a
+                    href="https://corporatefinanceinstitute.com/resources/knowledge/other/multiple-linear-regression/">multiple-linear</a>
+                regression.
+                <br />
+                <hr />
+                <small>
+                    This application was supported by PoliRural (<a href="https://polirural.eu"
+                        target="_blank">https://polirural.eu</a>).<br />
+                    <img src="https://polirural.eu/wp-content/uploads/2019/08/EU.jpg" style="width: 67px;" />
+                    It received funding from the European Union’s Horizon 2020 research and innovation programme under
+                    grant agreement no. 818496</small>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" (click)="close()" title="Dismiss"
+                    data-dismiss="modal">Dismiss</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/projects/test-statistics-app/src/app/info.component.ts
+++ b/projects/test-statistics-app/src/app/info.component.ts
@@ -1,0 +1,29 @@
+import {Component, ElementRef, OnDestroy, ViewRef} from '@angular/core';
+
+import {HsDialogComponent, HsDialogContainerService} from 'hslayers-ng';
+
+import {Subject} from 'rxjs';
+
+@Component({
+  selector: 'info',
+  templateUrl: './info-dialog.component.html',
+})
+export class InfoDialogComponent implements HsDialogComponent, OnDestroy {
+  private end = new Subject<void>();
+  viewRef: ViewRef;
+  data: any;
+
+  constructor(
+    private hsDialogContainerService: HsDialogContainerService,
+    public elementRef: ElementRef
+  ) {}
+
+  close(): void {
+    this.hsDialogContainerService.destroy(this, this.data.app);
+  }
+
+  ngOnDestroy(): void {
+    this.end.next();
+    this.end.complete();
+  }
+}


### PR DESCRIPTION

## Description

Replay the values stored in dialogObserver object when subscribing

## Related issues or pull requests

fix #3190

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
