### PR TITLE
fix: Don't cache getCapabilities, if response is error or no data was…

### DIFF
--- a/projects/hslayers/src/common/get-capabilities/capability-cache.service.ts
+++ b/projects/hslayers/src/common/get-capabilities/capability-cache.service.ts
@@ -11,7 +11,9 @@ export class HsCapabilityCacheService {
   cache: CapabilityCacheList = {};
   constructor() {}
   set(url: string, wrap: CapabilitiesResponseWrapper): void {
-    this.cache[url] = wrap;
+    if (!wrap?.error && wrap.response?.layers?.length > 0) {
+      this.cache[url] = wrap;
+    }
   }
 
   get(url: string): CapabilitiesResponseWrapper {


### PR DESCRIPTION
## Description

Arcgis services did not load any layers from the url. It was most likely because of some error while waiting for the response from the server. In Such case we should not store in cache this error response. Also if no layers are returned from the request, we should also no cache it.

## Related issues or pull requests

refs #3515 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
