### PR TITLE
Fix sidebar language panel abbreviation, if language is set in hsConfig (Issue-3258)

### DIFF
--- a/projects/hslayers/src/components/core/core.service.ts
+++ b/projects/hslayers/src/components/core/core.service.ts
@@ -62,6 +62,8 @@ export class HsCoreService {
     translateService.setDefaultLang(`${app}|en`);
     if (this.HsConfig.get(app).language) {
       translateService.use(`${app}|${this.HsConfig.get(app).language}`);
+      this.hsLanguageService.apps[app].language =
+        this.HsConfig.get(app).language;
     } else {
       translateService.use(translateService.getDefaultLang());
     }

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -387,7 +387,7 @@ export class HslayersAppComponent {
             mapSwipe: true,
           },
           enabledLanguages: 'sk, lv, en',
-          language: 'en',
+          language: 'lv',
           assetsPath: 'assets',
           saveMapStateOnReload: true,
           symbolizerIcons: [


### PR DESCRIPTION
## Description

Resolves issue 3258

## Related issues or pull requests

closes #3258 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
