### PR TITLE
Pass on created WFS layer

### DIFF
--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -382,7 +382,7 @@ export class HsCompositionsParserService {
       }
     }
 
-    //CSW serviceType compostitions
+    //CSW serviceType compositions
     const layers = await this.jsonToLayers(obj, app);
 
     const confirmed = obj.services
@@ -734,7 +734,11 @@ export class HsCompositionsParserService {
       case 'Vector':
       case 'hs.format.LaymanWfs':
         if (lyr_def.protocol?.format == 'hs.format.externalWFS') {
-          this.hsCompositionsLayerParserService.createWFSLayer(lyr_def, app);
+          resultLayer =
+            await this.hsCompositionsLayerParserService.createWFSLayer(
+              lyr_def,
+              app
+            );
         } else {
           resultLayer =
             await this.hsCompositionsLayerParserService.createVectorLayer(
@@ -754,7 +758,7 @@ export class HsCompositionsParserService {
         return;
     }
     if (resultLayer) {
-      resultLayer = await resultLayer; //createWMTSLayer returns Promise which need to be resolved first
+      resultLayer = await resultLayer; //createWMTSLayer returns Promise which needs to be resolved first
       setMetadata(resultLayer, lyr_def.metadata);
       setSwipeSide(resultLayer, lyr_def.swipeSide);
     }

--- a/projects/hslayers/src/components/compositions/schema.json
+++ b/projects/hslayers/src/components/compositions/schema.json
@@ -317,7 +317,7 @@
                   "hs.format.externalWFS",
                   "hs.format.Sparql"
                 ],
-                "title": "Layer procol format"
+                "title": "Layer protocol format"
               },
               "url": {
                 "$id": "#/properties/layers/items/properties/protocol/properties/url",


### PR DESCRIPTION
------------

## Description

Created WFS layer was not passed on to the rest of the code (missing variable assignment).
Additionally, the createWFSLayer() method was returning an array (de facto always 1-length), instead of a single item, as expected.

## Related issues or pull requests

resolves #3817

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
