### PR TITLE
fix: Clean up replay subjects when destroying containers

### DIFF
--- a/projects/hslayers/src/components/layout/dialogs/dialog-container.component.ts
+++ b/projects/hslayers/src/components/layout/dialogs/dialog-container.component.ts
@@ -32,6 +32,7 @@ export class HsDialogContainerComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+    this.HsDialogContainerService.cleanup(this.app);
   }
   ngOnInit(): void {
     this.HsDialogContainerService.get(this.app)

--- a/projects/hslayers/src/components/layout/dialogs/dialog-container.service.ts
+++ b/projects/hslayers/src/components/layout/dialogs/dialog-container.service.ts
@@ -17,9 +17,17 @@ class HsDialogContainerParams {
 export class HsDialogContainerService {
   apps: {
     [key: string]: HsDialogContainerParams;
-  } = {default: new HsDialogContainerParams()};
+  } = {};
 
   constructor() {}
+
+  cleanup(app?: string) {
+    if (app) {
+      delete this.apps[app];
+    } else {
+      this.apps = {};
+    }
+  }
 
   get(app: string = 'default'): HsDialogContainerParams {
     if (this.apps[app] === undefined) {

--- a/projects/hslayers/src/components/query/query-popup-widget-container.service.ts
+++ b/projects/hslayers/src/components/query/query-popup-widget-container.service.ts
@@ -25,6 +25,14 @@ export class HsQueryPopupWidgetContainerService extends HsPanelContainerService 
     super();
   }
 
+  cleanup(app?: string) {
+    if (app) {
+      delete this.apps[app];
+    } else {
+      this.apps = {};
+    }
+  }
+
   /**
    * Initialize query popup widgets
    * @param widgetNames - Array of widget names

--- a/projects/hslayers/src/components/query/query-popup/query-popup.component.ts
+++ b/projects/hslayers/src/components/query/query-popup/query-popup.component.ts
@@ -25,7 +25,8 @@ import {getPopUp} from '../../../common/layer-extensions';
   templateUrl: './query-popup.component.html',
 })
 export class HsQueryPopupComponent
-  implements OnDestroy, HsDialogComponent, AfterViewInit, OnInit {
+  implements OnDestroy, HsDialogComponent, AfterViewInit, OnInit
+{
   getFeatures = getFeatures;
   olMapLoadsSubscription: Subscription;
   attributesForHover = [];
@@ -74,6 +75,7 @@ export class HsQueryPopupComponent
     this.hsMapService
       .getMap(this.data.app)
       .removeOverlay(this.dataAppRef.hoverPopup);
+    this.hsQueryPopupWidgetContainerService.cleanup(this.data.app);
     this.olMapLoadsSubscription.unsubscribe();
   }
 

--- a/projects/hslayers/src/components/sidebar/sidebar.component.ts
+++ b/projects/hslayers/src/components/sidebar/sidebar.component.ts
@@ -34,6 +34,7 @@ export class HsSidebarComponent implements OnInit, OnDestroy {
   ) {}
   ngOnDestroy(): void {
     this.end.next();
+    this.end.complete();
   }
   ngOnInit(): void {
     const panel = this.HsShareUrlService.getParamValue(HS_PRMS.panel);


### PR DESCRIPTION
## Description

Clean up dialog/widget replaySubjects when container components get destroyed.
## Related issues or pull requests

#3445 3445

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
