### PR TITLE
feat: Scroll to app if it's present in the URL

### DIFF
--- a/projects/hslayers/src/components/layout/layout.component.ts
+++ b/projects/hslayers/src/components/layout/layout.component.ts
@@ -13,6 +13,7 @@ import {HsLayoutService} from './layout.service';
 import {HsMapHostDirective} from './map-host.directive';
 import {HsOverlayPanelContainerService} from './overlay-panel-container.service';
 import {HsPanelContainerService} from './panels/panel-container.service';
+import {HsShareUrlService} from '../permalink/share-url.service';
 import {HsUtilsService} from '../utils/utils.service';
 import {delay} from 'rxjs';
 
@@ -44,7 +45,8 @@ export class HsLayoutComponent implements AfterViewInit, OnInit {
     private elementRef: ElementRef,
     private HsUtilsService: HsUtilsService,
     public HsPanelContainerService: HsPanelContainerService,
-    public HsOverlayPanelContainerService: HsOverlayPanelContainerService
+    public HsOverlayPanelContainerService: HsOverlayPanelContainerService,
+    private hsShareUrlService: HsShareUrlService
   ) {}
 
   ngOnInit(): void {
@@ -62,6 +64,11 @@ export class HsLayoutComponent implements AfterViewInit, OnInit {
         'content',
         'width=device-width, initial-scale=0.6, maximum-scale=2, user-scalable=no'
       );
+    }
+
+    const appInUrl = this.hsShareUrlService.getParamValue('app');
+    if (appInUrl != undefined && this.app == appInUrl) {
+      this.HsLayoutService.scrollTo(this.elementRef);
     }
 
     this.HsEventBusService.layoutLoads.next({

--- a/projects/hslayers/src/components/layout/layout.service.ts
+++ b/projects/hslayers/src/components/layout/layout.service.ts
@@ -1,6 +1,7 @@
 import {BehaviorSubject, delay, lastValueFrom} from 'rxjs';
 import {
   ComponentFactoryResolver,
+  ElementRef,
   Injectable,
   Type,
   ViewContainerRef,
@@ -484,5 +485,9 @@ export class HsLayoutService {
 
   createOverlay(panelComponent: Type<any>, app?: string, data?: any): void {
     this.hsOverlayPanelContainerService.create(panelComponent, data || {}, app);
+  }
+
+  scrollTo(el: ElementRef) {
+    el.nativeElement.scrollIntoView({behavior: 'smooth'});
   }
 }

--- a/projects/hslayers/src/components/permalink/partials/share.component.html
+++ b/projects/hslayers/src/components/permalink/partials/share.component.html
@@ -7,16 +7,16 @@
             <div class="form-group">
                 <label for="pure-map-link" class="control-label">{{'PERMALINK.sharePureMap' | translateHs :
                     {app: data.app} }}</label>
-                <a [href]="HsShareService.data.pureMapUrl" target="_blank"
-                    id="pure-map-link">{{HsShareService.data.pureMapUrl}}</a>
+                <a [href]="appRef.pureMapUrl" target="_blank"
+                    id="pure-map-link">{{appRef.pureMapUrl}}</a>
                 <p><sub class="text-danger">{{'PERMALINK.sharesOnlyMap' | translateHs : {app: data.app} }}</sub></p>
             </div>
             <br>
             <div class="form-group">
                 <label for="permalink-link" class="control-label">{{'PERMALINK.permalink' | translateHs :
                     {app: data.app} }}</label><br />
-                <a [href]="HsShareService.data.permalinkUrl" target="_blank" style="overflow-x: hidden;"
-                    id="permalink-link">{{HsShareService.data.permalinkUrl}}</a>
+                <a [href]="appRef.permalinkUrl" target="_blank" style="overflow-x: hidden;"
+                    id="permalink-link">{{appRef.permalinkUrl}}</a>
                 <p><sub class="text-danger">{{'PERMALINK.sharesMapWith' | translateHs : {app: data.app} }}</sub></p>
             </div>
             <hr>
@@ -29,21 +29,21 @@
                 <div class="form-check">
                     <label class="form-check-label">
                         <input type="radio" class="form-check-input" [name]="'share-link-' + data.app" value="puremap"
-                            [(ngModel)]="HsShareService.data.shareLink" (click)="updateEmbedCode()">
+                            [(ngModel)]="appRef.shareLink" (click)="updateEmbedCode()">
                         {{'PERMALINK.pureMap' | translateHs : {app: data.app} }}
                     </label>
                 </div>
                 <div class="form-check">
                     <label class="form-check-label">
                         <input type="radio" class="form-check-input" [name]="'share-link-' + data.app" value="permalink"
-                            [(ngModel)]="HsShareService.data.shareLink" (click)="updateEmbedCode()">
+                            [(ngModel)]="appRef.shareLink" (click)="updateEmbedCode()">
                         {{'PERMALINK.permalink' | translateHs : {app: data.app} }}
                     </label>
                 </div>
             </fieldset>
             <div class="form-floating mb-3" [hidden]="!HsCore.embeddedEnabled">
                 <textarea class="form-control" style="height: 80px" id="permalink-embed"
-                    placeholder="'PERMALINK.embedCode' | translateHs : data" [(ngModel)]="HsShareService.data.embedCode"
+                    placeholder="'PERMALINK.embedCode' | translateHs : data" [(ngModel)]="appRef.embedCode"
                     [ngModelOptions]="{standalone: true}"></textarea>
                 <label for="permalink-embed" class="control-label">{{'PERMALINK.embedCode' | translateHs :
                     {app: data.app} }}</label>
@@ -57,13 +57,13 @@
                 <div class="form-floating mb-3" [title]="'COMMON.fillInName' | translateHs : data">
                     <input type="text" class="form-control" id="hs-prmlnk-title"
                         [placeholder]="'COMMON.name' | translateHs : data" (change)="invalidateShareUrl()"
-                        [(ngModel)]="HsShareService.data.title" [ngModelOptions]="{standalone: true}">
+                        [(ngModel)]="appRef.title" [ngModelOptions]="{standalone: true}">
                     <label for="hs-prmlnk-title" class="control-label">{{'COMMON.name' | translateHs : {app: data.app} }}</label>
                 </div>
                 <div class="form-floating mb-3" [title]="'COMMON.fillInDescriptive' | translateHs : data">
                     <textarea class="form-control" id="hs-prmlnk-abstract"
                         [placeholder]="'COMMON.abstract' | translateHs : data" (change)="invalidateShareUrl()"
-                        [(ngModel)]="HsShareService.data.abstract"
+                        [(ngModel)]="appRef.abstract"
                         [ngModelOptions]="{standalone: true}">                    </textarea>
                     <label for="hs-prmlnk-abstract" class="control-label">{{'COMMON.abstract' | translateHs :
                         {app: data.app} }}</label>

--- a/projects/hslayers/src/components/permalink/share-thumbnail.service.ts
+++ b/projects/hslayers/src/components/permalink/share-thumbnail.service.ts
@@ -41,7 +41,7 @@ export class HsShareThumbnailService {
     ctx.imageSmoothingEnabled = false;
   }
 
-  rendered($element, app: string, newRender?): void {
+  rendered($element, app: string, newRender?): string {
     if (!$element) {
       return;
     }

--- a/projects/hslayers/src/components/permalink/share.component.ts
+++ b/projects/hslayers/src/components/permalink/share.component.ts
@@ -4,9 +4,10 @@ import {HsCoreService} from '../core/core.service';
 import {HsLanguageService} from '../language/language.service';
 import {HsLayoutService} from '../layout/layout.service';
 import {HsPanelBaseComponent} from '../layout/panels/panel-base.component';
-import {HsShareService} from './share.service';
+import {HsShareAppData, HsShareService} from './share.service';
 import {HsShareUrlService} from './share-url.service';
 import {HsSidebarService} from '../sidebar/sidebar.service';
+
 @Component({
   selector: 'hs-share',
   templateUrl: './partials/share.component.html',
@@ -14,6 +15,7 @@ import {HsSidebarService} from '../sidebar/sidebar.service';
 export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
   new_share = false;
   name = 'permalink';
+  appRef: HsShareAppData;
 
   constructor(
     public HsShareService: HsShareService,
@@ -31,7 +33,7 @@ export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
    * @description Create Iframe tag for embedded map
    */
   updateEmbedCode(): string {
-    return this.HsShareService.getEmbedCode();
+    return this.HsShareService.getEmbedCode(this.data.app);
   }
 
   /**
@@ -39,14 +41,14 @@ export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
    * @description Select right share Url based on shareLink property (either Permalink Url or PureMap url)
    */
   getShareUrl(): string {
-    return this.HsShareService.getShareUrl();
+    return this.HsShareService.getShareUrl(this.data.app);
   }
 
   /**
    * @description Set share Url state invalid
    */
   invalidateShareUrl(): void {
-    this.HsShareService.invalidateShareUrl();
+    this.HsShareService.invalidateShareUrl(this.data.app);
   }
 
   /**
@@ -69,7 +71,9 @@ export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
       },
       this.data.app
     );
+
     this.HsShareUrlService.init(this.data.app);
     this.HsShareService.init(this.data.app);
+    this.appRef = this.HsShareService.get(this.data.app);
   }
 }

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.html
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.html
@@ -1,4 +1,50 @@
 <a id="poly1">Polygon 1</a>
 <a id="poly2">Polygon 2</a>
-<hslayers style="height: 30vh"></hslayers>
+<hslayers style="height: 60vh"></hslayers>
+
+<div class="container hsl">
+    <div class="row justify-content-md-center">
+        <div class="col col-1">
+
+        </div>
+        <div class="col col-8">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Scelerisque viverra mauris in aliquam sem fringilla ut morbi. Amet dictum sit amet
+                justo donec enim diam. Nisi est sit amet facilisis magna etiam. Sit amet luctus venenatis lectus magna
+                fringilla urna. Dapibus ultrices in iaculis nunc sed augue lacus viverra vitae. Semper eget duis at
+                tellus at urna condimentum. Ut tristique et egestas quis ipsum suspendisse. Ullamcorper morbi tincidunt
+                ornare massa eget egestas purus. Suspendisse faucibus interdum posuere lorem ipsum dolor. Lacus luctus
+                accumsan tortor posuere ac ut consequat semper viverra. Accumsan sit amet nulla facilisi. Sed turpis
+                tincidunt id aliquet risus. Nisl rhoncus mattis rhoncus urna neque viverra justo.</p>
+
+            <p>Sit amet porttitor eget dolor morbi non arcu risus. Arcu dui vivamus arcu felis bibendum ut tristique et.
+                Eget egestas purus viverra accumsan in. Dignissim convallis aenean et tortor at risus viverra adipiscing
+                at. Ultrices eros in cursus turpis massa tincidunt dui ut. Vitae sapien pellentesque habitant morbi
+                tristique senectus et netus. Et sollicitudin ac orci phasellus egestas tellus rutrum tellus. Sem et
+                tortor consequat id porta nibh venenatis cras. Et pharetra pharetra massa massa ultricies mi. Morbi quis
+                commodo odio aenean sed adipiscing diam donec adipiscing. Semper auctor neque vitae tempus quam. Enim
+                blandit volutpat maecenas volutpat blandit aliquam etiam erat. Lacus viverra vitae congue eu.</p>
+
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                    dolore magna aliqua. Scelerisque viverra mauris in aliquam sem fringilla ut morbi. Amet dictum sit amet
+                    justo donec enim diam. Nisi est sit amet facilisis magna etiam. Sit amet luctus venenatis lectus magna
+                    fringilla urna. Dapibus ultrices in iaculis nunc sed augue lacus viverra vitae. Semper eget duis at
+                    tellus at urna condimentum. Ut tristique et egestas quis ipsum suspendisse. Ullamcorper morbi tincidunt
+                    ornare massa eget egestas purus. Suspendisse faucibus interdum posuere lorem ipsum dolor. Lacus luctus
+                    accumsan tortor posuere ac ut consequat semper viverra. Accumsan sit amet nulla facilisi. Sed turpis
+                    tincidunt id aliquet risus. Nisl rhoncus mattis rhoncus urna neque viverra justo.</p>
+    
+                <p>Sit amet porttitor eget dolor morbi non arcu risus. Arcu dui vivamus arcu felis bibendum ut tristique et.
+                    Eget egestas purus viverra accumsan in. Dignissim convallis aenean et tortor at risus viverra adipiscing
+                    at. Ultrices eros in cursus turpis massa tincidunt dui ut. Vitae sapien pellentesque habitant morbi
+                    tristique senectus et netus. Et sollicitudin ac orci phasellus egestas tellus rutrum tellus. Sem et
+                    tortor consequat id porta nibh venenatis cras. Et pharetra pharetra massa massa ultricies mi. Morbi quis
+                    commodo odio aenean sed adipiscing diam donec adipiscing. Semper auctor neque vitae tempus quam. Enim
+                    blandit volutpat maecenas volutpat blandit aliquam etiam erat. Lacus viverra vitae congue eu.</p>
+        </div>
+        <div class="col col-1">
+
+        </div>
+    </div>
+</div>
 <hslayers style="height: 70vh" id="app-2"></hslayers>


### PR DESCRIPTION
## Description

Permalink generation gets reenabled in multi-app mode now. It adds a new GET param 'app' depending from which apps 'share' panel it was was called / displayed in. When hslayers is loaded the the page scrolls to the app specified in aforementioned GET param.

## Related issues or pull requests

#2821 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
