### PR TITLE
feat: Use grayscale map composition param

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -546,7 +546,7 @@
   "LAYERMANAGER": {
     "baselayers": "Podkladové vrstvy",
     "baseMapGallery": {
-      "grayscale": "Šedotón",
+      "greyscale": "Šedotón",
       "noBaseMap": "Bez podkladu"
     },
     "dialogRemoveAll": {

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -546,7 +546,7 @@
   "LAYERMANAGER": {
     "baselayers": "Baselayers",
     "baseMapGallery": {
-      "grayscale": "Grayscale",
+      "greyscale": "Greyscale",
       "noBaseMap": "No basemap"
     },
     "dialogRemoveAll": {

--- a/projects/hslayers/src/assets/locales/fr.json
+++ b/projects/hslayers/src/assets/locales/fr.json
@@ -79,7 +79,7 @@
   "LAYERMANAGER": {
     "baselayers": "Fond de carte de base",
     "baseMapGallery": {
-      "grayscale": "Niveaux de gris",
+      "greyscale": "Niveaux de gris",
       "noBaseMap": "Pas de fond de carte"
     },
     "dialogRemoveAll": {

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -545,7 +545,7 @@
   "LAYERMANAGER": {
     "baselayers": "Pamatslāņi",
     "baseMapGallery": {
-      "grayscale": "Pelēktoņu",
+      "greyscale": "Pelēktoņu",
       "noBaseMap": "Nav pamatkartes"
     },
     "dialogRemoveAll": {

--- a/projects/hslayers/src/assets/locales/nl.json
+++ b/projects/hslayers/src/assets/locales/nl.json
@@ -78,7 +78,7 @@
   "LAYERMANAGER": {
     "baselayers": "Basislagen",
     "baseMapGallery": {
-      "grayscale": "Grijstinten",
+      "greyscale": "Grijstinten",
       "noBaseMap": "Geen basiskaart"
     },
     "dialogRemoveAll": {

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -546,7 +546,7 @@
   "LAYERMANAGER": {
     "baselayers": "Podkladové vrstvy",
     "baseMapGallery": {
-      "grayscale": "Šedotón",
+      "greyscale": "Šedotón",
       "noBaseMap": "Bez podkladov"
     },
     "dialogRemoveAll": {

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -4,10 +4,10 @@ import {Geometry} from 'ol/geom';
 import {Group, Layer} from 'ol/layer';
 import {Source} from 'ol/source';
 
+import BaseLayer from 'ol/layer/Base';
 import {DOMFeatureLink} from './dom-feature-link.type';
 import {HsLaymanLayerDescriptor} from '../components/save-map/interfaces/layman-layer-descriptor.interface';
 import {accessRightsModel} from '../components/add-data/common/access-rights.model';
-import BaseLayer from 'ol/layer/Base';
 
 const ABSTRACT = 'abstract';
 const ACCESS_RIGHTS = 'access_rights';
@@ -27,6 +27,7 @@ const EXCLUSIVE = 'exclusive';
 const FEATURE_INFO_LANG = 'featureInfoLang';
 const FROM_COMPOSITION = 'fromComposition';
 const GET_FEATURE_INFO_TARGET = 'getFeatureInfoTarget';
+const GREYSCALE = 'greyscale';
 const HS_LAYMAN_SYNCHRONIZING = 'hsLaymanSynchronizing';
 const HS_QML = 'qml';
 const HS_SLD = 'sld';
@@ -361,6 +362,14 @@ export function setFeatureInfoTarget(
 
 export function getFeatureInfoTarget(layer: Layer<Source>): string {
   return layer.get(GET_FEATURE_INFO_TARGET);
+}
+
+export function getGreyscale(layer: Layer<Source>): boolean {
+  return layer.get(GREYSCALE);
+}
+
+export function setGreyscale(layer: Layer<Source>, greyscale: boolean): void {
+  layer.set(GREYSCALE, greyscale);
 }
 
 export function getSld(layer: Layer<Source>): string {

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -85,10 +85,12 @@ export class HsCompositionsLayerParserService {
   async createWMTSLayer(lyr_def, app: string): Promise<Tile<TileSource>> {
     const wmts = new Tile({
       source: new WMTS({} as any),
+      className: lyr_def.greyscale ? 'ol-layer hs-greyscale' : 'ol-layer',
       properties: {
         title: lyr_def.title,
         info_format: lyr_def.info_format,
         base: lyr_def.base,
+        greyscale: lyr_def.greyscale,
       },
     });
 
@@ -169,6 +171,7 @@ export class HsCompositionsLayerParserService {
       showInLayerManager: lyr_def.displayInLayerSwitcher,
       abstract: lyr_def.name || lyr_def.abstract,
       base: lyr_def.base,
+      greyscale: lyr_def.greyscale,
       metadata: lyr_def.metadata,
       dimensions: lyr_def.dimensions,
       legends: legends,
@@ -176,6 +179,7 @@ export class HsCompositionsLayerParserService {
       opacity: lyr_def.opacity || 1,
       source,
       subLayers: lyr_def.subLayers,
+      className: lyr_def.greyscale ? 'ol-layer hs-greyscale' : 'ol-layer',
     };
     const new_layer = lyr_def.singleTile
       ? new ImageLayer(layerOptions as ImageOptions<ImageSource>)
@@ -220,6 +224,8 @@ export class HsCompositionsLayerParserService {
       showInLayerManager: lyr_def.displayInLayerSwitcher,
       abstract: lyr_def.name || lyr_def.abstract,
       base: lyr_def.base,
+      greyscale: lyr_def.greyscale,
+      className: lyr_def.greyscale ? 'ol-layer hs-greyscale' : 'ol-layer',
       metadata: lyr_def.metadata,
       dimensions: lyr_def.dimensions,
       legends: legends,
@@ -260,12 +266,14 @@ export class HsCompositionsLayerParserService {
       minResolution: lyr_def.minResolution || 0,
       opacity: lyr_def.opacity || 1,
       source,
+      className: lyr_def.greyscale ? 'ol-layer hs-greyscale' : 'ol-layer',
       properties: {
         title: lyr_def.title,
         fromComposition: true,
         showInLayerManager: lyr_def.displayInLayerSwitcher,
         abstract: lyr_def.name || lyr_def.abstract,
         base: lyr_def.base || lyr_def.url.indexOf('openstreetmap') > -1,
+        greyscale: lyr_def.greyscale,
         metadata: lyr_def.metadata,
         dimensions: lyr_def.dimensions,
         legends: legends,
@@ -301,6 +309,7 @@ export class HsCompositionsLayerParserService {
       maxResolution: lyr_def.maxResolution || Infinity,
       minResolution: lyr_def.minResolution || 0,
       opacity: lyr_def.opacity || 1,
+      className: lyr_def.greyscale ? 'ol-layer hs-greyscale' : 'ol-layer',
       source,
       properties: {
         title: lyr_def.title,
@@ -308,6 +317,7 @@ export class HsCompositionsLayerParserService {
         showInLayerManager: lyr_def.displayInLayerSwitcher,
         abstract: lyr_def.name || lyr_def.abstract,
         base: lyr_def.base,
+        greyscale: lyr_def.greyscale,
         metadata: lyr_def.metadata,
         dimensions: lyr_def.dimensions,
         legends: legends,

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
@@ -34,6 +34,7 @@ import {HsTypeWidgetComponent} from '../widgets/type-widget.component';
 import {
   getBase,
   getCachedCapabilities,
+  getGreyscale,
   getRemovable,
   getTitle,
   setTitle,
@@ -58,6 +59,7 @@ export class HsLayerEditorComponent {
 
   layer_renamer_visible = false;
   getBase = getBase;
+  getGreyscale = getGreyscale;
   tmpTitle: string = undefined;
   constructor(
     public HsLayerUtilsService: HsLayerUtilsService,

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.html
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.html
@@ -15,13 +15,13 @@
             <div class="btn-group m-auto d-flex w-75" *ngIf="currentLayer.visible && getBase(currentLayer.layer)">
                 <button class="btn btn-sm btn-outline-primary  w-50"
                     (click)="HsLayerManagerService.setGreyscale(currentLayer, app)"
-                    [ngClass]="{'active' : !currentLayer.grayscale}" data-toggle="tooltip"
+                    [ngClass]="{'active' : !getGreyscale(currentLayer.layer)}" data-toggle="tooltip"
                     [title]="'LAYERMANAGER.layerEditor.zoomToLayer' | translateHs : {app} ">{{'COMMON.color' |
                     translateHs : {app} }}</button>
                 <button class="btn btn-sm btn-outline-primary  w-50"
                     (click)="HsLayerManagerService.setGreyscale(currentLayer, app)"
-                    [ngClass]="{'active' : currentLayer.grayscale}" data-toggle="tooltip"
-                    [title]="'LAYERMANAGER.layerEditor.styleLayer' | translateHs : {app} ">{{'LAYERMANAGER.baseMapGallery.grayscale'
+                    [ngClass]="{'active' : getGreyscale(currentLayer.layer)}" data-toggle="tooltip"
+                    [title]="'LAYERMANAGER.layerEditor.styleLayer' | translateHs : {app} ">{{'LAYERMANAGER.baseMapGallery.greyscale'
                     | translateHs : {app} }}</button>
             </div>
         </div>

--- a/projects/hslayers/src/components/layermanager/gallery/basemap-gallery.html
+++ b/projects/hslayers/src/components/layermanager/gallery/basemap-gallery.html
@@ -19,9 +19,9 @@
                     <div class="ps-1 w-100" *ngIf="!hsLayerManagerService.apps[data.app].menuExpanded"
                         (click)="hsLayerManagerService.setGreyscale(layer, data.app)">
                         <label class="form-check-label m-0"
-                            [ngClass]="{'hs-checkmark': layer.grayscale,'hs-uncheckmark':!layer.grayscale}"></label>
+                            [ngClass]="getGreyscale(layer.layer) ? 'hs-checkmark' : 'hs-uncheckmark'"></label>
                         <p class="ms-1 mb-0">
-                            {{'LAYERMANAGER.baseMapGallery.grayscale' | translateHs : {app: data.app} }}</p>
+                            {{'LAYERMANAGER.baseMapGallery.greyscale' | translateHs : {app: data.app} }}</p>
                     </div>
                     <label [attr.id]="layer?.idString()" class="ps-2 mb-0 w-100"
                         [ngStyle]="{'background-color':'rgba(192, 189, 189, 0.644)'}" (click)="expandMenu(layer)">

--- a/projects/hslayers/src/components/layermanager/gallery/layermanager-gallery.component.ts
+++ b/projects/hslayers/src/components/layermanager/gallery/layermanager-gallery.component.ts
@@ -1,12 +1,11 @@
-import {ChangeDetectionStrategy, Component,  ViewChild} from '@angular/core';
-
+import {ChangeDetectionStrategy, Component, ViewChild} from '@angular/core';
 import {HsLayerDescriptor} from '../layer-descriptor.interface';
 import {HsLayerManagerService} from '../layermanager.service';
 import {HsLayerUtilsService} from '../../utils/layer-utils.service';
 import {HsLayoutService} from '../../layout/layout.service';
 import {HsPanelBaseComponent} from '../../layout/panels/panel-base.component';
 import {NgbDropdown} from '@ng-bootstrap/ng-bootstrap';
-import {getBase} from '../../../common/layer-extensions';
+import {getBase, getGreyscale} from '../../../common/layer-extensions';
 
 @Component({
   selector: 'hs-layermanager-gallery',
@@ -15,6 +14,7 @@ import {getBase} from '../../../common/layer-extensions';
 })
 export class HsLayerManagerGalleryComponent extends HsPanelBaseComponent {
   menuExpanded = false;
+  getGreyscale = getGreyscale;
   @ViewChild('galleryDropdown', {static: false}) dropdown: NgbDropdown;
   constructor(
     public hsLayoutService: HsLayoutService,

--- a/projects/hslayers/src/components/layermanager/layer-descriptor.interface.ts
+++ b/projects/hslayers/src/components/layermanager/layer-descriptor.interface.ts
@@ -54,5 +54,5 @@ export interface HsLayerDescriptor {
    * OL source class of this layer, in case of 'vector' also with format (e.g. 'vector (KML)')
    */
   type?: string;
-  grayscale?: boolean;
+  greyscale?: boolean;
 }

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -57,6 +57,7 @@ import {
   getThumbnail,
   getTitle,
   setActive,
+  setGreyscale,
   setName,
   setOrigLayers,
   setPath,
@@ -1092,19 +1093,19 @@ export class HsLayerManagerService {
   }
 
   /**
-   * Makes layer grayscale
+   * Makes layer greyscale
    * @param layer - Selected layer (currentLayer)
    */
   setGreyscale(layer: HsLayerDescriptor, app): void {
     const layerContainer = this.hsLayoutService.apps[
       app
     ].contentWrapper.querySelector('.ol-layers > div:first-child');
-    if (layerContainer.classList.contains('hs-grayscale')) {
-      layerContainer.classList.remove('hs-grayscale');
-      layer.grayscale = false;
+    if (layerContainer.classList.contains('hs-greyscale')) {
+      layerContainer.classList.remove('hs-greyscale');
+      setGreyscale(layer.layer, false);
     } else {
-      layerContainer.classList.add('hs-grayscale');
-      layer.grayscale = true;
+      layerContainer.classList.add('hs-greyscale');
+      setGreyscale(layer.layer, true);
     }
 
     setTimeout(() => {

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -13,7 +13,6 @@ import {
   WMTS,
   XYZ,
 } from 'ol/source';
-import {CompoData} from './types/compo-data.type';
 import {Feature} from 'ol';
 import {GeoJSON} from 'ol/format';
 import {GeoJSONFeatureCollection} from 'ol/format/GeoJSON';
@@ -54,7 +53,6 @@ import {
   getWfsUrl,
   getWorkspace,
 } from '../../common/layer-extensions';
-import {transformExtent} from 'ol/proj';
 
 const LCLSTORAGE_EXPIRE = 5000;
 

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -13,6 +13,7 @@ import {
   WMTS,
   XYZ,
 } from 'ol/source';
+import {CompoData} from './types/compo-data.type';
 import {Feature} from 'ol';
 import {GeoJSON} from 'ol/format';
 import {GeoJSONFeatureCollection} from 'ol/format/GeoJSON';
@@ -39,6 +40,7 @@ import {
   getBase,
   getDefinition,
   getDimensions,
+  getGreyscale,
   getLegends,
   getMetadata,
   getName,
@@ -52,6 +54,7 @@ import {
   getWfsUrl,
   getWorkspace,
 } from '../../common/layer-extensions';
+import {transformExtent} from 'ol/proj';
 
 const LCLSTORAGE_EXPIRE = 5000;
 
@@ -334,6 +337,9 @@ export class HsSaveMapService {
     json.swipeSide = getSwipeSide(layer);
     json.opacity = layer.getOpacity();
     json.base = getBase(layer) ?? false;
+    if (json.base) {
+      json.greyscale = getGreyscale(layer);
+    }
     json.title = getTitle(layer);
     if (getTitle(layer) == undefined) {
       this.hsLogService.warn('Layer title undefined', layer);

--- a/projects/hslayers/src/components/save-map/types/layer-json.type.ts
+++ b/projects/hslayers/src/components/save-map/types/layer-json.type.ts
@@ -43,4 +43,5 @@ export type LayerJSON = {
   workspace?: string;
   features?: GeoJSONFeatureCollection;
   style?: SerializedStyle | string;
+  greyscale?: boolean;
 };

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -203,7 +203,7 @@ $list-group-item-padding-x: 1.25rem;
     flex: 1 1 auto;
   }
 
-  .hs-grayscale {
+  .hs-greyscale {
     filter: grayscale(100%);
   }
 

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -122,7 +122,7 @@ $list-group-item-padding-x: 1.25rem;
     flex: 1 1 auto;
   }
 
-  .hs-grayscale {
+  .hs-greyscale {
     filter: grayscale(100%);
   }
 


### PR DESCRIPTION
Make use of 'greyscale' attribute of map composition schema.

Aligned usage of gray vs grey to match composition schema.  Apparently gray is more American (https://www.grammarly.com/blog/gray-grey/).  
Thinking about it now Id probably prefer gray as CSS filter rule is named 'grayscale' with a.  But nvm

## Related issues or pull requests

fixes #3346 
## Pull request type
Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
