### PR TITLE
fix: Custom color maps on ol-ext 4 IDW layers

### DIFF
--- a/projects/hslayers/src/common/layers/hs.source.interpolated.ts
+++ b/projects/hslayers/src/common/layers/hs.source.interpolated.ts
@@ -249,6 +249,7 @@ export class InterpolatedSource extends IDW {
     } else {
       getColor = options.colorMap;
     }
+    super.getColor = getColor;
     super.computeImage = (e) => {
       const pts = e.data.pts;
       const width = e.data.width;


### PR DESCRIPTION
## Description

This fixes custom color maps in ol-ext 4 version for IDW layers. getColor function is encapsulated there and not exposed in IDwSource prototype which broke the custom color map functionality.

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
