### PR TITLE
Module federation fixes

### DIFF
--- a/projects/hslayers-cesium/src/hscesium-config.service.ts
+++ b/projects/hslayers-cesium/src/hscesium-config.service.ts
@@ -21,7 +21,9 @@ export class HsCesiumConfigObject {
   cesiumTime?: JulianDate;
   constructor() {}
 }
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class HsCesiumConfig {
   apps: {[id: string]: HsCesiumConfigObject} = {
     default: {},

--- a/projects/hslayers-material/src/lib/layermanager/layermanager.component.ts
+++ b/projects/hslayers-material/src/lib/layermanager/layermanager.component.ts
@@ -35,7 +35,9 @@ class HsLayerFlatNode {
   layer?: HsLayerDescriptor;
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class HsLayerDatabase {
   dataChange = new BehaviorSubject<HsLayerNode[]>([]);
   @Input() app = 'default';

--- a/projects/hslayers/src/components/language/custom-translate.service.ts
+++ b/projects/hslayers/src/components/language/custom-translate.service.ts
@@ -88,7 +88,9 @@ export class WebpackTranslateLoader implements TranslateLoader {
   }
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class CustomTranslationService extends TranslateService {
   constructor(HsConfig: HsConfig, HttpClient: HttpClient) {
     super(

--- a/projects/hslayers/src/components/language/language.service.ts
+++ b/projects/hslayers/src/components/language/language.service.ts
@@ -56,12 +56,18 @@ export class HsLanguageService {
 
   getTranslator(app: string): HsCustomTranslationService {
     if (this.apps[app] == undefined) {
-      this.apps[app] = {
-        language: app + '|' + DEFAULT_LANG,
-        translationService: this.translateServiceFactory(
+      let translationService;
+      if (typeof this.translateServiceFactory == 'object') {
+        translationService = this.translateServiceFactory;
+      } else if (typeof this.translateServiceFactory == 'function') {
+        translationService = this.translateServiceFactory(
           this.hsConfig,
           this.HttpClient
-        ),
+        );
+      }
+      this.apps[app] = {
+        language: app + '|' + DEFAULT_LANG,
+        translationService,
       };
     }
     return this.apps[app].translationService;

--- a/projects/hslayers/src/components/language/translate-custom.pipe.ts
+++ b/projects/hslayers/src/components/language/translate-custom.pipe.ts
@@ -23,7 +23,7 @@ export class TranslateCustomPipe
 {
   onLangChangeOverridden: boolean;
   constructor(
-    private translate2: TranslateService,
+    private translate2: CustomTranslationService,
     private _theRef: ChangeDetectorRef,
     private hsLanguageService: HsLanguageService
   ) {

--- a/projects/hslayers/src/components/utils/layer-utils.service.ts
+++ b/projects/hslayers/src/components/utils/layer-utils.service.ts
@@ -34,7 +34,9 @@ import {
   getTitle,
 } from '../../common/layer-extensions';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class HsLayerUtilsService {
   constructor(
     public HsUtilsService: HsUtilsService,

--- a/projects/hslayers/src/components/utils/utils.service.ts
+++ b/projects/hslayers/src/components/utils/utils.service.ts
@@ -17,7 +17,9 @@ export type Measurement = {
   unit: string;
 };
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class HsUtilsService {
   constructor(
     public HsConfig: HsConfig,

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -201,7 +201,9 @@ export class HsConfigObject {
   }
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class HsConfig {
   apps: {[id: string]: HsConfigObject} = {
     default: new HsConfigObject(),


### PR DESCRIPTION
## Description

At some point loading hslayers with module federation got broken. This PR adds `{  providedIn: 'root',}` to all services and also makes a hacky solution how to inject CustomTranslateService since it is a function when used in normal application, but an object (already an instance) when lazy-loaded through module federation.
## Related issues or pull requests

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
