### PR TITLE
hslayers-server: Provide callback for logout()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dependencygraph.svg
 .env.*
 !.env.example
 *.bat
-/.vs
+.vs
 stats.json
 .lingua
 bundle

--- a/projects/hslayers-server/.env.example
+++ b/projects/hslayers-server/.env.example
@@ -1,6 +1,5 @@
 NODE_ENV=production
 PROXY_PORT=8085
-HS_GEONAMES_API_KEY=*****
 SHARING_PORT=8086
 LAYMAN_PORT=8087
 DB_PATH=data/hslayers-server.db
@@ -17,4 +16,5 @@ OAUTH2_SECRET=secret-xxxxx-xxxxx-xxxxx-xxxxx-xxxxx
 OAUTH2_CALLBACK_URL=http://localhost:8087/callback
 CORS_WHITELIST=["http://localhost:4200", "https://hub.lesprojekt.cz"]
 SUCCESS_REDIRECT_URL=http://localhost:4200
+HS_GEONAMES_API_KEY=*****
 OPENROUTESERVICE_API_KEY=*****

--- a/projects/hslayers-server/src/layman.js
+++ b/projects/hslayers-server/src/layman.js
@@ -28,7 +28,7 @@ app.use(cors(corsOptions));
 var refreshStrategy = new OAuth2Refresh({
   refreshWindow: 10, // Time in seconds to perform a token refresh before it expires
   userProperty: 'ticket', // Active user property name to store OAuth tokens
-  authenticationURL: '/login', // URL to redirect unathorized users to
+  authenticationURL: '/login', // URL to redirect unauthorized users to
   callbackParameter: 'callback' //URL query parameter name to pass a return URL
 });
 
@@ -121,7 +121,7 @@ app.use(`/client/geoserver`, gsProxy);
 
 app.get('/', (req, res) => {
   if (req.session.passport && req.session.passport.user && req.session.passport.user.authenticated) {
-    res.send(req.session.passport.user.username); // TODO - close opener window/modal popup
+    res.send(req.session.passport.user.username); // TODO: - close opener window/modal popup
   }
   else
     res.send("<a href='/login'>Login</a>");
@@ -131,7 +131,9 @@ app.get('/login', passport.authenticate('oauth2'));
 
 app.get('/logout', (req, res) => {
   authnUtil.deleteUserSession(req);
-  req.logout();
+  req.logout((err) => {
+    if (err) console.log(err);
+  });
   res.redirect('/');
 });
 


### PR DESCRIPTION
## Description

Since [passport@0.6.0](https://github.com/jaredhanson/passport/blob/v0.6.0/CHANGELOG.md), req.logout() has a mandatory callback function param. Not providing it was throwing an error, effectively blocking the actual log-out action.

## Related issues or pull requests

resolves #3605 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
