### PR TITLE
Add load as WMS/WFS switcher to add-data

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -49,7 +49,8 @@
       "overwriteExistingLayer": "Vrstva již existuje!",
       "doYouWishToOverwrite": "Chcete přepsat vrstvu:",
       "noteForRepetiveDialog": "*Poznámka: Přejmenování a nahrání vrstvy selhalo, protože vrstva s tímto jménem již existuje!"
-    }
+    },
+    "loadAs": "Po nahrání načíst jako ..."
   },
   "ADDLAYERS": {
     "addSelected": "Přidat označené vrstvy do mapy",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -50,7 +50,8 @@
       "doYouWishToOverwrite": "Chcete přepsat vrstvu:",
       "noteForRepetiveDialog": "*Poznámka: Přejmenování a nahrání vrstvy selhalo, protože vrstva s tímto jménem již existuje!"
     },
-    "loadAs": "Po nahrání načíst jako ..."
+    "loadAs": "Po nahrání načíst jako ...",
+    "saveToDbExplanation": "Data budou nahrána do databáze na serveru a později budou dostupná skrze Datový katalog. Nezávisle na vstupním formátu, všechna vektorová data jsou z databáze načtena jako GeoJSON."
   },
   "ADDLAYERS": {
     "addSelected": "Přidat označené vrstvy do mapy",
@@ -626,7 +627,8 @@
       "loading": "Načítám dostupné časy ..."
     },
     "toggleAllLayerVisibility": "Přepnout viditelnost všech vrstev",
-    "User generated": "Uživatelský"
+    "User generated": "Uživatelský",
+    "basemapThumbnail": "Náhled podkladové mapy"
   },
   "LAYERS": {
     "existingLayer": "Existující vrstva",
@@ -833,7 +835,8 @@
     },
     "writeAccessRights": "Právo zápisu",
     "everyone": "Každý",
-    "perUser": "Vybraní uživatelé"
+    "perUser": "Vybraní uživatelé",
+    "compositionThumbnail": "Náhled kompozice"
   },
   "SENSORS": {
     "1D": "1D",
@@ -966,7 +969,9 @@
     "icon": "Ikona",
     "text": "Text",
     "line": "Linie",
-    "fill": "Výplň"
+    "fill": "Výplň",
+    "styleName": "Název stylu",
+    "unsavedChanges": "Máte neuložené změny stylu. Aby se změny zachovaly, ujistěte se před odchodem, že jste je uložili"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Měřit linie a polygony"

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -38,7 +38,7 @@
       "someOfTheUploadedFiles": "Uploaded file exceeded maximum allowed size of 20MB",
       "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files"
     },
-    "loadAs": "When uploaded load layer as ...",
+    "loadAs": "When uploaded, load layer as ...",
     "requestServiceLayers": "Request service layers",
     "saveToDatabase": "Save to database",
     "URL": {

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -38,6 +38,7 @@
       "someOfTheUploadedFiles": "Uploaded file exceeded maximum allowed size of 20MB",
       "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files"
     },
+    "loadAs": "When uploaded load layer as ...",
     "requestServiceLayers": "Request service layers",
     "saveToDatabase": "Save to database",
     "URL": {
@@ -101,10 +102,10 @@
     "SHP": {
       "loginRequired": "User login is required before layer can be loaded",
       "maximumNumberOf": "Maximum number of {{allowed}} files allowed, but {{length}} selected",
-      "missingOneOrMore": "Missing one or more Shape files. Load files with extensions *.shp, *.shx, *.dbf or zip containing these files.",
+      "missingOneOrMore": "Missing one or more Shape files. Load files with extensions *.shp, *.shx, *.dbf or a zip containing these files.",
       "shapeFile": "Shape file (shp+dbf+shx)",
       "SLDStyleFile": "Style file",
-      "neededFiles": "Load files with extensions *.shp, *.shx, *.dbf or zip file containing these files.",
+      "neededFiles": "Load files with extensions *.shp, *.shx, *.dbf or a zip file containing these files.",
       "considerUsingZip": "Consider using '.zip' format for shapefiles bigger than 10MB of size, that way upload will be much quicker.",
       "exceedingSize": "Shapefile being loaded exceeds recommended size"
     },

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -41,6 +41,7 @@
     "loadAs": "When uploaded, load layer as ...",
     "requestServiceLayers": "Request service layers",
     "saveToDatabase": "Save to database",
+    "saveToDbExplanation": "The data will be uploaded to a database on the server and will be later available via the Data Catalogue. No matter the input format, all vector data are loaded as a GeoJSON from the database.",
     "URL": {
       "selectAll": "Select all Layers",
       "submitLayerName": "Fill in layer name",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -49,7 +49,9 @@
       "overwriteExistingLayer": "Slānis jau eksistē!",
       "doYouWishToOverwrite": "Vai vēlaties pārrakstīt layer:",
       "noteForRepetiveDialog": "*Piezīme: Slāņa pārdēvēšana un augšupielāde neizdevās, jo šāds slāņa nosaukums jau pastāv!"
-    }
+    },
+    "loadAs": "Augšupielādējot, ielādēt slāni kā...",
+    "saveToDbExplanation": "Dati tiks augšupielādēti servera datu bāzē un vēlāk būs pieejami caur datu katalogu. Neatkarīgi no ievades formāta visi vektoru dati tiek ielādēti kā GeoJSON no datu bāzes."
   },
   "ADDLAYERS": {
     "addSelected": "Pievienot izvēlētos slāņus kartei",

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
@@ -130,7 +130,11 @@ export class HsCatalogueListItemComponent implements OnInit {
     this.selected_ds = endpoint;
 
     if (endpoint.type == 'layman') {
-      await this.hsLaymanBrowserService.fillLayerMetadata(endpoint, layer);
+      await this.hsLaymanBrowserService.fillLayerMetadata(
+        endpoint,
+        layer,
+        this.app
+      );
     }
     //this.metadata = this.hsDatasourcesMetadataService.decomposeMetadata(layer);
     //console.log(this.metadata);

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -235,6 +235,11 @@ export class HsLaymanBrowserService {
         })
       );
       if (data.code || data.message) {
+        if (data.code == 32) {
+          endpoint.user = 'anonymous';
+          endpoint.authenticated = false;
+          this.hsCommonLaymanService.authChange.next({endpoint, app});
+        }
         this.hsToastService.createToastPopupMessage(
           data.message ?? 'ADDLAYERS.ERROR.errorWhileRequestingLayers',
           data.detail ?? `${data.code}/${data.sub_code}`,

--- a/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layman/layman.service.ts
@@ -221,7 +221,8 @@ export class HsLaymanBrowserService {
    */
   async fillLayerMetadata(
     endpoint: HsEndpoint,
-    layer: HsAddDataLayerDescriptor
+    layer: HsAddDataLayerDescriptor,
+    app = 'default'
   ): Promise<HsAddDataLayerDescriptor> {
     const url = `${endpoint.url}/rest/workspaces/${layer.workspace}/layers/${layer.name}`;
     try {
@@ -233,6 +234,15 @@ export class HsLaymanBrowserService {
           withCredentials: true,
         })
       );
+      if (data.code || data.message) {
+        this.hsToastService.createToastPopupMessage(
+          data.message ?? 'ADDLAYERS.ERROR.errorWhileRequestingLayers',
+          data.detail ?? `${data.code}/${data.sub_code}`,
+          {},
+          app
+        );
+        return;
+      }
 
       layer.type =
         data?.file?.file_type === 'raster' ? ['WMS'] : ['WMS', 'WFS'];
@@ -258,7 +268,10 @@ export class HsLaymanBrowserService {
     layer: HsAddDataLayerDescriptor,
     app: string
   ): Promise<any> {
-    const lyr = await this.fillLayerMetadata(ds, layer);
+    const lyr = await this.fillLayerMetadata(ds, layer, app);
+    if (!lyr) {
+      return;
+    }
     let style: string = undefined;
     if (lyr.style?.url) {
       style = await this.getStyleFromUrl(lyr.style?.url);

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
@@ -2,7 +2,7 @@
   [title]="hsAddDataCommonFileService.getToolTipText(data, app)">
   <!-- TODO: Remove function call from template -->
   <button *ngIf="hsAddDataCommonFileService.isAuthorized()" class="btn btn-primary w-100"
-    [disabled]="!data.name || !data.srs" (click)="addAsWms()">
+    [disabled]="!data.name || !data.srs" (click)="add()">
     <i class="icon-plus" [hidden]="commonFileServiceRef.loadingToLayman"></i>
     <span class="hs-loader" [hidden]="!commonFileServiceRef.loadingToLayman"></span>
     <span [hidden]="commonFileServiceRef.loadingToLayman">{{'COMMON.add' | translateHs : {app} }}</span>

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.ts
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.ts
@@ -5,6 +5,7 @@ import {
   HsAddDataCommonFileService,
   HsAddDataCommonFileServiceParams,
 } from '../common-file.service';
+import {HsAddDataVectorService} from '../../vector/vector.service';
 import {HsConfig, HsConfigObject} from '../../../../config.service';
 import {HsLaymanService} from '../../../save-map/layman.service';
 
@@ -19,6 +20,7 @@ export class HsAddLayerAuthorizedComponent implements OnInit {
   configRef: HsConfigObject;
   constructor(
     public hsAddDataCommonFileService: HsAddDataCommonFileService,
+    private hsAddDataVectorService: HsAddDataVectorService,
     public hsLaymanService: HsLaymanService,
     private hsConfig: HsConfig
   ) {}
@@ -28,7 +30,7 @@ export class HsAddLayerAuthorizedComponent implements OnInit {
     this.configRef = this.hsConfig.get(this.app);
   }
 
-  async addAsWms(): Promise<any> {
-    await this.hsAddDataCommonFileService.addAsWms(this.data, this.app);
+  async add(): Promise<void> {
+    await this.hsAddDataCommonFileService.addAsService(this.data, this.app);
   }
 }

--- a/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.html
+++ b/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.html
@@ -11,4 +11,17 @@
       translateHs : {app} }}</label>
   </div>
   <hs-target-position [(addUnder)]="data.addUnder" [app]="app"></hs-target-position>
+  <div class="d-flex flex-row justify-content-between align-items-baseline mb-1 ps-4" *ngIf="data.loadAsType">
+    {{'ADDDATA.loadAs' | translateHs : {app} }}
+    <div class="btn-group ms-2">
+      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="data.loadAsType = 'wms'"
+        [ngClass]="{'active': data.loadAsType === 'wms'}">
+        WMS
+      </button>
+      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="data.loadAsType = 'wfs'"
+        [ngClass]="{'active': data.loadAsType === 'wfs'}">
+        WFS
+      </button>
+    </div>
+  </div>
 </div>

--- a/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.html
+++ b/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.html
@@ -14,11 +14,11 @@
   <div class="d-flex flex-row justify-content-between align-items-baseline mb-1 ps-4" *ngIf="data.loadAsType">
     {{'ADDDATA.loadAs' | translateHs : {app} }}
     <div class="btn-group ms-2">
-      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="data.loadAsType = 'wms'"
+      <button type="button" class="btn btn-light btn-outline-secondary" (click)="data.loadAsType = 'wms'"
         [ngClass]="{'active': data.loadAsType === 'wms'}">
         WMS
       </button>
-      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="data.loadAsType = 'wfs'"
+      <button type="button" class="btn btn-light btn-outline-secondary" (click)="data.loadAsType = 'wfs'"
         [ngClass]="{'active': data.loadAsType === 'wfs'}">
         WFS
       </button>

--- a/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.ts
+++ b/projects/hslayers/src/components/add-data/common/advanced-options/advanced-options.component.ts
@@ -1,20 +1,22 @@
 import {Component, Input, OnInit} from '@angular/core';
 
+import {FileDataObject} from '../../file/types/file-data-object.type';
 import {HsAddDataVectorService} from '../../vector/vector.service';
+import {VectorDataObject} from '../../vector/vector-data.type';
 
 @Component({
   selector: 'hs-advanced-options',
   templateUrl: 'advanced-options.component.html',
 })
 export class HsAdvancedOptionsComponent implements OnInit {
-  @Input() data: any;
+  @Input() data: FileDataObject & VectorDataObject;
   @Input() app = 'default';
   isKml: boolean;
   constructor(private hsAddDataVectorService: HsAddDataVectorService) {}
   ngOnInit(): void {
     this.isKml = this.hsAddDataVectorService.isKml(
       this.data.type,
-      this.data.url
+      this.data.url ?? null
     );
   }
 }

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -33,6 +33,9 @@ export class HsAddDataCommonFileServiceParams {
   loadingToLayman = false;
   asyncLoading = false;
   endpoint: HsEndpoint = null;
+  /**
+   * @param success - true when layer added successfully
+   */
   layerAddedAsService: Subject<boolean> = new Subject();
   dataObjectChanged: Subject<FileDataObject> = new Subject();
   fileUploadErrorHeader = 'ADDLAYERS.couldNotUploadSelectedFile';
@@ -380,7 +383,7 @@ export class HsAddDataCommonFileService {
     app: string
   ): Promise<FormData> {
     this.get(app).readingData = true;
-    const formdata = new FormData();
+    const formData = new FormData();
     let zipFile;
     const zip = new JSZip();
     if (this.isZip(files[0].type)) {
@@ -401,30 +404,29 @@ export class HsAddDataCommonFileService {
         }
       );
     }
-    formdata.append('file', zipFile, files[0].name.split('.')[0] + '.zip');
-
+    formData.append('file', zipFile, files[0].name.split('.')[0] + '.zip');
     if (sld) {
-      formdata.append(
+      formData.append(
         'sld',
         new Blob([sld.content], {type: sld.type}),
         sld.name
       );
     }
-    formdata.append('name', name);
+    formData.append('name', name);
     title = title == '' ? name : title;
-    formdata.append('title', title);
-    formdata.append('abstract', abstract);
-    formdata.append('crs', srs);
+    formData.append('title', title);
+    formData.append('abstract', abstract);
+    formData.append('crs', srs);
 
     const rights = this.hsLaymanService.parseAccessRightsForLayman(
       endpoint,
       access_rights
     );
 
-    formdata.append('access_rights.write', rights.write);
-    formdata.append('access_rights.read', rights.read);
+    formData.append('access_rights.write', rights.write);
+    formData.append('access_rights.read', rights.read);
     this.get(app).readingData = false;
-    return formdata;
+    return formData;
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -293,7 +293,7 @@ export class HsAddDataCommonFileService {
    * @param app - App identifier
    */
   async lookupLaymanLayer(name: string, app: string): Promise<boolean> {
-    const fiendlyName = getLaymanFriendlyLayerName(name);
+    const friendlyName = getLaymanFriendlyLayerName(name);
     const commonFileRef = this.get(app);
     let descriptor: HsLaymanLayerDescriptor;
     if (this.isAuthorized()) {
@@ -310,7 +310,7 @@ export class HsAddDataCommonFileService {
         throw error;
       }
     }
-    if (!descriptor || descriptor?.name != fiendlyName) {
+    if (!descriptor || descriptor?.name != friendlyName) {
       return false;
     } else {
       return true;
@@ -336,7 +336,7 @@ export class HsAddDataCommonFileService {
   }
 
   /**
-   * Calculates progress of individual file being zipped by transforimg value into 0 - 1 scale
+   * Calculates progress of individual file being zipped by transforming value into 0 - 1 scale
    */
   calculateFileProgress(value, nrOfFiles): number {
     const unit = 100 / nrOfFiles;
@@ -366,7 +366,7 @@ export class HsAddDataCommonFileService {
    * @param srs - EPSG code of selected projection (eg. "EPSG:4326")
    * @param sld - Array of sld files
    * @param access_rights - User access rights for the new layer,
-   * @returns Formdata object for HTTP request
+   * @returns FormData object for HTTP request
    */
   async constructFormData(
     endpoint: HsEndpoint,
@@ -432,7 +432,7 @@ export class HsAddDataCommonFileService {
    * answer with wms service url to add to map
    * @param data - Current data object for upload
    * @param app - App identifier
-   * @param options - (Optional) overwrite: Overwrite existing layman layer, repetive: Called for more the one time
+   * @param options - (Optional) overwrite: Overwrite existing layman layer, repetitive: Called for more the one time
    */
   async addAsWms(
     data: FileDataObject,

--- a/projects/hslayers/src/components/add-data/common/common.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common.service.ts
@@ -72,13 +72,19 @@ export class HsAddDataCommonService {
     }
     const nameOrTitle = serviceType !== 'wmts';
     for (const layer of services) {
-      //TODO: If Layman allows layers with different casing,
+      let layerName = nameOrTitle
+        ? layer.Name ?? layer.Title
+        : layer.Identifier;
+      //NOTE: If Layman allows layers with different casing,
       // then remove the case lowering
-      const layerName = nameOrTitle
-        ? layer.Name?.toLowerCase() ?? layer.Title?.toLowerCase()
-        : layer.Identifier?.toLowerCase();
+      layerName = layerName.toLowerCase();
+      // Removing the workspace (like user:my_layer)
+      layerName = layerName.includes(':')
+        ? layerName.split(':').slice(1).join(':')
+        : layerName;
       if (layerName === this.get(app).layerToSelect.toLowerCase()) {
         layer.checked = true;
+        return;
       }
     }
   }
@@ -87,7 +93,6 @@ export class HsAddDataCommonService {
     if (e?.status === 401) {
       this.hsToastService.createToastPopupMessage(
         'ADDLAYERS.capabilitiesParsingProblem',
-
         'ADDLAYERS.unauthorizedAccess',
         {serviceCalledFrom: 'HsAddDataCommonUrlService'},
         app

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -16,7 +16,7 @@
   <div class="form-floating mb-3">
     <textarea class="form-control" id='hs-ows-abstract'
       [placeholder]="'COMMON.fillInDescriptive' | translateHs : {app} " name="abstract" [(ngModel)]="data.abstract">
-                              </textarea>
+    </textarea>
     <label for="absctract" class="capabilities_label control-label">{{'COMMON.abstract' | translateHs : {app} }}</label>
 
   </div>

--- a/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.html
+++ b/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.html
@@ -1,6 +1,12 @@
 <ng-container *ngIf="data.type !== 'shp' && data.type !== 'raster'">
   <div class="d-flex flex-row justify-content-between align-items-baseline mb-1 ps-4">
-    {{'ADDDATA.saveToDatabase' | translateHs : {app} }}
+    <div>
+      {{'ADDDATA.saveToDatabase' | translateHs : {app} }}
+      <a class="btn btn-sm border-0" (click)="$event.stopPropagation();toggleDescVisibility()"
+        [title]="'ADDDATA.saveToDbExplanation' | translateHs: {app} ">
+        <i class="icon-info-sign text-primary"></i>
+      </a>
+    </div>
     <div class="btn-group ms-2">
       <button type="button" class="btn btn-light  btn-outline-secondary" (click)="setSaveToLayman(true)"
         [ngClass]="{'active':data.saveToLayman}">
@@ -11,6 +17,9 @@
         {{'COMMON.no' | translateHs : {app} }}
       </button>
     </div>
+  </div>
+  <div class="mb-1 ps-4 fst-italic text-secondary" [hidden]="!descriptionVisible">
+    {{'ADDDATA.saveToDbExplanation' | translateHs: {app} }}
   </div>
 </ng-container>
 <div class="ps-4 mt-3">

--- a/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.html
+++ b/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.html
@@ -2,11 +2,11 @@
   <div class="d-flex flex-row justify-content-between align-items-baseline mb-1 ps-4">
     {{'ADDDATA.saveToDatabase' | translateHs : {app} }}
     <div class="btn-group ms-2">
-      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="data.saveToLayman = true"
+      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="setSaveToLayman(true)"
         [ngClass]="{'active':data.saveToLayman}">
         {{'COMMON.yes' | translateHs : {app} }}
       </button>
-      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="data.saveToLayman = false"
+      <button type="button" class="btn btn-light  btn-outline-secondary" (click)="setSaveToLayman(false)"
         [ngClass]="{'active': !data.saveToLayman}">
         {{'COMMON.no' | translateHs : {app} }}
       </button>

--- a/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.ts
+++ b/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.ts
@@ -1,12 +1,24 @@
 import {Component, Input} from '@angular/core';
 
+import {DEFAULT_VECTOR_LOAD_TYPE} from '../../enums/load-types.const';
+import {FileDataObject} from '../../file/types/file-data-object.type';
+
 @Component({
   selector: 'hs-save-to-layman',
   templateUrl: 'save-to-layman.component.html',
 })
 export class HsSaveToLaymanComponent {
-  @Input() data: any;
+  @Input() data: FileDataObject;
   @Input() app = 'default';
 
   constructor() {}
+
+  setSaveToLayman(save: boolean) {
+    this.data.saveToLayman = save;
+    if (save) {
+      this.data.loadAsType = DEFAULT_VECTOR_LOAD_TYPE;
+    } else {
+      this.data.loadAsType = undefined;
+    }
+  }
 }

--- a/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.ts
+++ b/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.ts
@@ -10,6 +10,7 @@ import {FileDataObject} from '../../file/types/file-data-object.type';
 export class HsSaveToLaymanComponent {
   @Input() data: FileDataObject;
   @Input() app = 'default';
+  descriptionVisible = false;
 
   constructor() {}
 
@@ -20,5 +21,9 @@ export class HsSaveToLaymanComponent {
     } else {
       this.data.loadAsType = undefined;
     }
+  }
+
+  toggleDescVisibility() {
+    this.descriptionVisible = !this.descriptionVisible;
   }
 }

--- a/projects/hslayers/src/components/add-data/enums/load-types.const.ts
+++ b/projects/hslayers/src/components/add-data/enums/load-types.const.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_SHP_LOAD_TYPE = 'wms' as const;
+export const DEFAULT_VECTOR_LOAD_TYPE = 'wfs' as const;

--- a/projects/hslayers/src/components/add-data/file/file-base.component.ts
+++ b/projects/hslayers/src/components/add-data/file/file-base.component.ts
@@ -62,7 +62,7 @@ export class HsAddDataFileBaseComponent
         this.clearInput();
       });
 
-    commonFileServiceRef.layerAddedAsWms
+    commonFileServiceRef.layerAddedAsService
       .pipe(takeUntil(this.end))
       .subscribe((success) => {
         if (success) {

--- a/projects/hslayers/src/components/add-data/file/shp/shp.component.ts
+++ b/projects/hslayers/src/components/add-data/file/shp/shp.component.ts
@@ -1,6 +1,7 @@
 import {AfterViewInit, Component, Input, OnInit} from '@angular/core';
 
 import {AddDataFileType} from '../types/file.type';
+import {DEFAULT_SHP_LOAD_TYPE} from '../../enums/load-types.const';
 import {HsAddDataCommonFileService} from '../../common/common-file.service';
 import {HsAddDataCommonService} from '../../common/common.service';
 import {HsAddDataFileBaseComponent} from '../file-base.component';
@@ -35,6 +36,7 @@ export class HsFileShpComponent
     this.acceptedFormats = '.shp, .shx, .dbf, .sbn, .zip';
     this.baseFileType = this.fileType;
     super.ngOnInit();
+    this.data.loadAsType = DEFAULT_SHP_LOAD_TYPE;
   }
 
   async handleFileUpload(evt: HsUploadedFiles, app: string): Promise<void> {

--- a/projects/hslayers/src/components/add-data/file/types/file-data-object.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file-data-object.type.ts
@@ -11,6 +11,7 @@ export type FileDataObject = {
   extract_styles?: boolean;
   files?: FileDescriptor[];
   folder_name?: string;
+  loadAsType?: 'wms' | 'wfs';
   name?: string;
   saveAvailable?: boolean;
   saveToLayman?: boolean;

--- a/projects/hslayers/src/components/add-data/public-api.ts
+++ b/projects/hslayers/src/components/add-data/public-api.ts
@@ -9,4 +9,5 @@ export * from './add-data.module';
 export * from './add-data.service';
 export * from './dialog-overwrite-layer/overwrite-layer.component';
 export * from './dialog-rename-layer/rename-layer.component';
-export * from '../add-data/enums/overwrite-response';
+export * from './enums/load-types.const';
+export * from './enums/overwrite-response';

--- a/projects/hslayers/src/components/add-data/url/add-data-url.component.ts
+++ b/projects/hslayers/src/components/add-data/url/add-data-url.component.ts
@@ -104,8 +104,10 @@ export class HsAddDataUrlComponent implements OnInit, OnDestroy {
     }
     const layers = this.hsShareUrlService.getParamValue(`hs-${type}-layers`);
     const url = this.hsShareUrlService.getParamValue(`hs-${type}-to-connect`);
-
-    // const serviceName = `hsAddLayersWmsService`;
+    if (!url) {
+      this.hsAddDataUrlService.get(this.app).connectFromParams = false;
+      return;
+    }
     if (layers) {
       for (const layer of layers.split(';')) {
         this.hsAddDataOwsService.connectToOWS(

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
@@ -10,6 +10,8 @@ import {
 
 import {Cluster} from 'ol/source';
 
+import {DEFAULT_VECTOR_LOAD_TYPE} from '../../enums/load-types.const';
+import {FileDataObject} from '../../file/types/file-data-object.type';
 import {
   HsAddDataCommonFileService,
   HsAddDataCommonFileServiceParams,
@@ -42,7 +44,7 @@ export class HsAddDataVectorFileComponent
   @ViewChild(HsUploadComponent) hsUploadComponent: HsUploadComponent;
   acceptedFormats: string;
   uploadType = 'new';
-  data: VectorDataObject;
+  data: VectorDataObject & FileDataObject;
   fileInput: ElementRef;
   access_rights: accessRightsModel = {
     'access_rights.write': 'private',
@@ -200,6 +202,9 @@ export class HsAddDataVectorFileComponent
             this.hsCommonEndpointsService.endpoints.filter(
               (ep) => ep.type == 'layman'
             )[0]?.authenticated;
+          if (this.data.saveToLayman) {
+            this.data.loadAsType = DEFAULT_VECTOR_LOAD_TYPE;
+          }
         }
         //add layman endpoint url as url to allow sync
         if (
@@ -254,7 +259,7 @@ export class HsAddDataVectorFileComponent
     }
   }
   /**
-   * Reset data object to its default valuess
+   * Reset data object to its default values
    */
   setDataToDefault(): void {
     this.data = {

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
@@ -53,6 +53,7 @@ export class HsAddDataVectorFileComponent
   commonFileServiceRef: HsAddDataCommonFileServiceParams;
   configRef: HsConfigObject;
   private end = new Subject<void>();
+
   constructor(
     private hsAddDataVectorService: HsAddDataVectorService,
     private hsAddDataCommonFileService: HsAddDataCommonFileService,
@@ -65,6 +66,7 @@ export class HsAddDataVectorFileComponent
     private hsUtilsService: HsUtilsService,
     private hsConfig: HsConfig
   ) {}
+
   ngAfterViewInit(): void {
     this.fileInput = this.hsUploadComponent.getFileInput();
   }
@@ -258,6 +260,7 @@ export class HsAddDataVectorFileComponent
       this.fileInput.nativeElement.value = '';
     }
   }
+
   /**
    * Reset data object to its default values
    */

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -11,6 +11,7 @@ import Feature from 'ol/Feature';
 import {HsAddDataCommonFileService} from '../common/common-file.service';
 import {HsAddDataService} from '../add-data.service';
 import {HsLaymanService} from '../../save-map/layman.service';
+import {HsLogService} from '../../../common/log/log.service';
 import {HsMapService} from '../../map/map.service';
 import {HsStylerService} from '../../styles/styler.service';
 import {HsUtilsService} from '../../utils/utils.service';
@@ -60,12 +61,13 @@ export class HsAddDataVectorService {
   };
 
   constructor(
-    private hsMapService: HsMapService,
-    private hsUtilsService: HsUtilsService,
-    private hsStylerService: HsStylerService,
-    private hsAddDataService: HsAddDataService,
     private hsAddDataCommonFileService: HsAddDataCommonFileService,
-    private hsLaymanService: HsLaymanService
+    private hsAddDataService: HsAddDataService,
+    private hsLaymanService: HsLaymanService,
+    private hsLog: HsLogService,
+    private hsMapService: HsMapService,
+    private hsStylerService: HsStylerService,
+    private hsUtilsService: HsUtilsService
   ) {}
 
   /**
@@ -497,7 +499,7 @@ export class HsAddDataVectorService {
       };
       return object;
     } catch (e) {
-      console.log('Uploaded file is not supported!');
+      this.hsLog.warn('Uploaded file is not supported!');
       return {error: 'couldNotUploadSelectedFile'};
     }
   }
@@ -509,7 +511,7 @@ export class HsAddDataVectorService {
    * @returns JSON object with parsed data
    */
   async readUploadedFile(file: File, app: string): Promise<any> {
-    let uploadedData: any = {};
+    let uploadedData;
     const fileType = this.tryGuessTypeFromNameOrUrl(file.name.toLowerCase());
     switch (fileType) {
       case 'kml':
@@ -528,7 +530,7 @@ export class HsAddDataVectorService {
             return uploadedData;
           }
         } catch (e) {
-          console.log('Uploaded file is not supported!', e);
+          this.hsLog.warn('Uploaded file is not supported!', e);
           return {error: 'couldNotUploadSelectedFile'};
         }
     }
@@ -556,7 +558,7 @@ export class HsAddDataVectorService {
    * @returns JSON object with file name and read features
    */
   createVectorObjectFromJson(json: any, app: string): any {
-    let features = [];
+    let features: Feature[] = [];
     const format = new GeoJSON();
     const projection = format.readProjection(json);
     if (!projection) {
@@ -608,8 +610,8 @@ export class HsAddDataVectorService {
   }
 
   /**
-   * Convert uploaded kml or gpx files into GeoJSON format / parse loaded GeoJSON
-   * @param file - Uploaded  kml, gpx or GeoJSON files
+   * Convert uploaded KML or GPX files into GeoJSON format / parse loaded GeoJSON
+   * @param file - Uploaded KML, GPX or GeoJSON files
    * @param app - App identifier
    */
   async convertUploadedData(file: File, app: string): Promise<any> {
@@ -644,7 +646,7 @@ export class HsAddDataVectorService {
       uploadedData.type = fileType;
       return uploadedData;
     } catch (e) {
-      console.error('Uploaded file is not supported' + e);
+      this.hsLog.warn('Uploaded file is not supported' + e);
       return {error: 'couldNotUploadSelectedFile'};
     }
   }

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -39,7 +39,6 @@ export class HsAddDataVectorService {
         temporaryFileReader.abort();
         reject(new DOMException('Problem parsing input file.'));
       };
-
       temporaryFileReader.onload = () => {
         resolve(temporaryFileReader.result);
       };
@@ -53,13 +52,13 @@ export class HsAddDataVectorService {
         temporaryFileReader.abort();
         reject(new DOMException('Problem parsing input file.'));
       };
-
       temporaryFileReader.onload = () => {
         resolve(temporaryFileReader.result);
       };
       temporaryFileReader.readAsDataURL(inputFile);
     });
   };
+
   constructor(
     private hsMapService: HsMapService,
     private hsUtilsService: HsUtilsService,
@@ -104,10 +103,9 @@ export class HsAddDataVectorService {
           options,
           app
         );
-
         /* 
         TODO: Should have set definition property with protocol inside 
-        so layer synchronizer would know if to sync 
+        so layer synchronizer would know if to sync
         */
         if (options.saveToLayman) {
           if (this.hsUtilsService.undefineEmptyString(url) !== undefined) {
@@ -121,7 +119,6 @@ export class HsAddDataVectorService {
             });
           }
         }
-
         if (this.hsMapService.getMap(app)) {
           this.hsAddDataService.addLayer(lyr, app, addUnder);
         }
@@ -141,7 +138,7 @@ export class HsAddDataVectorService {
    * @param abstract - Abstract of new layer
    * @param srs - EPSG code of selected projection (eg. "EPSG:4326")
    * @param options - Other options
-   * @returns Promise which return OpenLayer's vector layer
+   * @returns Promise which returns OpenLayer's vector layer
    */
   async createVectorLayer(
     type: string,
@@ -432,7 +429,7 @@ export class HsAddDataVectorService {
   /**
    * Check if uploaded data are KML
    * @param fileType - Uploaded data type
-   * @param url -  Upload source url
+   * @param url - Upload source url
    * @returns True, if data are in KML format, false otherwise
    */
   isKml(fileType: string, url: string): boolean {

--- a/projects/hslayers/src/components/compositions/compositions.spec.ts
+++ b/projects/hslayers/src/components/compositions/compositions.spec.ts
@@ -176,8 +176,11 @@ describe('compositions', () => {
         {
           provide: HsAddDataVectorService,
           useValue: new HsAddDataVectorService(
+            null,
+            null,
+            null,
+            null,
             mockedMapService,
-            mockedUtilsService,
             new HsStylerService(
               null,
               mockedUtilsService,
@@ -192,9 +195,7 @@ describe('compositions', () => {
               null,
               null
             ),
-            null,
-            null,
-            null
+            mockedUtilsService
           ),
         },
         {

--- a/projects/hslayers/src/components/draw/draw.service.ts
+++ b/projects/hslayers/src/components/draw/draw.service.ts
@@ -307,7 +307,8 @@ export class HsDrawService {
     if (!(layer instanceof Layer)) {
       metadata = await this.hsLaymanBrowserService.fillLayerMetadata(
         appRef.laymanEndpoint,
-        layer
+        layer,
+        app
       );
     }
     if (metadata) {

--- a/projects/hslayers/src/components/layermanager/gallery/basemap-gallery.html
+++ b/projects/hslayers/src/components/layermanager/gallery/basemap-gallery.html
@@ -25,7 +25,13 @@
                     </div>
                     <label [attr.id]="layer?.idString()" class="ps-2 mb-0 w-100"
                         [ngStyle]="{'background-color':'rgba(192, 189, 189, 0.644)'}" (click)="expandMenu(layer)">
-                        {{hsLayerManagerService.apps[data.app].menuExpanded ? 'Less ': 'More'}}</label>
+                        <ng-container *ngIf="hsLayerManagerService.apps[data.app].menuExpanded;else more">
+                            {{'COMMON.less' | translateHs : {app: data.app} }}
+                        </ng-container>
+                        <ng-template #more>
+                            {{'COMMON.more' | translateHs : {app: data.app} }}
+                        </ng-template>
+                    </label>
                 </div>
 
                 <img [ngClass]="{'active': layer.active}" [src]="layer.thumbnail"

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -1318,7 +1318,7 @@ export class HsLayerManagerService {
   }
 
   /*
-    Creats a copy of the currentLayer
+    Creates a copy of the currentLayer
   */
   async copyLayer(newTitle: string, app: string): Promise<void> {
     const copyTitle = this.createCopyTitle(newTitle, app);
@@ -1379,7 +1379,7 @@ export class HsLayerManagerService {
   }
 
   /*
-    Creats a copy of the currentLayer if it is a vector layer
+    Creates a copy of the currentLayer if it is a vector layer
   */
   copyVectorLayer(newTitle: string, app: string): void {
     let features;
@@ -1412,7 +1412,7 @@ export class HsLayerManagerService {
   }
 
   /*
-    Creats a new title for the copied layer
+    Creates a new title for the copied layer
   */
   createCopyTitle(newTitle: string, app: string): string {
     const layerName = getName(this.apps[app].currentLayer.layer);

--- a/projects/hslayers/src/components/save-map/interfaces/layman-layer-descriptor.interface.ts
+++ b/projects/hslayers/src/components/save-map/interfaces/layman-layer-descriptor.interface.ts
@@ -66,9 +66,24 @@ export interface HsLaymanLayerDescriptor {
     status?: StatusStateType;
     error?: any;
   };
-  code?: any;
   exists?: boolean;
   layman_metadata?: {
     publication_status: 'COMPLETE' | 'INCOMPLETE' | 'UPDATING';
   };
+  /**
+   * Only when error
+   */
+  message?: string;
+  /**
+   * Only when error
+   */
+  detail?: string;
+  /**
+   * Only when error
+   */
+  code?: number;
+  /**
+   * Only when error
+   */
+  sub_code?: number;
 }

--- a/projects/hslayers/src/components/save-map/layer-synchronizer.service.ts
+++ b/projects/hslayers/src/components/save-map/layer-synchronizer.service.ts
@@ -101,7 +101,7 @@ export class HsLayerSynchronizerService {
     const definition = getDefinition(layer);
     return (
       this.hsUtilsService.instOf(layer.getSource(), VectorSource) &&
-      //Test whether fromat cointains 'wfs' AND does not contian 'external'. Case insensitive
+      //Test whether format contains 'wfs' AND does not contain 'external'. Case insensitive
       new RegExp('^(?=.*wfs)(?:(?!external).)*$', 'i').test(
         definition?.format?.toLowerCase()
       )
@@ -251,6 +251,7 @@ export class HsLayerSynchronizerService {
       app
     );
   }
+
   /**
    * Handler for feature property change event
    * @param feature - Feature whose property change event was captured
@@ -274,6 +275,7 @@ export class HsLayerSynchronizerService {
       app
     );
   }
+
   /**
    * Sync any feature changes inside a layer, that is being stored on Layman's service database
    * @param add - Features being added

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -236,7 +236,7 @@ export class HsLaymanService implements HsSaverService {
    * @param formdata - FormData object used for sending data over HTTP request
    * @param saveAsNew - Save as new composition
    * @param app - App identifier
-   * @param compositionJson - Json with composition's definition
+   * @param compositionJson - JSON with composition's definition
    * @returns Promise result of POST/PATCH request
    */
   async makeMapPostPatchRequest(
@@ -287,7 +287,7 @@ export class HsLaymanService implements HsSaverService {
           );
           return err;
         });
-        //Unsuccessfull request response contains code,detail and message properties
+        //Unsuccessful request response contains code, detail and message properties
         if (!response.code) {
           success = true;
         } else {

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -599,6 +599,13 @@ export class HsLaymanService implements HsSaverService {
     }, 2000);
   }
 
+  /**
+   * Converts OL Feature objects into a GeoJSON
+   * @param features - Array of OL Features
+   * @param crsSupported - True if current CRS is supported by Layman
+   * @param withFeatures FIXME: What is this good for?
+   * @returns GeoJSON representation of the input features
+   */
   getFeatureGeoJSON(
     features: Feature<Geometry>[],
     crsSupported: boolean,
@@ -606,22 +613,21 @@ export class HsLaymanService implements HsSaverService {
   ) {
     const f = new GeoJSON();
     let geojson: Feature<Geometry>[];
-    if (withFeatures) {
-      if (!crsSupported) {
-        geojson = f.writeFeaturesObject(
-          features.map((f) => {
-            const f2 = f.clone();
-            f2.getGeometry().transform(this.crs, 'EPSG:3857');
-            return f2;
-          })
-        );
-      } else {
-        geojson = f.writeFeaturesObject(features);
-      }
-      return geojson;
-    } else {
+    if (!withFeatures) {
       return;
     }
+    if (!crsSupported) {
+      geojson = f.writeFeaturesObject(
+        features.map((f) => {
+          const f2 = f.clone();
+          f2.getGeometry().transform(this.crs, 'EPSG:3857');
+          return f2;
+        })
+      );
+    } else {
+      geojson = f.writeFeaturesObject(features);
+    }
+    return geojson;
   }
 
   /**


### PR DESCRIPTION
## Description

New switcher in Advanced Options which adds possibility to:
* load Shapefile as a WFS service (previously only WMS was possible) and
* load KML/GeoJSON as a WMS service (previously only WFS was possible)
![image](https://user-images.githubusercontent.com/5598693/206190309-ae871a68-6f57-4231-8dc9-59495dba9336.png)

Also adding a brief description about what the "save to database" actually means and how it behaves (hidden by default).
![image](https://user-images.githubusercontent.com/5598693/206197130-b94686b3-62e9-43b2-bc7a-af48246775d4.png)

## Related issues or pull requests

resolves #3440 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
