### PR TITLE
fix: Load external wfs layers without add layers panel

### DIFF
--- a/projects/hslayers/src/common/layers/hs.source.WfsSource.ts
+++ b/projects/hslayers/src/common/layers/hs.source.WfsSource.ts
@@ -48,14 +48,20 @@ export class WfsSource extends Vector<Geometry> {
         const srs = crs.toUpperCase();
 
         extent = transformExtent(extent, projection.getCode(), srs);
-        if (srs.includes('4326') || srs.includes('4258')) {
+        if (/*srs.includes('4326') || */ srs.includes('4258')) {
           extent = [extent[1], extent[0], extent[3], extent[2]];
         }
+        //https://gis.stackexchange.com/questions/30602/openlayers-wfs-flip-coordinates
+        //Do this, so feature coordinates would be in the right order. Without urn they aren't
+        //Can test with https://hub4everybody.com/geoserver/jan_vrobel/wfs
+        const srsWithUrn = srs.includes('urn')
+          ? srs
+          : 'urn:x-ogc:def:crs:' + srs;
         const params = {
           service: 'wfs',
           version: data_version, // == '2.0.0' ? '1.1.0' : data_version,
           request: 'GetFeature',
-          srsName: srs,
+          srsName: srsWithUrn,
           output_format: output_format,
           // count: layer.limitFeatureCount ? 1000 : '',
           BBOX: extent.join(',') + ',' + srs,

--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
@@ -436,7 +436,7 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
    */
   getLayer(layer, options: addLayerOptions, app: string): Layer<Source> {
     const appRef = this.get(app);
-    const new_layer = new VectorLayer({
+    const newLayer = new VectorLayer({
       properties: {
         name: options.layerName,
         title: layer.Title.replace(/\//g, '&#47;'),
@@ -467,7 +467,7 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
       renderOrder: null,
       //Used to determine whether its URL WFS service when saving to compositions
     });
-    return new_layer;
+    return newLayer;
   }
 
   /**

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -728,7 +728,10 @@ export class HsCompositionsParserService {
       case 'Vector':
       case 'hs.format.LaymanWfs':
         if (lyr_def.protocol?.format == 'hs.format.externalWFS') {
-          this.hsCompositionsLayerParserService.createWFSLayer(lyr_def, app);
+          resultLayer = this.hsCompositionsLayerParserService.createWFSLayer(
+            lyr_def,
+            app
+          );
         } else {
           resultLayer =
             await this.hsCompositionsLayerParserService.createVectorLayer(
@@ -748,7 +751,7 @@ export class HsCompositionsParserService {
         return;
     }
     if (resultLayer) {
-      resultLayer = await resultLayer; //createWMTSLayer returns Promise which need to be resolved first
+      resultLayer = await resultLayer; //createWMTSLayer returns Promise which needs to be resolved first
       setMetadata(resultLayer, lyr_def.metadata);
       setSwipeSide(resultLayer, lyr_def.swipeSide);
     }


### PR DESCRIPTION
## Description
HsCompositionsParserService.jsonToLayer doesnt return a layer when lyr_def.protocol?.format == 'hs.format.externalWFS' is used. This prevents external WFS layers in whiteboard (they are handled like oridinary vector layers by mw library, not haslayers instead)
This is fixed in this PR by utilizing common/layers/hs.source.WfsSource

Had problems with SRS because corrdinate pairs where switched in BBOX and in GML response. Tried to fix it for EPSG:4326, but special case for 4258 still remains 

```
if (/*srs.includes('4326') || */ srs.includes('4258')) {
```
Need to check that

This also supports a new `version` attribute in the composition schema which specifies VERSION param used in WFS requests:
```
"protocol":{
                    "url":"https://hub4everybody.com/geoserver/jan_vrobel/wfs",
                    "format":"hs.format.externalWFS",
                    "version": "2.0.0"
                },
```



## Related issues or pull requests

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
