### PR TITLE
fix: Wrong usage of nullish coalescing operator when trasforming WMS bbox

### DIFF
--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -335,7 +335,7 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
         preferred?.extent ??
         transformExtent(
           serviceLayer.BoundingBox[0].extent,
-          serviceLayer.BoundingBox[0].crs ?? crs, //Use BBOX object crs - when missing assume its same as layer's
+          serviceLayer.BoundingBox[0].crs || crs, //Use BBOX object crs - when missing assume its same as layer's
           this.hsMapService.getMap(app).getView().getProjection()
         );
     } else if (crs !== undefined) {


### PR DESCRIPTION
Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
