### PR TITLE
Fix composition/add-data item list overflow triggering map extent change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22243,6 +22243,7 @@
     },
     "node_modules/vega-embed/node_modules/yallist": {
       "version": "4.0.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -40243,7 +40244,8 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/projects/hslayers/src/components/add-data/add-data.component.html
+++ b/projects/hslayers/src/components/add-data/add-data.component.html
@@ -1,9 +1,9 @@
-<div class="card hs-main-panel" [hidden]="(isVisible$ | async) === false">
-    <hs-panel-header name="addData" [title]="'PANEL_HEADER.DATASOURCE_SELECTOR' | translateHs : data"
-        [app]="data.app">
+<div class="card hs-main-panel overflow-hidden h-100" style="margin-top: 0 !important;"
+    [hidden]="(isVisible$ | async) === false">
+    <hs-panel-header name="addData" [title]="'PANEL_HEADER.DATASOURCE_SELECTOR' | translateHs : data" [app]="data.app">
     </hs-panel-header>
-    <div class="card-body">
-        <ul class="nav flex-column flex-sm-row dss-tabs" role="tablist">
+    <div class="card-body" style="overflow-y: auto;">
+        <ul class="nav flex-column flex-sm-row dss-tabs sticky-top bg-white" role="tablist">
             <li class="nav-item hs-tab-single-datasources">
                 <a class="nav-link" [ngClass]="{'bg-primary text-white': appRef.dsSelected === 'catalogue'}" role="tab"
                     data-toggle="tab" (click)="datasetSelect('catalogue')">

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.component.html
@@ -1,136 +1,139 @@
 <div class="card hs-main-panel">
-    <div class="mt-3 mx-3 ps-1 d-flex justify-content-between">
-        <div class="input-group w-50">
-            <input type="search" class="form-control w-50" [placeholder]="'COMMON.search' | translateHs : {app}  "
-                name="search" [(ngModel)]="data.query.textFilter" (ngModelChange)="queryByFilter()">
-            <button class="input-group-text text-secondary border-start-0" (click)="queryByFilter()">
-                <i class="icon-search icon-primary"></i>
-            </button>
-        </div>
-        <hs-layman-current-user [app]="app" [endpoint]="hsLaymanService.getLaymanEndpoint()"></hs-layman-current-user>
-        <!-- TODO: Remove function call from template -->
-    </div>
-    <div class="d-flex ms-4 me-3 justify-content-between py-1 ">
-        <div class="d-flex">
-            <div class="input-group-text border-0">
-                <input type="checkbox" class="checkbox-lg" [(ngModel)]="data.filterByExtent" (change)="queryByFilter()"
-                    name="filterByExtent">
-                <span class="ms-1">{{'COMPOSITIONS.filterByMap' | translateHs : {app} }}</span>
+    <div class="hs-add-data-catalogue-header">
+        <div class="mt-3 mx-3 ps-1 d-flex justify-content-between">
+            <div class="input-group w-50">
+                <input type="search" class="form-control w-50" [placeholder]="'COMMON.search' | translateHs : {app}  "
+                    name="search" [(ngModel)]="data.query.textFilter" (ngModelChange)="queryByFilter()">
+                <button class="input-group-text text-secondary border-start-0" (click)="queryByFilter()">
+                    <i class="icon-search icon-primary"></i>
+                </button>
             </div>
-            <div class="input-group-text border-0 ms-1"
-                *ngIf="hsLaymanService.getLaymanEndpoint() && !hsLaymanService.isLaymanGuest()">
-                <!-- TODO: Remove function call from template -->
-                <input type="checkbox" [(ngModel)]="data.onlyMine" (ngModelChange)="queryByFilter()" name="onlyMine">
-                <span class="ms-1">{{'COMPOSITIONS.onlyMine' | translateHs : {app} }}</span>
-            </div>
-        </div>
-
-        <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block">
-            <button class="btn btn-light hs-white-background hs-custom-toggle" (click)="openOptionsMenu()"
-                ngbDropdownToggle>{{translateString('COMMON',optionsButtonLabel)}}</button>
+            <hs-layman-current-user [app]="app"
+                [endpoint]="hsLaymanService.getLaymanEndpoint()"></hs-layman-current-user>
             <!-- TODO: Remove function call from template -->
-            <div ngbDropdownMenu class="dropdown-menu-right p-2 m-1"
-                style="min-width: 23rem; max-width: 23rem;  overflow: visible" aria-labelledby="filtersDropdown">
-                <table class="p-1 ps-3" style="border-collapse:separate; border-spacing:0.5rem 0.5rem;">
-                    <tbody>
-                        <tr>
-                            <td class="tdbreak">
-                                {{'ADDDATA.CATALOGUE.filterType' | translateHs : {app} }}
-                            </td>
-                            <td ngbDropdown display="dynamic" placement="bottom-right"
-                                #searchTypeDropdown="ngbDropdown">
-                                <button type="button" ngbDropdownToggle
-                                    class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
-                                    style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{translateString('ADDDATA.CATALOGUE.searchFilterTypes',
-                                    data.textField)}}
-                                </button>
-                                <ul ngbDropdownMenu aria-labelledby="searchType" class="ps-2"
-                                    style="overflow-y: auto; max-height: 10rem; min-width:10rem">
-                                    <li *ngFor="let searchType of textFieldTypes; let index = index" class="p-2 p-md-0">
-                                        <label style="cursor: pointer;"><input class="me-2" type="radio"
-                                                name="searchType-index" [checked]="(index === 0)"
-                                                (change)="selectType(searchType);searchTypeDropdown.close()">{{translateString('ADDDATA.CATALOGUE.searchFilterTypes',
-                                            searchType)}}</label>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="tdbreak">
-                                {{'ADDDATA.CATALOGUE.resourceType' | translateHs : {app} }}
-                            </td>
-                            <td ngbDropdown display="dynamic" placement="bottom-right" #resourceType="ngbDropdown">
-                                <button type="button" ngbDropdownToggle
-                                    class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
-                                    style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{translateString('ADDDATA.CATALOGUE.queryDataTypes',
-                                    data.query.type)}}
-                                </button>
-                                <ul ngbDropdownMenu aria-labelledby="type" class="ps-2"
-                                    style="overflow-y: auto; max-height: 10rem; min-width:10rem">
-                                    <li *ngFor="let type of dataTypes; let index = index" class="p-2 p-md-0">
-                                        <label style="cursor: pointer;"><input class="me-2" type="radio"
-                                                name="type-index" [checked]="(index === 1)"
-                                                (change)="selectQueryType(type, 'type');resourceType.close()">{{translateString('ADDDATA.CATALOGUE.queryDataTypes',
-                                            type)}}</label>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="tdbreak">
-                                {{'COMMON.sortBy' | translateHs : {app} }}
-                            </td>
-                            <td ngbDropdown display="dynamic" placement="bottom-right" #sortByDrop="ngbDropdown">
-                                <button type="button" ngbDropdownToggle
-                                    class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
-                                    style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{translateString('ADDDATA.CATALOGUE.sortbyTypes', data.query.sortby)}}
-                                    <!-- TODO: Remove function call from template -->
-                                </button>
-                                <ul ngbDropdownMenu aria-labelledby="sortBy" class="ps-2"
-                                    style="overflow-y: auto; max-height: 10rem; min-width:10rem">
-                                    <li *ngFor="let sortType of sortbyTypes, let index = index;" class="p-2 p-md-0">
-                                        <label style="cursor: pointer;"><input class="me-2" type="radio"
-                                                name="sort-index" [checked]="(index === 0)"
-                                                (change)="selectQueryType(sortType, 'sortby');sortByDrop.close()">{{translateString('ADDDATA.CATALOGUE.sortbyTypes',
-                                            sortType)}}</label>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+        </div>
+        <div class="d-flex ms-4 me-3 justify-content-between py-1 ">
+            <div class="d-flex">
+                <div class="input-group-text border-0">
+                    <input type="checkbox" class="checkbox-lg" [(ngModel)]="data.filterByExtent"
+                        (change)="queryByFilter()" name="filterByExtent">
+                    <span class="ms-1">{{'COMPOSITIONS.filterByMap' | translateHs : {app} }}</span>
+                </div>
+                <div class="input-group-text border-0 ms-1"
+                    *ngIf="hsLaymanService.getLaymanEndpoint() && !hsLaymanService.isLaymanGuest()">
+                    <!-- TODO: Remove function call from template -->
+                    <input type="checkbox" [(ngModel)]="data.onlyMine" (ngModelChange)="queryByFilter()"
+                        name="onlyMine">
+                    <span class="ms-1">{{'COMPOSITIONS.onlyMine' | translateHs : {app} }}</span>
+                </div>
+            </div>
+            <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block">
+                <button class="btn btn-light hs-white-background hs-custom-toggle" (click)="openOptionsMenu()"
+                    ngbDropdownToggle>{{translateString('COMMON',optionsButtonLabel)}}</button>
+                <!-- TODO: Remove function call from template -->
+                <div ngbDropdownMenu class="dropdown-menu-right p-2 m-1"
+                    style="min-width: 23rem; max-width: 23rem;  overflow: visible" aria-labelledby="filtersDropdown">
+                    <table class="p-1 ps-3" style="border-collapse:separate; border-spacing:0.5rem 0.5rem;">
+                        <tbody>
+                            <tr>
+                                <td class="tdbreak">
+                                    {{'ADDDATA.CATALOGUE.filterType' | translateHs : {app} }}
+                                </td>
+                                <td ngbDropdown display="dynamic" placement="bottom-right"
+                                    #searchTypeDropdown="ngbDropdown">
+                                    <button type="button" ngbDropdownToggle
+                                        class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
+                                        style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
+                                        {{translateString('ADDDATA.CATALOGUE.searchFilterTypes',
+                                        data.textField)}}
+                                    </button>
+                                    <ul ngbDropdownMenu aria-labelledby="searchType" class="ps-2"
+                                        style="overflow-y: auto; max-height: 10rem; min-width:10rem">
+                                        <li *ngFor="let searchType of textFieldTypes; let index = index"
+                                            class="p-2 p-md-0">
+                                            <label style="cursor: pointer;"><input class="me-2" type="radio"
+                                                    name="searchType-index" [checked]="(index === 0)"
+                                                    (change)="selectType(searchType);searchTypeDropdown.close()">{{translateString('ADDDATA.CATALOGUE.searchFilterTypes',
+                                                searchType)}}</label>
+                                        </li>
+                                    </ul>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tdbreak">
+                                    {{'ADDDATA.CATALOGUE.resourceType' | translateHs : {app} }}
+                                </td>
+                                <td ngbDropdown display="dynamic" placement="bottom-right" #resourceType="ngbDropdown">
+                                    <button type="button" ngbDropdownToggle
+                                        class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
+                                        style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
+                                        {{translateString('ADDDATA.CATALOGUE.queryDataTypes',
+                                        data.query.type)}}
+                                    </button>
+                                    <ul ngbDropdownMenu aria-labelledby="type" class="ps-2"
+                                        style="overflow-y: auto; max-height: 10rem; min-width:10rem">
+                                        <li *ngFor="let type of dataTypes; let index = index" class="p-2 p-md-0">
+                                            <label style="cursor: pointer;"><input class="me-2" type="radio"
+                                                    name="type-index" [checked]="(index === 1)"
+                                                    (change)="selectQueryType(type, 'type');resourceType.close()">{{translateString('ADDDATA.CATALOGUE.queryDataTypes',
+                                                type)}}</label>
+                                        </li>
+                                    </ul>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tdbreak">
+                                    {{'COMMON.sortBy' | translateHs : {app} }}
+                                </td>
+                                <td ngbDropdown display="dynamic" placement="bottom-right" #sortByDrop="ngbDropdown">
+                                    <button type="button" ngbDropdownToggle
+                                        class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
+                                        style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
+                                        {{translateString('ADDDATA.CATALOGUE.sortbyTypes', data.query.sortby)}}
+                                        <!-- TODO: Remove function call from template -->
+                                    </button>
+                                    <ul ngbDropdownMenu aria-labelledby="sortBy" class="ps-2"
+                                        style="overflow-y: auto; max-height: 10rem; min-width:10rem">
+                                        <li *ngFor="let sortType of sortbyTypes, let index = index;" class="p-2 p-md-0">
+                                            <label style="cursor: pointer;"><input class="me-2" type="radio"
+                                                    name="sort-index" [checked]="(index === 0)"
+                                                    (change)="selectQueryType(sortType, 'sortby');sortByDrop.close()">{{translateString('ADDDATA.CATALOGUE.sortbyTypes',
+                                                sortType)}}</label>
+                                        </li>
+                                    </ul>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
-    <div class="tab-content">
-        <div class="card d-flex" style="font-size: 1rem !important;">
-            <div class="card-body">
-                <!-- <div *ngIf="endpoint.type == 'micka'">
-                        <hs-micka-filters micka-dataset-config="{url: endpoint.url}"></hs-micka-filters>
-                    </div>
-                -->
-                <ul class="list-group">
-                    <li [hidden]="appRef.dataLoading" style="cursor: pointer;"
-                        *ngFor="let layer of appRef.catalogEntries; trackBy:( 'id' | trackByProperty )"
-                        class="clearfix list-group-item" [ngClass]="{'hs-endpoint-item-active': layer.highlighted}"
-                        (click)="layerSelected(layer)" (mouseover)="highlightLayer(layer, true,app)"
-                        (mouseleave)="highlightLayer(layer, false,app)">
-                        <hs-catalogue-list-item [layer]="layer" [app]="app"></hs-catalogue-list-item>
-                    </li>
-                    <li class='list-group-item text-primary text-center py-2' [hidden]="!appRef.dataLoading"><span
-                            class="pe-2 hs-loader hs-loader-dark"></span>&emsp;{{'ADDDATA.CATALOGUE.loading' | translateHs
-                        : {app} }}</li>
-                    <li [hidden]='appRef.catalogEntries.length > 0 || appRef.dataLoading' class='list-group-item'
-                        style="border-top-width: 1px; border-radius: inherit">
-                        {{'DATASOURCE_SELECTOR.noResults' | translateHs : {app} }}</li>
-                </ul>
-            </div>
-            <ng-container *ngIf="appRef.matchedRecords !== 0 && !appRef.dataLoading">
-                <hs-pager [app]="app" [pagerService]="hsAddDataCatalogueService"></hs-pager>
-            </ng-container>
+    <div class="card d-flex" style="font-size: 1rem !important;">
+        <div class="card-body">
+            <!-- <div *ngIf="endpoint.type == 'micka'">
+                    <hs-micka-filters micka-dataset-config="{url: endpoint.url}"></hs-micka-filters>
+                </div>
+            -->
+            <ul class="list-group">
+                <li [hidden]="appRef.dataLoading" style="cursor: pointer;"
+                    *ngFor="let layer of appRef.catalogEntries; trackBy:( 'id' | trackByProperty )"
+                    class="clearfix list-group-item" [ngClass]="{'hs-endpoint-item-active': layer.highlighted}"
+                    (click)="layerSelected(layer)" (mouseover)="highlightLayer(layer, true,app)"
+                    (mouseleave)="highlightLayer(layer, false,app)">
+                    <hs-catalogue-list-item [layer]="layer" [app]="app"></hs-catalogue-list-item>
+                </li>
+                <li class='list-group-item text-primary text-center py-2' [hidden]="!appRef.dataLoading"><span
+                        class="pe-2 hs-loader hs-loader-dark"></span>&emsp;{{'ADDDATA.CATALOGUE.loading' | translateHs
+                    : {app} }}</li>
+                <li [hidden]='appRef.catalogEntries.length > 0 || appRef.dataLoading' class='list-group-item'
+                    style="border-top-width: 1px; border-radius: inherit">
+                    {{'DATASOURCE_SELECTOR.noResults' | translateHs : {app} }}</li>
+            </ul>
         </div>
     </div>
+    <ng-container *ngIf="appRef.matchedRecords !== 0 && !appRef.dataLoading">
+        <hs-pager class="sticky-bottom bg-white border border-top-0" [app]="app"
+            [pagerService]="hsAddDataCatalogueService"></hs-pager>
+    </ng-container>
 </div>

--- a/projects/hslayers/src/components/compositions/compositions.component.html
+++ b/projects/hslayers/src/components/compositions/compositions.component.html
@@ -1,183 +1,193 @@
-<div class="card hs-main-panel" [hidden]="(isVisible$ | async) === false">
-    <hs-panel-header name="composition_browser" [title]="'PANEL_HEADER.COMPOSITIONS' | translateHs : data"
-        [app]="data.app">
-        <extra-buttons class="d-flex align-items-center">
-            <button class="but-title-sm hs-extra-buttons" (click)="reload()"
-                [title]="'COMMON.reload' | translateHs : data">
-                <i class="glyphicon icon-fatredo"></i>
-            </button>
-            <button class="but-title-sm hs-extra-buttons" [title]="'PANEL_HEADER.SAVECOMPOSITION'|translateHs : data"
-                (click)="openSaveMapPanel()" [hidden]="!saveMapAvailable()"><!-- TODO: Remove function call from template -->
-                <span class="icon-save-floppy"></span>
-            </button>
-            <label class="but-title-sm hs-extra-buttons btn-file mb-0" style="padding: 1px 6px;"
-                [title]="'COMPOSITIONS.import' | translateHs : data">
-                <span class="icon-upload"></span><input type="file" (change)="handleFileSelect($event, data.app)"
-                    accept=".json" style="display: none;">
-            </label>
-            <button class="but-title-sm hs-extra-buttons" [title]="'COMPOSITIONS.addByAddress'|translateHs : data"
-                (click)="changeUrlButtonVisible()">
-                <span class="icon-plus"></span>
-            </button>
-        </extra-buttons>
-    </hs-panel-header>
-    <div class="mt-3 mx-3 ps-1 d-flex justify-content-between">
-        <div class="input-group mb-2" [hidden]="!addCompositionUrlVisible">
-            <input type="text" class="form-control" [placeholder]="'COMPOSITIONS.Address'|translateHs : data"
-                [(ngModel)]="urlToAdd" [ngModelOptions]="{standalone: true}">
-            <button type="button" class="btn btn-secondary" (click)="addCompositionUrl(urlToAdd)"><i
-                    class="icon-link"></i></button>
-        </div>
-    </div>
-    <div class="mx-3 ps-1 d-flex justify-content-between">
-        <div class="input-group" style="width: 55% !important;">
-            <input type="search" class="form-control border-end-0" [placeholder]="'COMMON.search'|translateHs : data"
-                name="search" [(ngModel)]="catalogueRef.data.query.title" (ngModelChange)="loadFilteredCompositions()">
-            <button class="input-group-text text-secondary border-start-0" (click)="loadFilteredCompositions()">
-                <i class="icon-search icon-primary"></i>
-            </button>
-        </div>
-        <hs-layman-current-user [app]="data.app" [endpoint]="getLaymanEndpoint()"><!-- TODO: Remove function call from template -->
-        </hs-layman-current-user>
-    </div>
-    <div class="d-flex ms-4 me-3 justify-content-between py-1 ">
-        <div class="d-flex">
-            <div class="input-group-text border-0">
-                <input type="checkbox" class="checkbox-lg" [(ngModel)]="catalogueRef.filterByExtent" (change)='loadFilteredCompositions()'
-                    name="catalogueRef.filterByExtent">
-                <span class="ms-1">{{'COMPOSITIONS.filterByMap' | translateHs : {app: data.app} }}</span>
-            </div>
-            <div class="input-group-text border-0 ms-1" *ngIf="getLaymanEndpoint() && !isLaymanGuest()"><!-- TODO: Remove function call from template -->
-                <input type="checkbox" [(ngModel)]="catalogueRef.filterByOnlyMine" (change)='loadFilteredCompositions()'
-                    name="catalogueRef.filterByOnlyMine">
-                <span class="ms-1">{{'COMPOSITIONS.onlyMine' | translateHs : {app: data.app} }}</span>
+<div class="card hs-main-panel h-100 overflow-hidden" style="margin-top: 0 !important;"
+    [hidden]="(isVisible$ | async) === false">
+    <div class="hs-compositions-header">
+        <hs-panel-header name="composition_browser" [title]="'PANEL_HEADER.COMPOSITIONS' | translateHs : data"
+            [app]="data.app">
+            <extra-buttons class="d-flex align-items-center">
+                <button class="but-title-sm hs-extra-buttons" (click)="reload()"
+                    [title]="'COMMON.reload' | translateHs : data">
+                    <i class="glyphicon icon-fatredo"></i>
+                </button>
+                <button class="but-title-sm hs-extra-buttons"
+                    [title]="'PANEL_HEADER.SAVECOMPOSITION'|translateHs : data" (click)="openSaveMapPanel()"
+                    [hidden]="!saveMapAvailable()"><!-- TODO: Remove function call from template -->
+                    <span class="icon-save-floppy"></span>
+                </button>
+                <label class="but-title-sm hs-extra-buttons btn-file mb-0" style="padding: 1px 6px;"
+                    [title]="'COMPOSITIONS.import' | translateHs : data">
+                    <span class="icon-upload"></span><input type="file" (change)="handleFileSelect($event, data.app)"
+                        accept=".json" style="display: none;">
+                </label>
+                <button class="but-title-sm hs-extra-buttons" [title]="'COMPOSITIONS.addByAddress'|translateHs : data"
+                    (click)="changeUrlButtonVisible()">
+                    <span class="icon-plus"></span>
+                </button>
+            </extra-buttons>
+        </hs-panel-header>
+        <div class="mt-3 mx-3 ps-1 d-flex justify-content-between">
+            <div class="input-group mb-2" [hidden]="!addCompositionUrlVisible">
+                <input type="text" class="form-control" [placeholder]="'COMPOSITIONS.Address'|translateHs : data"
+                    [(ngModel)]="urlToAdd" [ngModelOptions]="{standalone: true}">
+                <button type="button" class="btn btn-secondary" (click)="addCompositionUrl(urlToAdd)"><i
+                        class="icon-link"></i></button>
             </div>
         </div>
-        <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block">
-            <button class="btn btn-light hs-white-background hs-custom-toggle" (click)="openOptionsMenu()"
-                ngbDropdownToggle>{{translateString('COMMON', optionsButtonLabel)}}</button><!-- TODO: Remove function call from template -->
-            <div ngbDropdownMenu class="dropdown-menu-right p-2 m-1"
-                style="min-width: 23rem; max-width: 23rem;  overflow: visible" aria-labelledby="filtersDropdown">
-                <table class="p-1 ps-3" style="border-collapse:separate; border-spacing:0.5rem 0.5rem;">
-                    <tbody>
-                        <!-- <tr>
-                                    <td class="tdbreak">
-                                        {{'COMMON.type' | translateHs : {app: data.app} }}
-                                    </td>
-                                    <td>
-                                        <select class="form-control hs-background-alfa ps-1" name="type"
-                                            [(ngModel)]="catalogueRef.data.type"
-                                            (change)="loadFilteredCompositions()"
-                                            style="min-width: 11rem; max-width: 11rem;border:0px">
-                                            <option *ngFor="let type of catalogueRef.types"
-                                                [ngValue]="type.value">
-                                                {{translateString('COMPOSITONTYPES', type.name)}}</option>
-                                        </select>
-                                    </td>
-                                </tr> -->
-                        <tr>
-                            <td class="tdbreak">
-                                {{'COMMON.keywords' | translateHs : {app: data.app} }}
-                            </td>
-                            <td ngbDropdown display="dynamic" placement="bottom-right">
-                                <button type="button" ngbDropdownToggle
-                                    class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
-                                    style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{'COMPOSITIONS.selectKeywords' | translateHs : {app: data.app} }}
-                                </button>
-                                <ul ngbDropdownMenu aria-labelledby="keywords" class="ps-2"
-                                    style="overflow-y: auto; max-height: 10rem; min-width: 15rem">
-                                    <li *ngFor="let keyword of catalogueRef.data.keywords, let index = index;" class="p-1 p-md-0">
-                                        <label style="cursor: pointer;"><input class="me-2" type="checkbox"
-                                                [(ngModel)]="keyword.selected" name="keyword[index]"
-                                                (change)="loadFilteredCompositions()">{{translateString('COMPOSITONKEYWORDS',
-                                            keyword.name)}}</label>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="tdbreak">
-                                {{'COMPOSITIONS.inspireTheme' | translateHs : {app: data.app} }}
-                            </td>
-                            <td ngbDropdown display="dynamic" placement="bottom-right">
-                                <button type="button" ngbDropdownToggle
-                                    class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
-                                    style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{'COMPOSITIONS.selectThemes' | translateHs : {app: data.app} }}
-                                </button>
-                                <ul ngbDropdownMenu aria-labelledby="inspireThemes" class="ps-2"
-                                    style="overflow-y: auto; max-height: 10rem; min-width: 20rem">
-                                    <li *ngFor="let theme of catalogueRef.data.themes, let index = index;" class="p-1 p-md-0">
-                                        <label style="cursor: pointer;"><input class="me-2" type="checkbox"
-                                                [(ngModel)]="theme.selected" name="theme[index]"
-                                                (change)="loadFilteredCompositions()">{{translateString('COMPOSITONINSPIRETHEMES',
-                                            theme.name)}}</label>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-
-                        <tr>
-                            <td class="tdbreak">
-                                {{'COMMON.sortBy' | translateHs : {app: data.app} }}
-                            </td>
-                            <td ngbDropdown display="dynamic" placement="bottom-right" #sortByDrop="ngbDropdown">
-                                <button type="button" ngbDropdownToggle
-                                    class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
-                                    style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
-                                    {{translateString('COMPOSITONSORTVALUES',
-                                    catalogueRef.data.sortBy.name)}}
-                                </button>
-                                <ul ngbDropdownMenu aria-labelledby="sortBy" class="ps-2"
-                                    style="overflow-y: auto; max-height: 10rem; min-width:10rem">
-                                    <li *ngFor="let item of catalogueRef.sortByValues, let index = index;" class="p-2 p-md-0">
-                                        <label style="cursor: pointer;"><input class="me-2" type="radio"
-                                                name="sort-index" [checked]="(index === 0)"
-                                                (change)="sortByValueChanged(item);sortByDrop.close()">{{translateString('COMPOSITONSORTVALUES',
-                                            item.name)}}</label>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2" style="text-align: center; vertical-align: middle;">
-                                <button class="btn w-100 btn-light hs-background-alfa" style="border-radius: 0.25rem;"
-                                    (click)="clearFilters()">
-                                    {{'COMPOSITIONS.clearFilters' | translateHs : {app: data.app} }}</button>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+        <div class="mx-3 ps-1 d-flex justify-content-between">
+            <div class="input-group" style="width: 55% !important;">
+                <input type="search" class="form-control border-end-0"
+                    [placeholder]="'COMMON.search'|translateHs : data" name="search"
+                    [(ngModel)]="catalogueRef.data.query.title" (ngModelChange)="loadFilteredCompositions()">
+                <button class="input-group-text text-secondary border-start-0" (click)="loadFilteredCompositions()">
+                    <i class="icon-search icon-primary"></i>
+                </button>
+            </div>
+            <hs-layman-current-user [app]="data.app"
+                [endpoint]="getLaymanEndpoint()"><!-- TODO: Remove function call from template -->
+            </hs-layman-current-user>
+        </div>
+        <div class="d-flex ms-4 me-3 justify-content-between py-1 ">
+            <div class="d-flex">
+                <div class="input-group-text border-0">
+                    <input type="checkbox" class="checkbox-lg" [(ngModel)]="catalogueRef.filterByExtent"
+                        (change)='loadFilteredCompositions()' name="catalogueRef.filterByExtent">
+                    <span class="ms-1">{{'COMPOSITIONS.filterByMap' | translateHs : {app: data.app} }}</span>
+                </div>
+                <div class="input-group-text border-0 ms-1" *ngIf="getLaymanEndpoint() && !isLaymanGuest()">
+                    <!-- TODO: Remove function call from template -->
+                    <input type="checkbox" [(ngModel)]="catalogueRef.filterByOnlyMine"
+                        (change)='loadFilteredCompositions()' name="catalogueRef.filterByOnlyMine">
+                    <span class="ms-1">{{'COMPOSITIONS.onlyMine' | translateHs : {app: data.app} }}</span>
+                </div>
+            </div>
+            <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block">
+                <button class="btn btn-light hs-white-background hs-custom-toggle" (click)="openOptionsMenu()"
+                    ngbDropdownToggle>{{translateString('COMMON',
+                    optionsButtonLabel)}}</button><!-- TODO: Remove function call from template -->
+                <div ngbDropdownMenu class="dropdown-menu-right p-2 m-1"
+                    style="min-width: 23rem; max-width: 23rem;  overflow: visible" aria-labelledby="filtersDropdown">
+                    <table class="p-1 ps-3" style="border-collapse:separate; border-spacing:0.5rem 0.5rem;">
+                        <tbody>
+                            <!-- <tr>
+                                        <td class="tdbreak">
+                                            {{'COMMON.type' | translateHs : {app: data.app} }}
+                                        </td>
+                                        <td>
+                                            <select class="form-control hs-background-alfa ps-1" name="type"
+                                                [(ngModel)]="catalogueRef.data.type"
+                                                (change)="loadFilteredCompositions()"
+                                                style="min-width: 11rem; max-width: 11rem;border:0px">
+                                                <option *ngFor="let type of catalogueRef.types"
+                                                    [ngValue]="type.value">
+                                                    {{translateString('COMPOSITONTYPES', type.name)}}</option>
+                                            </select>
+                                        </td>
+                                    </tr> -->
+                            <tr>
+                                <td class="tdbreak">
+                                    {{'COMMON.keywords' | translateHs : {app: data.app} }}
+                                </td>
+                                <td ngbDropdown display="dynamic" placement="bottom-right">
+                                    <button type="button" ngbDropdownToggle
+                                        class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
+                                        style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
+                                        {{'COMPOSITIONS.selectKeywords' | translateHs : {app: data.app} }}
+                                    </button>
+                                    <ul ngbDropdownMenu aria-labelledby="keywords" class="ps-2"
+                                        style="overflow-y: auto; max-height: 10rem; min-width: 15rem">
+                                        <li *ngFor="let keyword of catalogueRef.data.keywords, let index = index;"
+                                            class="p-1 p-md-0">
+                                            <label style="cursor: pointer;"><input class="me-2" type="checkbox"
+                                                    [(ngModel)]="keyword.selected" name="keyword[index]"
+                                                    (change)="loadFilteredCompositions()">{{translateString('COMPOSITONKEYWORDS',
+                                                keyword.name)}}</label>
+                                        </li>
+                                    </ul>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tdbreak">
+                                    {{'COMPOSITIONS.inspireTheme' | translateHs : {app: data.app} }}
+                                </td>
+                                <td ngbDropdown display="dynamic" placement="bottom-right">
+                                    <button type="button" ngbDropdownToggle
+                                        class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
+                                        style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
+                                        {{'COMPOSITIONS.selectThemes' | translateHs : {app: data.app} }}
+                                    </button>
+                                    <ul ngbDropdownMenu aria-labelledby="inspireThemes" class="ps-2"
+                                        style="overflow-y: auto; max-height: 10rem; min-width: 20rem">
+                                        <li *ngFor="let theme of catalogueRef.data.themes, let index = index;"
+                                            class="p-1 p-md-0">
+                                            <label style="cursor: pointer;"><input class="me-2" type="checkbox"
+                                                    [(ngModel)]="theme.selected" name="theme[index]"
+                                                    (change)="loadFilteredCompositions()">{{translateString('COMPOSITONINSPIRETHEMES',
+                                                theme.name)}}</label>
+                                        </li>
+                                    </ul>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tdbreak">
+                                    {{'COMMON.sortBy' | translateHs : {app: data.app} }}
+                                </td>
+                                <td ngbDropdown display="dynamic" placement="bottom-right" #sortByDrop="ngbDropdown">
+                                    <button type="button" ngbDropdownToggle
+                                        class="btn btn-light btn-sm hs-custom-toggle hs-background-alfa p-2 ps-1 border-0"
+                                        style="text-align:start; min-width: 11rem; max-width: 11rem; border-radius: 0px; justify-content: space-between; display:flex; align-items: center;">
+                                        {{translateString('COMPOSITONSORTVALUES',
+                                        catalogueRef.data.sortBy.name)}}
+                                    </button>
+                                    <ul ngbDropdownMenu aria-labelledby="sortBy" class="ps-2"
+                                        style="overflow-y: auto; max-height: 10rem; min-width:10rem">
+                                        <li *ngFor="let item of catalogueRef.sortByValues, let index = index;"
+                                            class="p-2 p-md-0">
+                                            <label style="cursor: pointer;"><input class="me-2" type="radio"
+                                                    name="sort-index" [checked]="(index === 0)"
+                                                    (change)="sortByValueChanged(item);sortByDrop.close()">{{translateString('COMPOSITONSORTVALUES',
+                                                item.name)}}</label>
+                                        </li>
+                                    </ul>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="text-align: center; vertical-align: middle;">
+                                    <button class="btn w-100 btn-light hs-background-alfa"
+                                        style="border-radius: 0.25rem;" (click)="clearFilters()">
+                                        {{'COMPOSITIONS.clearFilters' | translateHs : {app: data.app} }}</button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
-    <div class="tab-content">
-        <div class="card d-flex" style="font-size: 1rem !important;">
-            <div class="card-body">
-                <ul class="list-group">
-                    <li *ngFor="let composition of catalogueRef.compositionEntries" [hidden]="catalogueRef.dataLoading"
-                        class="list-group-item clearfix" style="cursor: pointer;"
-                        [ngClass]="{'hs-endpoint-item-active' : composition.highlighted}"
-                        (mouseover)="highlightComposition(composition, true)"
-                        (mouseleave)="highlightComposition(composition, false)"
-                        (click)="compositionClicked(composition)" data-container="body" data-placement="bottom"
-                        [attr.title]="composition.mdAbstract">
-                        <hs-compositions-list-item [composition]="composition" [app]="data.app"
-                            [selectedCompId]="selectedCompId">
-                        </hs-compositions-list-item>
-                    </li>
-                    <li class="list-group-item text-primary text-center py-2" *ngIf="catalogueRef.dataLoading"><span
-                            class="hs-loader hs-loader-dark pe-2"></span>&emsp;{{'COMMON.loading' |
-                        translateHs: {app: data.app} }}</li>
-                    <li [hidden]="catalogueRef.compositionEntries.length > 0 || catalogueRef.dataLoading"
-                        class="list-group-item">
-                        {{'DATASOURCE_SELECTOR.noResults' | translateHs : {app: data.app} }}</li>
-                </ul>
-            </div>
-            <ng-container *ngIf="catalogueRef.matchedRecords !== 0 && !catalogueRef.dataLoading">
-                <hs-pager [app]="data.app" [pagerService]="hsCompositionsCatalogueService"></hs-pager>
-            </ng-container>
+    <div class="card d-flex flex-fill border-bottom-0" style="font-size: 1rem !important; overflow-y:auto;     overflow-y: auto;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;">
+        <div class="card-body border-0">
+            <ul class="list-group">
+                <li *ngFor="let composition of catalogueRef.compositionEntries" [hidden]="catalogueRef.dataLoading"
+                    class="list-group-item clearfix" style="cursor: pointer;"
+                    [ngClass]="{'hs-endpoint-item-active' : composition.highlighted}"
+                    (mouseover)="highlightComposition(composition, true)"
+                    (mouseleave)="highlightComposition(composition, false)" (click)="compositionClicked(composition)"
+                    data-container="body" data-placement="bottom" [attr.title]="composition.mdAbstract">
+                    <hs-compositions-list-item [composition]="composition" [app]="data.app"
+                        [selectedCompId]="selectedCompId">
+                    </hs-compositions-list-item>
+                </li>
+                <li class="list-group-item text-primary text-center py-2" *ngIf="catalogueRef.dataLoading"><span
+                        class="hs-loader hs-loader-dark pe-2"></span>&emsp;{{'COMMON.loading' |
+                    translateHs: {app: data.app} }}</li>
+                <li [hidden]="catalogueRef.compositionEntries.length > 0 || catalogueRef.dataLoading"
+                    class="list-group-item">
+                    {{'DATASOURCE_SELECTOR.noResults' | translateHs : {app: data.app} }}</li>
+            </ul>
         </div>
     </div>
+    <ng-container *ngIf="catalogueRef.matchedRecords !== 0 && !catalogueRef.dataLoading">
+        <hs-pager class="sticky-bottom bg-white border border-top-0" [app]="data.app"
+            [pagerService]="hsCompositionsCatalogueService"></hs-pager>
+    </ng-container>
 </div>


### PR DESCRIPTION
## Description

Excess height of add-data and composition lists were triggering `extentChange` event (by changing map width when the scrollbar appeared)
Fixed by moving scroll deeper into DOM - now only panel content shrinks.

Compositions panel:
![compositions](https://user-images.githubusercontent.com/44566616/212316210-86fd533b-f4d1-4501-8efb-f3f090487e62.gif)


For add-data panel it was a bit different because of different DOM structure.  The issue is fixed, but scrolling behaviour of some of the elements is a bit different than expected I'd say (different from the composition panel at very least). 
I was not able to keep both add-data tabs (catalogue,URL,file) and catalogue header visible.. Its one or the other.

I chose the header because the other option affects not only catalogue but other tabs (for example when adding WMS layer, tabs would be visible when scrolling). Not that it would look bad its just change from what we have atm.
See examples below 
Tabs:
![adddata-tab](https://user-images.githubusercontent.com/44566616/212316738-7cb9a7e8-6a59-4036-9d0b-01504fff5dbb.gif)

Header:
![adddata-header](https://user-images.githubusercontent.com/44566616/212316780-317be6a1-2928-488d-8c94-4f4e65cc543c.gif)


## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
