### PR TITLE
Replace loader icon with a CSS loader

### DIFF
--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
@@ -42,8 +42,8 @@
                             <button type="button" class="btn btn-"
                                 [ngClass]="{'btn-primary': getCurrentInterval() === interval}"
                                 (click)="timeButtonClicked(interval)" *ngFor="let interval of getIntervals()"
-                                [attr.aria-label]="'SENSORS.oneHour' | translateHs: {app: data.app} ">{{getTranslation(interval.name)}}<img
-                                    [src]="configRef._ajaxLoaderPath" [hidden]="!interval.loading"></button>
+                                [attr.aria-label]="'SENSORS.oneHour' | translateHs: {app: data.app} ">{{getTranslation(interval.name)}}&emsp;<span
+                                    class="hs-loader" [hidden]="!interval.loading"></span></button>
                         </div>
                     </div>
                     <div class="m-1">

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -68,9 +68,10 @@
             <i class="icon-remove"></i>
         </button>
     </div> -->
-    <div [hidden]="!loadingInfo" class='list-group-item text-primary text-center py-2'><img class="pe-2"
-            [src]="configRef._ajaxLoaderPath" />{{'ADDDATA.CATALOGUE.loading' | translateHs : {app} }}</div>
-
+    <div [hidden]="!loadingInfo" class="list-group-item text-primary text-center py-2">
+        <span class="pe-2 hs-loader hs-loader-dark"></span>
+        &emsp;{{'ADDDATA.CATALOGUE.loading' | translateHs : {app} }}
+    </div>
     <div class="card bg-light align-items-center"
         [hidden]="!selectTypeToAddLayerVisible || loadingInfo || appRef.selectedLayer?.id !== layer.id">
         <div class="d-flex flex-row justify-content-between align-items-center w-100">

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.component.html
@@ -120,8 +120,8 @@
                         (mouseleave)="highlightLayer(layer, false,app)">
                         <hs-catalogue-list-item [layer]="layer" [app]="app"></hs-catalogue-list-item>
                     </li>
-                    <li class='list-group-item text-primary text-center py-2' [hidden]="!appRef.dataLoading"><img
-                            class="pe-2" [src]="configRef._ajaxLoaderPath" />{{'ADDDATA.CATALOGUE.loading' | translateHs
+                    <li class='list-group-item text-primary text-center py-2' [hidden]="!appRef.dataLoading"><span
+                            class="pe-2 hs-loader hs-loader-dark"></span>&emsp;{{'ADDDATA.CATALOGUE.loading' | translateHs
                         : {app} }}</li>
                     <li [hidden]='appRef.catalogEntries.length > 0 || appRef.dataLoading' class='list-group-item'
                         style="border-top-width: 1px; border-radius: inherit">

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
@@ -4,7 +4,7 @@
   <button *ngIf="hsAddDataCommonFileService.isAuthorized()" class="btn btn-primary w-100"
     [disabled]="!data.name || !data.srs" (click)="addAsWms()">
     <i class="icon-plus" [hidden]="commonFileServiceRef.loadingToLayman"></i>
-    <img [src]="configRef._ajaxLoaderPath" [hidden]="!commonFileServiceRef.loadingToLayman" />
+    <span class="hs-loader" [hidden]="!commonFileServiceRef.loadingToLayman"></span>
     <span [hidden]="commonFileServiceRef.loadingToLayman">{{'COMMON.add' | translateHs : {app} }}</span>
     <span *ngIf="commonFileServiceRef.loadingToLayman && commonFileServiceRef.asyncLoading">{{'COMMON.uploading' |
       translateHs : {app} }}</span>

--- a/projects/hslayers/src/components/add-data/common/url/progress/progress.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/progress/progress.component.html
@@ -1,6 +1,7 @@
 <div class="d-flex justify-content-center btn-group w-75 m-auto">
-  <button class="btn btn-primary w-75">{{'ADDDATA.CATALOGUE.loading' | translateHs: {app} }}<img class="ms-2"
-      [src]="configRef._ajaxLoaderPath" /></button>
+  <button class="btn btn-primary w-75">{{'ADDDATA.CATALOGUE.loading' | translateHs: {app} }}&emsp;
+    <span class="ms-2 hs-loader"></span>
+  </button>
   <button class="btn btn-secondary" (click)="hsAddDataService.cancelUrlRequest.next(app)">&#10006;
   </button>
 </div>

--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.component.html
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.component.html
@@ -24,8 +24,8 @@
                         [app]="app">
                     </hs-url-add>
                     <button *ngIf="appRef.loadingFeatures"
-                        class="btn btn-primary w-75">{{'ADDLAYERS.loadingFeaturePleaseWait' | translateHs: {app} }}<img
-                            class="ms-2" [src]="configRef._ajaxLoaderPath" /></button>
+                        class="btn btn-primary w-75">{{'ADDLAYERS.loadingFeaturePleaseWait' | translateHs: {app} }}&emsp;<span
+                            class="ms-2 hs-loader"></span></button>
                 </div>
             </li>
 

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.html
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.html
@@ -36,10 +36,14 @@
     </div>
     <button class="btn btn-primary w-100 mt-2" [disabled]="uploadType === 'new' ? !data.title : !data.sourceLayer"
       (click)="add()">
-      <i class="icon-plus" [hidden]="commonFileServiceRef.loadingToLayman"></i>
-      <img [src]="configRef._ajaxLoaderPath" [hidden]="!commonFileServiceRef.loadingToLayman" />
-      <span [hidden]="commonFileServiceRef.loadingToLayman">{{'COMMON.add' | translateHs : {app} }}</span>
-      <span [hidden]="!commonFileServiceRef.loadingToLayman">{{'COMMON.uploading' | translateHs : {app} }}</span>
+      <span [hidden]="commonFileServiceRef.loadingToLayman">
+        <i class="icon-plus"></i>&emsp;
+        {{'COMMON.add' | translateHs : {app} }}
+      </span>
+      <span [hidden]="!commonFileServiceRef.loadingToLayman">
+        <span class="hs-loader"></span>&emsp;
+        {{'COMMON.uploading' | translateHs : {app} }}
+      </span>
     </button>
   </div>
 </form>

--- a/projects/hslayers/src/components/compositions/compositions.component.html
+++ b/projects/hslayers/src/components/compositions/compositions.component.html
@@ -167,8 +167,8 @@
                             [selectedCompId]="selectedCompId">
                         </hs-compositions-list-item>
                     </li>
-                    <li class="list-group-item text-primary text-center py-2" *ngIf="catalogueRef.dataLoading"><img
-                            class="pe-2" [src]="configRef._ajaxLoaderPath" />{{'COMMON.loading' |
+                    <li class="list-group-item text-primary text-center py-2" *ngIf="catalogueRef.dataLoading"><span
+                            class="hs-loader hs-loader-dark pe-2"></span>&emsp;{{'COMMON.loading' |
                         translateHs: {app: data.app} }}</li>
                     <li [hidden]="catalogueRef.compositionEntries.length > 0 || catalogueRef.dataLoading"
                         class="list-group-item">

--- a/projects/hslayers/src/components/compositions/dialogs/csw-layers-dialog/csw-layers-dialog.component.html
+++ b/projects/hslayers/src/components/compositions/dialogs/csw-layers-dialog/csw-layers-dialog.component.html
@@ -29,7 +29,7 @@
                             <ng-template #loadingLayers>
                                 <button
                                     class="accordion-button justify-content-between">{{'COMPOSITIONS.cswDialog.servicesLoading'
-                                    | translateHs:{app: data.app} }}<img [src]="configRef._ajaxLoaderPath" /></button>
+                                    | translateHs:{app: data.app} }}&emsp;<span class="hs-loader"></span></button>
                             </ng-template>
                         </ng-template>
                         <ng-template ngbPanelContent>

--- a/projects/hslayers/src/components/draw/partials/draw.html
+++ b/projects/hslayers/src/components/draw/partials/draw.html
@@ -31,7 +31,7 @@
             </ol>
             {{'DRAW.longerLoading' | translateHs: {app: data.app} }}
             <div class="d-flex justify-content-center pt-3">
-                <img [src]="configRef._ajaxLoaderPath" />
+                <span class="hs-loader hs-loader-dark"></span>
             </div>
         </div>
     </div>

--- a/projects/hslayers/src/components/print/print.component.html
+++ b/projects/hslayers/src/components/print/print.component.html
@@ -89,7 +89,7 @@
             </div>
             <div class="d-flex justify-content-center btn-group w-75 m-auto" *ngIf="isLoading()">
                 <button class="btn btn-primary w-75">{{'ADDDATA.CATALOGUE.loading' | translateHs : {app: data.app}
-                    }}...<img class="ms-2" [src]="configRef._ajaxLoaderPath" /></button>
+                    }}...<span class="hs-loader ms-2"></span></button>
                 <button class="btn btn-secondary" (click)="cancelLoading()">&#10006;
                 </button>
             </div>

--- a/projects/hslayers/src/components/trip-planner/trip-planner.component.ts
+++ b/projects/hslayers/src/components/trip-planner/trip-planner.component.ts
@@ -20,7 +20,6 @@ export class HsTripPlannerComponent
   extends HsPanelBaseComponent
   implements OnInit
 {
-  loaderImage: string;
   timer: any;
   name = 'tripPlanner';
   configRef: HsConfigObject;

--- a/projects/hslayers/src/components/trip-planner/trip_planner.html
+++ b/projects/hslayers/src/components/trip-planner/trip_planner.html
@@ -18,7 +18,7 @@
           [hidden]="!waypoint.editMode" (blur)="toggleEdit(waypoint)" />
       </div>
       <div class="p-1">
-        <img [hidden]="!waypoint.loading" [src]="configRef._ajaxLoaderPath" />
+        <span [hidden]="!waypoint.loading" class="hs-loader hs-loader-dark"></span>
       </div>
       <div class="p-1" style="height: 1.7em">
         <div style="margin-top: 1em">{{ formatDistance(waypoint) }}

--- a/projects/hslayers/src/config.service.ts
+++ b/projects/hslayers/src/config.service.ts
@@ -148,14 +148,17 @@ export class HsConfigObject {
   timeDisplayFormat?: string;
 
   /**
-   *  Determines behavior of exclusive layers (layer.exclusive = true) visibility
-   *  If set to true, only layers with same path are affected by exclusivity
+   * Determines behavior of exclusive layers (layer.exclusive = true) visibility
+   * If set to true, only layers with same path are affected by exclusivity
    */
   pathExclusivity?: boolean;
   ngRouter?: boolean;
-  /*
-   *   Path of image to ajax loader animation,
-   *   which is calculated automatically from assetPath */
+  /**
+   * Path of image to ajax loader animation,
+   * which is calculated automatically from assetPath
+   * TODO: REMOVE in 12.0
+   * @deprecated - replace the image with <span class="hs-loader"></span> or <span class="hs-loader hs-loader-dark"></span>
+   */
   _ajaxLoaderPath?: string;
 
   constructor() {

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -906,6 +906,47 @@ $list-group-item-padding-x: 1.25rem;
     box-shadow: none;
   }
 
+  /*
+  * Loader by https://cssloaders.github.io/
+  */
+  .hs-loader {
+    position: relative;
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    background: white;
+    transform: rotateX(65deg) rotate(45deg);
+    color: $gray-200;
+    animation: layers1 1s linear infinite alternate;
+  }
+
+  .hs-loader-dark {
+    background: $primary;
+    color: $gray-400
+  }
+
+  .hs-loader:after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.7);
+    animation: layerTr 1s linear infinite alternate;
+  }
+
+  .hs-loader-dark:after {
+    background: rgba(82, 162, 216, 0.7);
+  }
+
+  @keyframes layers1 {
+    0% {box-shadow: 0px 0px 0 0px}
+    90% , 100% {box-shadow: 0.75em 0.75em 0 -1px}
+  }
+
+  @keyframes layerTr {
+    0% {transform:  translate(0, 0) scale(1)}
+    100% {transform: translate(-0.75em, -0.75em) scale(1)}
+  }
+
   @import "../components/layout/partials/layout.component.scss";
   @import "../components/layermanager/layermanager.component.scss";
   @import "../components/layermanager/logical-list/layerlist.component.scss";


### PR DESCRIPTION
## Description

The old "ajaxLoaderIcon" is so last year. Even thought the image itself is tiny, so it is not an issue with bundle size, its appearance on the site relies on properly set assetsPath. That can cause troubles and represents a bottle-neck. Additionally, the old loader in gray colours creates a bad visual readability on a blue background (used on buttons). The new loader icon is composed by SCSS transitions and animations. It also creates a unique UI, instead of an echo of late 2000s design. Most of the code was borrowed from https://cssloaders.github.io/

![image](https://user-images.githubusercontent.com/5598693/207734928-025169fc-a7b4-46de-92bc-8a03412ee4dc.png)

![image](https://user-images.githubusercontent.com/5598693/207735179-2a6656a6-630b-4a8e-be0a-e3b88bf62521.png)

![image](https://user-images.githubusercontent.com/5598693/207735091-0a1b1268-745b-49a8-ae6f-17024d39187e.png)

Removing the old icon from the repo can be considered a breaking change, thus for now I have only marked it as deprecated.

## Related issues or pull requests

none

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
