### PR TITLE
fix: inherit parent el min-height, so the map doesn't disappear when …

### DIFF
--- a/projects/hslayers-material/src/lib/layout/layout.component.html
+++ b/projects/hslayers-material/src/lib/layout/layout.component.html
@@ -1,4 +1,4 @@
-<div #hslayout class="hs-page-wrapper hsl w-100 h-100">
+<div #hslayout class="hsl hs-page-wrapper w-100 h-100" style="min-height: inherit !important">
     <div class="hs-content-wrapper d-flex w-100 h-100" [ngClass]="{
         'hs-open': HsLayoutService.sidebarExpanded && sidebarVisible,
         'hs-sb-right': HsConfig.get(app).sidebarPosition === 'right' && sidebarVisible,

--- a/projects/hslayers-material/src/lib/layout/layout.component.scss
+++ b/projects/hslayers-material/src/lib/layout/layout.component.scss
@@ -11,6 +11,7 @@ hslayers-material {
     }
 
     .hs-map-space {
+        min-height: inherit;
 	flex: 1 1 auto;
 	position: relative;
     }

--- a/projects/hslayers/src/components/layout/partials/layout.component.scss
+++ b/projects/hslayers/src/components/layout/partials/layout.component.scss
@@ -1,5 +1,6 @@
 .hs-content-wrapper {
     position: relative;
+    min-height: inherit;
     font-family: Roboto, "Helvetica Neue", sans-serif;
 
     &.hs-open .hs-panelspace{

--- a/projects/hslayers/src/components/layout/partials/layout.html
+++ b/projects/hslayers/src/components/layout/partials/layout.html
@@ -1,4 +1,4 @@
-<div #hslayout class="hs-page-wrapper hsl" style="width: 100%; height: 100%;">
+<div #hslayout class="hsl hs-page-wrapper" style="width: 100%; height: 100%; min-height: inherit !important">
     <div class="hs-content-wrapper d-flex w-100 h-100"
         [ngClass]="{'hs-open': HsLayoutService.apps[app].sidebarExpanded && sidebarVisible, 'hs-sb-right': sidebarPosition === 'right' && sidebarVisible, 'hs-sb-left': sidebarPosition === 'left' && sidebarVisible, 'hs-sb-bottom': sidebarPosition === 'bottom'}">
         <!-- ng-if="HsLayoutService.componentEnabled('guiOverlay')" -->
@@ -13,7 +13,8 @@
                 <hs-sidebar class="border-0" [app]="app"></hs-sidebar>
                 <div class="hs-panelplace">
                     <hs-mini-sidebar *ngIf="HsLayoutService.apps[app].minisidebar" [app]="app"
-                        [hidden]="!panelVisible('sidebar',app, this)"><!-- TODO: Remove function call from template -->
+                        [hidden]="!panelVisible('sidebar',app, this)">
+                        <!-- TODO: Remove function call from template -->
                     </hs-mini-sidebar>
                     <hs-panel-container [service]="HsPanelContainerService" class="hs-panelplace" [app]="app">
                     </hs-panel-container>

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -187,6 +187,7 @@ $list-group-item-padding-x: 1.25rem;
   }
 
   .hs-map-space {
+    min-height: inherit;
     flex: 1 1 auto;
     position: relative;
   }

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -134,6 +134,7 @@ $list-group-item-padding-x: 1.25rem;
   }
 
   .hs-map-space {
+    min-height: inherit;
     flex: 1 1 auto;
     position: relative;
   }


### PR DESCRIPTION

## Description

hs-map-space needs an inherited min-height value from hs-layout element, so when all panels are closed, the map won't collapse on its on to 0 height. It is a problem for statistics app currently.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
