### PR TITLE
Raster timeseries

### DIFF
--- a/cypress/tests/add-data.cy.ts
+++ b/cypress/tests/add-data.cy.ts
@@ -23,7 +23,7 @@ describe('Hslayers application', () => {
 
     //it('Wms capabilities should be retrieved', () => {
     cy.get(`hs-url-wms hs-common-url input`).type(
-      'https://hub.lesprojekt.cz/geoserver/leitnerfilip_wms/ows'
+      'https://watlas.lesprojekt.cz/geoserver/filip_wms/ows'
     );
     cy.get(`hs-url-wms hs-common-url input + button`).click();
     cy.wait(1000);

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -40,7 +40,7 @@
       "highlightAndSelect": "Označte a vyberte časovou značku v názvu",
       "inferredRegex": "Odvozený regulární výraz",
       "selectedString": "Vybraný řetězec",
-      "verifyInferredRegex": "Před pokračováním ověřte odvozený regulární výraz"
+      "verifyInferredRegex": "Před pokračováním ověřte a potvrďte odvozený regulární výraz"
     },
     "requestServiceLayers": "Vyžádat vrstvy",
     "saveToCatalogue": "Uložit do katalogu",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -123,7 +123,6 @@
     "useTiles": "Použít dlaždice",
     "Vector": {
       "addingFiles": "Přidávání {{featuresCount}} prvku do:",
-      "addSld": "Přidat soubor SLD/QML",
       "chooseFiles": "Vyberte soubory...",
       "chooseLayer": "Vyberte prosím vrstvu ze seznamu ...",
       "dragAndDropFiles": "Přetáhněte soubory",
@@ -150,7 +149,10 @@
       "pickIdParamPt1": "Která proměnná obsahuje",
       "pickIdParamName": "unikátní identifikátor",
       "pickIdParamPt2": "dotazovaných prvků?"
-    }
+    },
+    "addsld": "Přidat soubor SLD",
+    "addqml": "Přidat soubor QML",
+    "addsldqml": "Přidat soubor SLD/QML"
   },
   "COMMON": {
     "abstract": "Abstrakt",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -36,7 +36,11 @@
     "FILE": {
       "onlyOneZipFileCan": "Lze nahrát pouze jeden soubor ZIP najednou",
       "someOfTheUploadedFiles": "Nahrávaný soubor přesahuje maximální povolenou velikost 20MB",
-      "zipFileCannotBeUploaded": "Soubor archivu nemůže být nahrát současně s běžnými soubory"
+      "zipFileCannotBeUploaded": "Soubor archivu nemůže být nahrát současně s běžnými soubory",
+      "highlightAndSelect": "Označte a vyberte časovou značku v názvu",
+      "inferredRegex": "Odvozený regulární výraz",
+      "selectedString": "Vybraný řetězec",
+      "verifyInferredRegex": "Před pokračováním ověřte odvozený regulární výraz"
     },
     "requestServiceLayers": "Vyžádat vrstvy",
     "saveToCatalogue": "Uložit do katalogu",
@@ -86,6 +90,7 @@
     "OlDoesNotRecognizeProjection": "OL nezná požadované kartografické zobrazení vrstvy",
     "queryFormat": "Formát dotazu",
     "Raster image": "Rastrový snímek",
+    "Raster time series": "Časová řada snímků",
     "rasterImageryWith": "Georeferencované rastrové snímky jsou v současnosti podporované pouze v souřadnicových systémech EPSG:4326 a EPSG:3857. Prosím, ujistěte se před nahráním, že vaše data splňují tyto požadavky.",
     "registerMetadata": "Registrovat metadata",
     "resampleLayer": "Převzorkovat vrstvu",
@@ -290,7 +295,9 @@
     "wrongCombinationOfParams": "Neplatná kombinace parametrů",
     "yes": "Ano",
     "zoomTo": "zvětšit na",
-    "composition": "Kompozice"
+    "composition": "Kompozice",
+    "select": "Vybrat",
+    "verify": "Ověřit"
   },
   "COMPOSITIONS": {
     "addByAddress": "Přidat kompozici z adresy",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -36,7 +36,11 @@
     "FILE": {
       "onlyOneZipFileCan": "Only one zip file can be uploaded at once",
       "someOfTheUploadedFiles": "Uploaded file exceeded maximum allowed size of 20MB",
-      "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files"
+      "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files",
+      "highlightAndSelect": "Highlight and select timestamp in title",
+      "selectedString": "Selected string",
+      "inferedRegex": "Infered regex pattern",
+      "verifyInferedRegex": "Verify infered datetime regex pattern before you continue"
     },
     "loadAs": "When uploaded, load layer as ...",
     "requestServiceLayers": "Request service layers",
@@ -290,7 +294,9 @@
     "reading": "Reading data",
     "unsavedChanges": "Unsaved changes",
     "return": "Return",
-    "composition": "Composition"
+    "composition": "Composition",
+    "select": "Select",
+    "verify": "Verify"
   },
   "COMPOSITIONS": {
     "addByAddress": "Add composition by address",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -40,7 +40,7 @@
       "highlightAndSelect": "Highlight and select timestamp in title",
       "selectedString": "Selected string",
       "inferredRegex": "Inferred regex pattern",
-      "verifyInferredRegex": "Verify inferred datetime regex pattern before you continue"
+      "verifyInferredRegex": "Please review and confirm the datetime format before proceeding"
     },
     "loadAs": "When uploaded, load layer as ...",
     "requestServiceLayers": "Request service layers",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -133,7 +133,6 @@
     "useTiles": "Use tiles",
     "Vector": {
       "addingFiles": "Adding {{featuresCount}} features into:",
-      "addSld": "Add SLD/QML file",
       "chooseFiles": "Choose files...",
       "chooseLayer": "Please, choose a layer from list...",
       "dragAndDropFiles": "Drag and drop files",
@@ -150,7 +149,10 @@
     },
     "WMTS": {
       "tileMatrix": "Tile matrix"
-    }
+    },
+    "addsld": "Add SLD file",
+    "addqml": "Add QML file",
+    "addsldqml": "Add SLD/QML file"
   },
   "COMMON": {
     "abstract": "Abstract",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -39,8 +39,8 @@
       "zipFileCannotBeUploaded": "Archive file cannot be uploaded together with regular files",
       "highlightAndSelect": "Highlight and select timestamp in title",
       "selectedString": "Selected string",
-      "inferedRegex": "Infered regex pattern",
-      "verifyInferedRegex": "Verify infered datetime regex pattern before you continue"
+      "inferredRegex": "Inferred regex pattern",
+      "verifyInferredRegex": "Verify inferred datetime regex pattern before you continue"
     },
     "loadAs": "When uploaded, load layer as ...",
     "requestServiceLayers": "Request service layers",
@@ -100,6 +100,7 @@
     "OlDoesNotRecognizeProjection": "OL does not recognize requested layers projection",
     "queryFormat": "Query format",
     "Raster image": "Raster image",
+    "Raster time series": "Raster time series",
     "rasterImageryWith": "Raster imagery with georeferencing is currently only supported on EPSG:4326 and EPSG:3857 coordinate systems. Please make sure your data meets these requirements before uploading.",
     "registerMetadata": "Register metadata",
     "resampleLayer": "Resample layer",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -118,7 +118,6 @@
     "useTiles": "Izmantojiet \"flīzes\"",
     "Vector": {
       "addingFiles": "Pievienot {{featuresCount}} grafiskos objektus iekš",
-      "addSld": "Pievienot SLD/QML failu",
       "chooseFiles": "Izvēlieties failus...",
       "chooseLayer": "Lūdzu, izvēlieties slāni no saraksta...",
       "dragAndDropFiles": "Velciet un nometiet failus",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -36,7 +36,10 @@
     "FILE": {
       "onlyOneZipFileCan": "Súbory ZIP je možné nahrávať len po jednom",
       "someOfTheUploadedFiles": "Nahrávaný súbor prekročil maximálnu povolenú veľkosť 20MB",
-      "zipFileCannotBeUploaded": "Súbor archívu nie je možné nahrať spolu s bežnými súbormi"
+      "zipFileCannotBeUploaded": "Súbor archívu nie je možné nahrať spolu s bežnými súbormi",
+      "highlightAndSelect": "Vyznačte a vyberte ",
+      "inferedRegex": "Odvodený regulárny výraz",
+      "verifyInferedRegex": "Pred pokračovaním overte odvodený regulárny výraz"
     },
     "requestServiceLayers": "Vyžiadať vrstvy služby",
     "saveToCatalogue": "Uložit do katalógu",
@@ -290,7 +293,9 @@
     "unsavedChanges": "Neuložené zmeny",
     "return": "Vrátiť sa",
     "query": "Dotaz",
-    "composition": "Kompozícia"
+    "composition": "Kompozícia",
+    "select": "Vybrať",
+    "verify": "Overiť"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pridať kompozíciu z adresy",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -39,7 +39,8 @@
       "zipFileCannotBeUploaded": "Súbor archívu nie je možné nahrať spolu s bežnými súbormi",
       "highlightAndSelect": "Vyznačte a vyberte ",
       "inferredRegex": "Odvodený regulárny výraz",
-      "verifyInferredRegex": "Pred pokračovaním overte odvodený regulárny výraz"
+      "verifyInferredRegex": "Pred pokračovaním overte odvodený regulárny výraz",
+      "selectedString": "Vybraný reťazec"
     },
     "requestServiceLayers": "Vyžiadať vrstvy služby",
     "saveToCatalogue": "Uložit do katalógu",
@@ -148,7 +149,8 @@
       "pickIdParamName": "unikátny identifikátor",
       "pickIdParamPt1": "Ktorá premenná obsahuje",
       "pickIdParamPt2": "z dopytovaných prvkov?"
-    }
+    },
+    "Raster time series": "Časová rada snímkov"
   },
   "COMMON": {
     "abstract": "Abstrakt",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -38,8 +38,8 @@
       "someOfTheUploadedFiles": "Nahrávaný súbor prekročil maximálnu povolenú veľkosť 20MB",
       "zipFileCannotBeUploaded": "Súbor archívu nie je možné nahrať spolu s bežnými súbormi",
       "highlightAndSelect": "Vyznačte a vyberte ",
-      "inferedRegex": "Odvodený regulárny výraz",
-      "verifyInferedRegex": "Pred pokračovaním overte odvodený regulárny výraz"
+      "inferredRegex": "Odvodený regulárny výraz",
+      "verifyInferredRegex": "Pred pokračovaním overte odvodený regulárny výraz"
     },
     "requestServiceLayers": "Vyžiadať vrstvy služby",
     "saveToCatalogue": "Uložit do katalógu",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -122,7 +122,6 @@
     "useTiles": "Použíť dlaždice",
     "Vector": {
       "addingFiles": "Pridávanie {{featuresCount}} prvkov do:",
-      "addSld": "Pridať súbor SLD/QML",
       "chooseFiles": "Vyberte súbory...",
       "chooseLayer": "Vyberte vrstvu zo zoznamu ...",
       "dragAndDropFiles": "Pretiahnite súbory",
@@ -150,7 +149,10 @@
       "pickIdParamPt1": "Ktorá premenná obsahuje",
       "pickIdParamPt2": "z dopytovaných prvkov?"
     },
-    "Raster time series": "Časová rada snímkov"
+    "Raster time series": "Časová rada snímkov",
+    "addsld": "Pridať súbor SLD",
+    "addqml": "Pridať súbor QML",
+    "addsldqml": "Pridať súbor SLD/QML"
   },
   "COMMON": {
     "abstract": "Abstrakt",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -39,7 +39,7 @@
       "zipFileCannotBeUploaded": "Súbor archívu nie je možné nahrať spolu s bežnými súbormi",
       "highlightAndSelect": "Vyznačte a vyberte ",
       "inferredRegex": "Odvodený regulárny výraz",
-      "verifyInferredRegex": "Pred pokračovaním overte odvodený regulárny výraz",
+      "verifyInferredRegex": "Pred pokračovaním overte a potvrďte odvodený regulárny výraz",
       "selectedString": "Vybraný reťazec"
     },
     "requestServiceLayers": "Vyžiadať vrstvy služby",

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
@@ -6,9 +6,9 @@
     <i class="icon-plus" [hidden]="commonFileServiceRef.loadingToLayman"></i>
     <span class="hs-loader" [hidden]="!commonFileServiceRef.loadingToLayman"></span>
     <span [hidden]="commonFileServiceRef.loadingToLayman">{{'COMMON.add' | translateHs : {app} }}</span>
-    <span *ngIf="commonFileServiceRef.loadingToLayman && commonFileServiceRef.asyncLoading">{{'COMMON.uploading' |
+    <span *ngIf="commonFileServiceRef.loadingToLayman && commonFileServiceRef.asyncLoading">&emsp;{{'COMMON.uploading' |
       translateHs : {app} }}</span>
-    <span *ngIf="commonFileServiceRef.loadingToLayman && commonFileServiceRef.readingData">{{'COMMON.reading' |
+    <span *ngIf="commonFileServiceRef.loadingToLayman && commonFileServiceRef.readingData">&emsp;{{'COMMON.reading' |
       translateHs : {app} }}</span>
     <ngb-progressbar
       *ngIf="commonFileServiceRef.loadingToLayman && (commonFileServiceRef.asyncLoading || commonFileServiceRef.readingData)"

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
@@ -1,8 +1,8 @@
 <div class="w-100 mt-2" style="display: inline-block;" data-toggle="tooltip" data-placement="top"
   [title]="hsAddDataCommonFileService.getToolTipText(data, app)">
   <!-- TODO: Remove function call from template -->
-  <button *ngIf="hsAddDataCommonFileService.isAuthorized()" class="btn btn-primary w-100"
-    [disabled]="!data.name || !data.srs" (click)="add()">
+  <button *ngIf="hsAddDataCommonFileService.isAuthorized()" class="btn btn-primary w-100" [disabled]="!canAdd()"
+    (click)="add()">
     <i class="icon-plus" [hidden]="commonFileServiceRef.loadingToLayman"></i>
     <span class="hs-loader" [hidden]="!commonFileServiceRef.loadingToLayman"></span>
     <span [hidden]="commonFileServiceRef.loadingToLayman">{{'COMMON.add' | translateHs : {app} }}</span>

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.ts
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.ts
@@ -33,4 +33,14 @@ export class HsAddLayerAuthorizedComponent implements OnInit {
   async add(): Promise<void> {
     await this.hsAddDataCommonFileService.addAsService(this.data, this.app);
   }
+
+  private hasNameAndSrs() {
+    return this.data.name && this.data.srs;
+  }
+
+  canAdd() {
+    return this.data.type == 'raster-ts'
+      ? this.hasNameAndSrs() && this.data.timeRegex
+      : this.hasNameAndSrs();
+  }
 }

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -588,6 +588,8 @@ export class HsAddDataCommonFileService {
       response.name
     );
     if (descriptor?.file.error) {
+      const error = descriptor.file.error;
+      const msg = error?.detail.message ?? error.message;
       this.hsToastService.createToastPopupMessage(
         this.hsLanguageService.getTranslation(
           'ADDLAYERS.ERROR.someErrorHappened',
@@ -596,7 +598,7 @@ export class HsAddDataCommonFileService {
         ),
         this.hsLanguageService.getTranslationIgnoreNonExisting(
           'LAYMAN.ERROR',
-          descriptor.file.error.code.toString(),
+          msg ?? descriptor.file.error.code.toString(),
           undefined,
           app
         ),

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -364,7 +364,7 @@ export class HsAddDataCommonFileService {
     app: string
   ): Promise<FormData> {
     this.get(app).readingData = true;
-    const {files, name, abstract, srs, access_rights, timeRegex, format} =
+    const {files, name, abstract, srs, access_rights, timeRegex} =
       formDataParams;
     const sld = formDataParams.serializedStyle;
     const formData = new FormData();
@@ -398,9 +398,6 @@ export class HsAddDataCommonFileService {
     }
     if (timeRegex) {
       formData.append('time_regex', timeRegex);
-    }
-    if (format) {
-      formData.append('format', format);
     }
     formData.append('name', name);
     const title = formDataParams.title == '' ? name : formDataParams.title;
@@ -468,7 +465,6 @@ export class HsAddDataCommonFileService {
             serializedStyle: data.serializedStyle,
             access_rights: data.access_rights,
             timeRegex: data.timeRegex,
-            format: data.format,
           },
           app,
           options?.overwrite

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -32,11 +32,13 @@
     <div class="d-flex justify-content-between align-items-center">
       <p class="ps-4">{{'ADDLAYERS.SHP.SLDStyleFile' | translateHs : {app} }}</p>
       <label class="dropzone-label">
-        <input name="file" type="file" accept=".sld, .qml" class="inputfile"
+        <input name="file" type="file" [accept]="allowedStyles.list" class="inputfile"
           (change)="read({fileList: $event.target.files, uploader: 'style', dropped: false})" id="style">
         <label for="style" class="p-2 rounded" style="font-size: 1em;"
           [ngClass]="data.serializedStyle ? 'bg-success' : 'bg-primary'">
-          <i class="icon-uploadalt p-2"></i>{{data.serializedStyle?.name ?? 'ADDLAYERS.Vector.addSld' | translateHs :
+          <i class="icon-uploadalt p-2"></i>{{data.serializedStyle?.name ?? allowedStyles.title |
+          translateHs
+          :
           {app} }}</label>
       </label>
     </div>
@@ -49,5 +51,3 @@
   <ng-container *ngIf="advancedPanelVisible">
     <hs-advanced-options [data]="data" [app]="app"></hs-advanced-options>
   </ng-container>
-
-</div>

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -1,10 +1,5 @@
 <div>
 
-  <div *ngIf="data.type.includes('raster')"
-    class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
-    <p class="m-0"> {{'ADDLAYERS.rasterImageryWith' | translateHs : {app} }}</p>
-  </div>
-
   <div class="form-floating mb-3">
     <input [placeholder]="'ADDDATA.URL.submitLayerName' | translateHs : {app} " class="form-control" name="name"
       [(ngModel)]="data.name" (ngModelChange)="data.title = data.name" />
@@ -18,7 +13,10 @@
     <label for="absctract" class="capabilities_label control-label">{{'COMMON.abstract' | translateHs : {app} }}</label>
 
   </div>
-
+  <div *ngIf="data.type.includes('raster')"
+    class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
+    <p class="m-0"> {{'ADDLAYERS.rasterImageryWith' | translateHs : {app} }}</p>
+  </div>
   <div class="d-flex w-100 flex-column">
     <div class="form-floating" *ngIf="data.type === 'shp' || data.type.includes('raster')">
       <select class="form-select rounded-0" id="hs-add-data-crs" [(ngModel)]="data.srs" name="srs"

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -28,7 +28,7 @@
     <!-- TODO: Remove function call from template -->
     <hs-save-to-layman [data]="data" [app]="app"></hs-save-to-layman>
   </ng-container>
-  <ng-container *ngIf="data.type === 'shp' || data.type === 'raster' || data.type === 'geojson'">
+  <ng-container *ngIf="data.type === 'shp' || data.type.includes('raster') || data.type === 'geojson'">
     <div class="d-flex justify-content-between align-items-center">
       <p class="ps-4">{{'ADDLAYERS.SHP.SLDStyleFile' | translateHs : {app} }}</p>
       <label class="dropzone-label">

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -1,7 +1,5 @@
 <div>
 
-  <p [hidden]="data?.srs"><sub class="text-danger">{{'ADDLAYERS.Vector.note' | translateHs : {app} }}</sub></p>
-
   <div *ngIf="data.type === 'raster'"
     class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
     <p class="m-0"> {{'ADDLAYERS.rasterImageryWith' | translateHs : {app} }}</p>
@@ -20,7 +18,7 @@
     <label for="absctract" class="capabilities_label control-label">{{'COMMON.abstract' | translateHs : {app} }}</label>
 
   </div>
-  <div class="form-group" *ngIf="data.type === 'shp' || data.type === 'raster'">
+  <div class="form-group" *ngIf="data.type === 'shp' || data.type.includes('raster')">
     <div class="input-group">
       <span class="input-group-text control-label">{{'ADDLAYERS.srs' | translateHs : {app} }}</span>
       <select class="form-control form-select" [(ngModel)]="data.srs" name="srs">
@@ -30,6 +28,7 @@
       </select>
     </div>
   </div>
+  <p [hidden]="data?.srs"><sub class="text-danger">{{'ADDLAYERS.Vector.note' | translateHs : {app} }}</sub></p>
 
   <ng-container *ngIf="hsAddDataCommonFileService.isAuthorized() && data.saveAvailable">
     <!-- TODO: Remove function call from template -->
@@ -41,8 +40,10 @@
       <label class="dropzone-label">
         <input name="file" type="file" accept=".sld, .qml" class="inputfile"
           (change)="read({fileList: $event.target.files, uploader: 'style', dropped: false})" id="style">
-        <label for="style" class="p-2 rounded" style="font-size: 1em;" [ngClass]="data.serializedStyle ? 'bg-success' : 'bg-primary'">
-          <i class="icon-uploadalt p-2"></i>{{data.serializedStyle?.name ?? 'ADDLAYERS.Vector.addSld' | translateHs : {app} }}</label>
+        <label for="style" class="p-2 rounded" style="font-size: 1em;"
+          [ngClass]="data.serializedStyle ? 'bg-success' : 'bg-primary'">
+          <i class="icon-uploadalt p-2"></i>{{data.serializedStyle?.name ?? 'ADDLAYERS.Vector.addSld' | translateHs :
+          {app} }}</label>
       </label>
     </div>
   </ng-container>

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -13,15 +13,11 @@
     <label for="absctract" class="capabilities_label control-label">{{'COMMON.abstract' | translateHs : {app} }}</label>
 
   </div>
-  <div *ngIf="data.type.includes('raster')"
-    class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
-    <p class="m-0"> {{'ADDLAYERS.rasterImageryWith' | translateHs : {app} }}</p>
-  </div>
   <div class="d-flex w-100 flex-column">
     <div class="form-floating" *ngIf="data.type === 'shp' || data.type.includes('raster')">
       <select class="form-select rounded-0" id="hs-add-data-crs" [(ngModel)]="data.srs" name="srs"
         [ngClass]="data?.srs ? 'is-valid mb-2' : 'is-invalid'" aria-label="CRS floating label select">
-        <option *ngFor="let epsg of hsLaymanService.supportedCRRList | filter: srsFilter" [ngValue]="epsg">{{epsg}}
+        <option *ngFor="let epsg of hsLaymanService.supportedCRRList" [ngValue]="epsg">{{epsg}}
       </select>
       <label for="hs-add-data-crs">{{'ADDLAYERS.srs' | translateHs : {app} }}</label>
     </div>

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -1,6 +1,6 @@
 <div>
 
-  <div *ngIf="data.type === 'raster'"
+  <div *ngIf="data.type.includes('raster')"
     class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">
     <p class="m-0"> {{'ADDLAYERS.rasterImageryWith' | translateHs : {app} }}</p>
   </div>

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.html
@@ -18,14 +18,14 @@
     <label for="absctract" class="capabilities_label control-label">{{'COMMON.abstract' | translateHs : {app} }}</label>
 
   </div>
-  <div class="form-group" *ngIf="data.type === 'shp' || data.type.includes('raster')">
-    <div class="input-group">
-      <span class="input-group-text control-label">{{'ADDLAYERS.srs' | translateHs : {app} }}</span>
-      <select class="form-control form-select" [(ngModel)]="data.srs" name="srs">
-        <option [ngValue]="null" disabled selected hidden>{{'ADDLAYERS.SRSRequired' | translateHs : {app} }}</option>
+
+  <div class="d-flex w-100 flex-column">
+    <div class="form-floating" *ngIf="data.type === 'shp' || data.type.includes('raster')">
+      <select class="form-select rounded-0" id="hs-add-data-crs" [(ngModel)]="data.srs" name="srs"
+        [ngClass]="data?.srs ? 'is-valid mb-2' : 'is-invalid'" aria-label="CRS floating label select">
         <option *ngFor="let epsg of hsLaymanService.supportedCRRList | filter: srsFilter" [ngValue]="epsg">{{epsg}}
-        </option>
       </select>
+      <label for="hs-add-data-crs">{{'ADDLAYERS.srs' | translateHs : {app} }}</label>
     </div>
   </div>
   <p [hidden]="data?.srs"><sub class="text-danger">{{'ADDLAYERS.Vector.note' | translateHs : {app} }}</sub></p>

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.ts
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.ts
@@ -29,7 +29,7 @@ export class HsNewLayerFormComponent implements OnInit {
 
   ngOnInit() {
     this.appRef = this.hsAddDataCommonFileService.get(this.app);
-    if (this.data.type === 'raster') {
+    if (this.data.type.includes('raster')) {
       this.srsFilter = (item): boolean => {
         return ['4326', '3857'].some((epsg) => item.includes(epsg));
       };

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.ts
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.ts
@@ -18,9 +18,6 @@ export class HsNewLayerFormComponent implements OnInit {
   @Input() data: FileDataObject;
   @Input() app = 'default';
   appRef: HsAddDataCommonFileServiceParams;
-  srsFilter = (srs: string): boolean => {
-    return true;
-  };
   constructor(
     public hsAddDataCommonFileService: HsAddDataCommonFileService,
     private hsFileService: HsFileService,
@@ -29,11 +26,6 @@ export class HsNewLayerFormComponent implements OnInit {
 
   ngOnInit() {
     this.appRef = this.hsAddDataCommonFileService.get(this.app);
-    if (this.data.type.includes('raster')) {
-      this.srsFilter = (item): boolean => {
-        return ['4326', '3857'].some((epsg) => item.includes(epsg));
-      };
-    }
   }
 
   async read(evt: HsUploadedFiles): Promise<void> {

--- a/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.ts
+++ b/projects/hslayers/src/components/add-data/common/new-layer-form/new-layer-form.component.ts
@@ -18,6 +18,10 @@ export class HsNewLayerFormComponent implements OnInit {
   @Input() data: FileDataObject;
   @Input() app = 'default';
   appRef: HsAddDataCommonFileServiceParams;
+  allowedStyles: {
+    list: string;
+    title: string;
+  };
   constructor(
     public hsAddDataCommonFileService: HsAddDataCommonFileService,
     private hsFileService: HsFileService,
@@ -26,6 +30,13 @@ export class HsNewLayerFormComponent implements OnInit {
 
   ngOnInit() {
     this.appRef = this.hsAddDataCommonFileService.get(this.app);
+    this.allowedStyles = {
+      list:
+        this.data.allowedStyles.length > 3
+          ? '.sld, .qml'
+          : `.${this.data.allowedStyles}`,
+      title: `ADDLAYERS.add${this.data.allowedStyles}`,
+    };
   }
 
   async read(evt: HsUploadedFiles): Promise<void> {

--- a/projects/hslayers/src/components/add-data/file/file-base.component.ts
+++ b/projects/hslayers/src/components/add-data/file/file-base.component.ts
@@ -95,7 +95,7 @@ export class HsAddDataFileBaseComponent
       saveAvailable: true,
       saveToLayman: true,
       serializedStyle: null,
-      srs: null,
+      srs: undefined,
       title: '',
       type: this.baseFileType,
     };

--- a/projects/hslayers/src/components/add-data/file/file-base.component.ts
+++ b/projects/hslayers/src/components/add-data/file/file-base.component.ts
@@ -98,6 +98,7 @@ export class HsAddDataFileBaseComponent
       srs: undefined,
       title: '',
       type: this.baseFileType,
+      allowedStyles: 'sldqml',
     };
     this.hsAddDataCommonFileService.clearParams(this.app);
     this.hsAddDataCommonService.clearParams(this.app);

--- a/projects/hslayers/src/components/add-data/file/file-type-values.ts
+++ b/projects/hslayers/src/components/add-data/file/file-type-values.ts
@@ -21,4 +21,8 @@ export const AddDataFileValues: Array<{id: AddDataFileType; text: string}> = [
     id: 'raster',
     text: 'Raster image',
   },
+  {
+    id: 'raster-ts',
+    text: 'Raster time series',
+  },
 ];

--- a/projects/hslayers/src/components/add-data/file/file.component.html
+++ b/projects/hslayers/src/components/add-data/file/file.component.html
@@ -13,6 +13,7 @@
         <hs-file-vector [fileType]="typeSelected" *ngIf="typeSelected === 'gpx'" [app]="app"></hs-file-vector>
         <hs-file-vector [fileType]="typeSelected" *ngIf="typeSelected === 'kml'" [app]="app"></hs-file-vector>
         <hs-file-shp *ngIf="typeSelected === 'shp'" [app]="app"></hs-file-shp>
-        <hs-file-raster *ngIf="typeSelected === 'raster'" [app]="app"></hs-file-raster>
+        <hs-file-raster [fileType]="typeSelected" *ngIf="typeSelected === 'raster'" [app]="app"></hs-file-raster>
+        <hs-file-raster [fileType]="typeSelected" *ngIf="typeSelected === 'raster-ts'" [app]="app"></hs-file-raster>
     </div>
 </div>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -1,13 +1,12 @@
 <div class="d-flex flex-column justify-content-between w-100 pb-2">
-    <div class="d-flex w-100 input-group">
-        <form class="form-floating  flex-fill">
-            <input #hsTimeseriesTitle readonly type="text" class="form-control form-control-sm" id="hs-timeseries-title"
+    <div class="d-flex w-100 flex-column">
+        <form class="input-group">
+            <input #hsTimeseriesTitle readonly type="text" class="form-control" id="hs-timeseries-title"
                 [value]="fileTitle" [ngClass]="{'is-invalid': !selectedString}">
-            <label for="hs-timeseries-title" [ngClass]="{'text-danger': !selectedString}">Highlight
-                timestamp in title</label>
+            <button type="button" (click)="selectDateString($event)" class="btn btn-sm btn-primary">Select</button>
         </form>
-
-        <button type="button" (click)="selectDateString($event)" class="btn btn-sm btn-primary">Select</button>
+        <label for="hs-timeseries-title" class="text-danger small" [hidden]="selectedString">Highlight
+            and select timestamp in title</label>
     </div>
 
     <ngb-accordion #acc="ngbAccordion" class="my-2" [hidden]="!formVisible" activeIds="hs-timeseries-acc">

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -10,27 +10,20 @@
     </div>
 
     <ngb-accordion #acc="ngbAccordion" class="my-2" [hidden]="!formVisible" activeIds="hs-timeseries-acc">
-        <ngb-panel id="hs-timeseries-acc" title="Infered params">
+        <ngb-panel id="hs-timeseries-acc">
+            <ng-template ngbPanelHeader let-opened="opened">
+                <button ngbPanelToggle class="accordion-button text-black-50">Selected string: <span
+                        class="text-black ps-1">{{selectedString}}</span></button>
+            </ng-template>
             <ng-template ngbPanelContent>
-                <form [formGroup]="form" class="d-flex flex-column">
-                    <div class="text-black-50">
-                        Selected string: <span class="text-black">{{selectedString}}</span>
+                <form [formGroup]="form" class="d-flex flex-column ">
+                    <div class="form-floating mt-2 flex-fill"
+                        [ngClass]="{'verification-pending': !form.get('verified').value}">
+                        <input formControlName="regex" type="text" class="form-control form-control-sm"
+                            id="hs-timeseries-regex" [ngClass]="{'is-valid': form.get('verified').value}">
+                        <label for="hs-timeseries-regex">Infered regex pattern</label>
                     </div>
-                    <div class="d-flex flex-column justify-content-between flex-md-row gap-2">
-                        <div class="form-floating mt-2 flex-fill"
-                            [ngClass]="{'verification-pending': !form.get('verified').value}">
-                            <input formControlName="regex" type="text" class="form-control form-control-sm"
-                                id="hs-timeseries-regex">
-                            <label for="hs-timeseries-regex">Infered regex pattern</label>
-                        </div>
-                        <div class="form-floating mt-2 flex-fill"
-                            [ngClass]="{'verification-pending': !form.get('verified').value}">
-                            <input formControlName="format" type="text" class="form-control form-control-sm"
-                                id="hs-timeseries-format">
-                            <label for="hs-timeseries-format">Infered date format</label>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-baseline justify-content-end" *ngIf="!form.get('verified').value">
+                    <div class="d-flex justify-content-between">
                         <p class="text-black-50 small">Verify infered values before you continue</p>
                         <button type="button" (click)="verifyInputs()"
                             class="btn btn-sm btn-primary m-2 w-25">Verify</button>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -30,7 +30,7 @@
                         <p class="text-black-50 small pt-1">{{'ADDDATA.FILE.verifyInferredRegex' |
                             translateHs: {app} }}</p>
                         <button type="button" (click)="verifyInputs()"
-                            class="btn btn-sm btn-primary m-2 w-25">{{'COMMON.verify' |
+                            class="btn btn-sm btn-primary m-2 w-25">{{'COMMON.confirm' |
                             translateHs: {app} }}</button>
                     </div>
                 </form>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -1,0 +1,37 @@
+<div>
+    <div class="d-flex flex-column justify-content-between w-100">
+        <div class="d-flex w-100 input-group">
+            <form class="form-floating  flex-fill">
+                <input #hsTimeseriesTitle readonly type="text" class="form-control form-control-sm is-invalid"
+                    id="hs-timeseries-title" [value]="fileTitle">
+                <label for="hs-timeseries-title">Highlight timestamp in title</label>
+            </form>
+
+            <button type="button" (click)="getSelectedString($event)" class="btn btn-sm btn-primary">Select</button>
+        </div>
+
+        <ngb-accordion #acc="ngbAccordion" class="my-2">
+            <ngb-panel id="toggle-1" title="Infered params">
+                <ng-template ngbPanelContent>
+                    <div class="d-flex flex-column">
+                        <div>
+                            Selected string: {{selectedString}}
+                        </div>
+                        <div class="d-flex flex-column justify-content-between flex-md-row gap-2">
+                            <div class="form-floating mt-2 flex-fill">
+                                <input required type="text" class="form-control form-control-sm"
+                                    id="hs-timeseries-regex" value="[0-9]{4}[0-9]{2}[0-9]{2}">
+                                <label for="hs-timeseries-regex">Infered regex pattern</label>
+                            </div>
+                            <div class="form-floating mt-2 flex-fill">
+                                <input required type="email" class="form-control form-control-sm"
+                                    id="hs-timeseries-format" value="yyyy_mm_dd">
+                                <label for="hs-timeseries-format">Infered date format</label>
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+            </ngb-panel>
+        </ngb-accordion>
+    </div>
+</div>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -3,17 +3,19 @@
         <form class="input-group">
             <input #hsTimeseriesTitle readonly type="text" class="form-control" id="hs-timeseries-title"
                 [value]="fileTitle" [ngClass]="{'is-invalid': !selectedString}">
-            <button type="button" (click)="selectDateString($event)" class="btn btn-sm btn-primary">Select</button>
+            <button type="button" (click)="selectDateString($event)" class="btn btn-sm btn-primary">{{'COMMON.select' |
+                translateHs : {app} }}</button>
         </form>
-        <label for="hs-timeseries-title" class="text-danger small" [hidden]="selectedString">Highlight
-            and select timestamp in title</label>
+        <label for="hs-timeseries-title" class="text-danger small pt-1"
+            [hidden]="selectedString">{{'ADDDATA.FILE.highlightAndSelect' | translateHs: {app} }}</label>
+
     </div>
 
     <ngb-accordion #acc="ngbAccordion" class="my-2" [hidden]="!formVisible" activeIds="hs-timeseries-acc">
         <ngb-panel id="hs-timeseries-acc">
             <ng-template ngbPanelHeader let-opened="opened">
-                <button ngbPanelToggle class="accordion-button text-black-50">Selected string: <span
-                        class="text-black ps-1">{{selectedString}}</span></button>
+                <button ngbPanelToggle class="accordion-button text-black-50">{{'ADDDATA.FILE.selectedString' |
+                    translateHs: {app} }}: <span class="text-black ps-1">{{selectedString}}</span></button>
             </ng-template>
             <ng-template ngbPanelContent>
                 <form [formGroup]="form" class="d-flex flex-column ">
@@ -21,12 +23,15 @@
                         [ngClass]="{'verification-pending': !form.get('verified').value}">
                         <input formControlName="regex" type="text" class="form-control form-control-sm"
                             id="hs-timeseries-regex" [ngClass]="{'is-valid': form.get('verified').value}">
-                        <label for="hs-timeseries-regex">Infered regex pattern</label>
+                        <label for="hs-timeseries-regex">{{'ADDDATA.FILE.inferedRegex' |
+                            translateHs: {app} }}</label>
                     </div>
                     <div class="d-flex justify-content-between">
-                        <p class="text-black-50 small">Verify infered datetime pattern before you continue</p>
+                        <p class="text-black-50 small pt-1">{{'ADDDATA.FILE.verifyInferedRegex' |
+                            translateHs: {app} }}</p>
                         <button type="button" (click)="verifyInputs()"
-                            class="btn btn-sm btn-primary m-2 w-25">Verify</button>
+                            class="btn btn-sm btn-primary m-2 w-25">{{'COMMON.verify' |
+                            translateHs: {app} }}</button>
                     </div>
                 </form>
             </ng-template>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -24,7 +24,7 @@
                         <label for="hs-timeseries-regex">Infered regex pattern</label>
                     </div>
                     <div class="d-flex justify-content-between">
-                        <p class="text-black-50 small">Verify infered values before you continue</p>
+                        <p class="text-black-50 small">Verify infered datetime pattern before you continue</p>
                         <button type="button" (click)="verifyInputs()"
                             class="btn btn-sm btn-primary m-2 w-25">Verify</button>
                     </div>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -1,37 +1,43 @@
-<div>
-    <div class="d-flex flex-column justify-content-between w-100">
-        <div class="d-flex w-100 input-group">
-            <form class="form-floating  flex-fill">
-                <input #hsTimeseriesTitle readonly type="text" class="form-control form-control-sm is-invalid"
-                    id="hs-timeseries-title" [value]="fileTitle">
-                <label for="hs-timeseries-title">Highlight timestamp in title</label>
-            </form>
+<div class="d-flex flex-column justify-content-between w-100 pb-2">
+    <div class="d-flex w-100 input-group">
+        <form class="form-floating  flex-fill">
+            <input #hsTimeseriesTitle readonly type="text" class="form-control form-control-sm" id="hs-timeseries-title"
+                [value]="fileTitle" [ngClass]="{'is-invalid': !selectedString}">
+            <label for="hs-timeseries-title" [ngClass]="{'text-danger': !selectedString}">Highlight
+                timestamp in title</label>
+        </form>
 
-            <button type="button" (click)="getSelectedString($event)" class="btn btn-sm btn-primary">Select</button>
-        </div>
+        <button type="button" (click)="selectDateString($event)" class="btn btn-sm btn-primary">Select</button>
+    </div>
 
-        <ngb-accordion #acc="ngbAccordion" class="my-2">
-            <ngb-panel id="toggle-1" title="Infered params">
-                <ng-template ngbPanelContent>
-                    <div class="d-flex flex-column">
-                        <div>
-                            Selected string: {{selectedString}}
+    <ngb-accordion #acc="ngbAccordion" class="my-2" [hidden]="!formVisible" activeIds="hs-timeseries-acc">
+        <ngb-panel id="hs-timeseries-acc" title="Infered params">
+            <ng-template ngbPanelContent>
+                <form [formGroup]="form" class="d-flex flex-column">
+                    <div class="text-black-50">
+                        Selected string: <span class="text-black">{{selectedString}}</span>
+                    </div>
+                    <div class="d-flex flex-column justify-content-between flex-md-row gap-2">
+                        <div class="form-floating mt-2 flex-fill"
+                            [ngClass]="{'verification-pending': !form.get('verified').value}">
+                            <input formControlName="regex" type="text" class="form-control form-control-sm"
+                                id="hs-timeseries-regex">
+                            <label for="hs-timeseries-regex">Infered regex pattern</label>
                         </div>
-                        <div class="d-flex flex-column justify-content-between flex-md-row gap-2">
-                            <div class="form-floating mt-2 flex-fill">
-                                <input required type="text" class="form-control form-control-sm"
-                                    id="hs-timeseries-regex" value="[0-9]{4}[0-9]{2}[0-9]{2}">
-                                <label for="hs-timeseries-regex">Infered regex pattern</label>
-                            </div>
-                            <div class="form-floating mt-2 flex-fill">
-                                <input required type="email" class="form-control form-control-sm"
-                                    id="hs-timeseries-format" value="yyyy_mm_dd">
-                                <label for="hs-timeseries-format">Infered date format</label>
-                            </div>
+                        <div class="form-floating mt-2 flex-fill"
+                            [ngClass]="{'verification-pending': !form.get('verified').value}">
+                            <input formControlName="format" type="text" class="form-control form-control-sm"
+                                id="hs-timeseries-format">
+                            <label for="hs-timeseries-format">Infered date format</label>
                         </div>
                     </div>
-                </ng-template>
-            </ngb-panel>
-        </ngb-accordion>
-    </div>
+                    <div class="d-flex align-items-baseline justify-content-end" *ngIf="!form.get('verified').value">
+                        <p class="text-black-50 small">Verify infered values before you continue</p>
+                        <button type="button" (click)="verifyInputs()"
+                            class="btn btn-sm btn-primary m-2 w-25">Verify</button>
+                    </div>
+                </form>
+            </ng-template>
+        </ngb-panel>
+    </ngb-accordion>
 </div>

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.html
@@ -23,11 +23,11 @@
                         [ngClass]="{'verification-pending': !form.get('verified').value}">
                         <input formControlName="regex" type="text" class="form-control form-control-sm"
                             id="hs-timeseries-regex" [ngClass]="{'is-valid': form.get('verified').value}">
-                        <label for="hs-timeseries-regex">{{'ADDDATA.FILE.inferedRegex' |
+                        <label for="hs-timeseries-regex">{{'ADDDATA.FILE.inferredRegex' |
                             translateHs: {app} }}</label>
                     </div>
                     <div class="d-flex justify-content-between">
-                        <p class="text-black-50 small pt-1">{{'ADDDATA.FILE.verifyInferedRegex' |
+                        <p class="text-black-50 small pt-1">{{'ADDDATA.FILE.verifyInferredRegex' |
                             translateHs: {app} }}</p>
                         <button type="button" (click)="verifyInputs()"
                             class="btn btn-sm btn-primary m-2 w-25">{{'COMMON.verify' |

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.scss
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.scss
@@ -5,3 +5,14 @@
         padding: 0.5rem !important;
     }
 }
+
+.verification-pending {
+    label {
+        color: var(--bs-warning);
+        opacity: 1 !important;
+    }
+
+    input {
+        border-color: var(--bs-warning);
+    }
+}

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.scss
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.scss
@@ -1,0 +1,7 @@
+::ng-deep {
+
+    .accordion-button,
+    .accordion-body {
+        padding: 0.5rem !important;
+    }
+}

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -43,7 +43,7 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
   supportedRegex = [
     {
       regex: /^[0-9]{8}T([0-9]{6}([0-9]{3})?)(Z)?$/,
-      timeregex: '([0-9]{8})T([0-9]{X})',
+      timeregex: '[0-9]{8}T[0-9]{6}',
     },
     {
       regex: /^[0-9._/-]+(?<![a-zA-Z])$/,
@@ -159,12 +159,16 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
   inferRegexPatternFromString(timestamp: string, regex: string): string {
     if (regex !== '^[0-9._/-]+(?<![a-zA-Z])$') {
       const match = timestamp.match(regex);
-      return (
-        this.supportedRegex[0].timeregex.replace(
-          'X',
-          match[1].length.toString()
-        ) + (match[3] ? 'Z' : '')
-      );
+      const hasMs = match[1].length == 9;
+      let timeregex = this.supportedRegex[0].timeregex;
+      //has Z postfix
+      if (match[3]) {
+        //If miliseconds are included in timestamp ignore them
+        timeregex = hasMs ? `(${timeregex})${match[2]}(Z)` : `${timeregex}Z`;
+      }
+      //timeregex alone would work but in UI its a bit more clear that
+      //only first 6 time digits are used
+      return hasMs ? `(${timeregex})${match[2]}` : timeregex;
     }
     const separator = this.getSeparator(timestamp);
     if (separator) {

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -47,8 +47,6 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
     this.form = this.fb.group({
       /* Regex string encoding of date patter used in file name  */
       regex: ['', Validators.required],
-      /* Date format used in file name eg. YYYY.MM.DD  */
-      format: ['yyyyMMdd', Validators.required],
       verified: [false, Validators.requiredTrue],
     });
   }
@@ -68,6 +66,8 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
       .dataObjectChanged.pipe(takeUntil(this.end))
       .subscribe((data) => {
         if (data.files) {
+          this.resetForm();
+          this.data.srs = undefined;
           this.getFileTitle(data.files[0].content);
         }
       });
@@ -86,8 +86,6 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
     this.form.patchValue({verified: true});
     this.accordionComponent.expand('hs-timeseries-acc');
     this.data.timeRegex = `${this.form.controls.regex.value}`;
-    //Will be used as a part of timeRegex directly
-    // `format=${this.form.controls.format.value}`;
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -1,9 +1,12 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, ViewChild} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {NgbAccordion} from '@ng-bootstrap/ng-bootstrap';
 
 import {loadAsync} from 'jszip';
 
 import {FileDataObject} from '../../types/file-data-object.type';
 import {FileDescriptor} from '../../types/file-descriptor.type';
+import {HsToastService} from '../../../../layout/toast/toast.service';
 
 @Component({
   selector: 'hs-file-raster-timeseries',
@@ -12,12 +15,24 @@ import {FileDescriptor} from '../../types/file-descriptor.type';
 })
 export class RasterTimeseriesComponent implements OnInit {
   @Input() data: FileDataObject;
+  @ViewChild('acc') accordionComponent: NgbAccordion;
+
+  form: FormGroup;
+  formVisible = false;
 
   tsData: FileDescriptor;
   fileTitle: string;
 
   selectedString: string;
-  constructor() {}
+  constructor(private fb: FormBuilder, private hsToastService: HsToastService) {
+    this.form = this.fb.group({
+      /* Regex string encoding of date patter used in file name  */
+      regex: ['', Validators.required],
+      /* Date format used in file name eg. YYYY.MM.DD  */
+      format: ['yyyyMMdd', Validators.required],
+      verified: [false, Validators.requiredTrue],
+    });
+  }
 
   ngOnInit() {
     this.tsData = this.data.files[0];
@@ -29,12 +44,50 @@ export class RasterTimeseriesComponent implements OnInit {
     });
   }
 
-  getSelectedString(e: MouseEvent) {
-    e.preventDefault();
-    const selection = window.getSelection();
-    this.selectedString = selection.toString();
+  /** On click handler used by user to mark infered inputs as verified */
+  verifyInputs(): void {
+    this.form.patchValue({verified: true});
+    this.accordionComponent.expand('hs-timeseries-acc');
+    /**
+     * TODO:
+     * - If raster-ts active its neccessary for verified control to be true
+     * to be able to 'Add' layer
+     * - use options object for constructFormData
+     */
+  }
 
-    this.inferRegexPatternFromString(this.selectedString);
+  private checkStringValidity(): boolean {
+    return (
+      !/[a-zA-Z]/.test(this.selectedString) && this.selectedString.length > 0
+    );
+  }
+
+  selectDateString(e: MouseEvent): void {
+    e.preventDefault();
+    //Reset verified control
+    this.form.patchValue({verified: false});
+    //Get selected string
+    this.selectedString = this.getSelectedText();
+
+    const isValid = this.checkStringValidity();
+    if (isValid) {
+      this.form.patchValue({
+        regex: this.inferRegexPatternFromString(this.selectedString),
+      });
+      this.formVisible = true;
+    } else {
+      this.selectedString = undefined;
+      this.formVisible = false;
+
+      this.hsToastService.createToastPopupMessage(
+        'Selected string is invalid',
+        'Selected string is missing or contains alphabetical characters.',
+        {
+          toastStyleClasses: 'bg-danger text-light',
+          customDelay: 7000,
+        }
+      );
+    }
   }
 
   /**
@@ -47,17 +100,29 @@ export class RasterTimeseriesComponent implements OnInit {
   }
 
   /**
-   *
+   *Infer regex pattern from selected string
    */
   inferRegexPatternFromString(timestamp: string): string {
     const specialCharacter = this.getSpecialCharacters(timestamp);
 
     if (specialCharacter) {
       let parts = timestamp.split(specialCharacter);
-      parts = parts.map((part) => {
-        return `[0-9]{${part.length}}`;
-      });
-      return parts.join('');
+      parts = parts.map((part) => `[0-9]{${part.length}}`);
+      return parts.join(specialCharacter);
     }
+  }
+
+  /**
+   * Extract selected text from element.
+   * Necessarry workaround because of Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=85686
+   */
+  private getSelectedText(): string {
+    const inputElement = document.getElementById(
+      'hs-timeseries-title'
+    ) as HTMLInputElement;
+    return inputElement.value.substring(
+      inputElement.selectionStart,
+      inputElement.selectionEnd
+    );
   }
 }

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -39,6 +39,22 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
   fileTitle: string;
 
   selectedString: string;
+
+  supportedRegex = [
+    {
+      regex: /[0-9]{8}T[0-9]{9}Z/,
+      timeregex: '([0-9]{8})T([0-9]{9})Z',
+    },
+    {
+      regex: /[0-9]{8}T[0-9]{9}/,
+      timeregex: '([0-9]{8})T([0-9]{9})',
+    },
+    {
+      regex: /^[0-9T._/-]+(?<![a-zA-Z])$/,
+      timeregex: undefined,
+    },
+  ];
+
   constructor(
     private fb: FormBuilder,
     private hsToastService: HsToastService,
@@ -97,13 +113,11 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
    * - consist of digits only or digits and separators  ., _, /, or -
    */
   private checkStringValidity(): string | undefined {
-    return [
-      /^[0-9T._/-]+(?<![a-zA-Z])$/,
-      /[0-9]{8}T[0-9]{9}Z/,
-      /[0-9]{8}T[0-9]{9}/,
-    ].find((r: RegExp) => {
-      return r.test(this.selectedString);
-    })?.source;
+    return this.supportedRegex
+      .map((val) => val.regex)
+      .find((r: RegExp) => {
+        return r.test(this.selectedString);
+      })?.source;
   }
 
   selectDateString(e: MouseEvent): void {
@@ -148,7 +162,9 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
    */
   inferRegexPatternFromString(timestamp: string, regex: string): string {
     if (regex !== '^[0-9T._/-]+(?<![a-zA-Z])$') {
-      return regex;
+      return this.supportedRegex.find(
+        (val) => val.regex.toString().replace(/\//g, '') == regex
+      ).timeregex;
     }
     const separator = this.getSeparator(timestamp);
     // /[0-9]{8}T[0-9]{9}Z/.test(this.selectedString)

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -96,21 +96,23 @@ export class RasterTimeseriesComponent implements OnInit {
    * Get first special character from string selected by user
    * Assuming its separator
    */
-  private getSpecialCharacters(input: string): string {
-    const specialCharacters = input.match(/[._\/-]/g) || [];
-    return specialCharacters[0];
+  private getSeparator(input: string): string {
+    const separators = input.match(/[._\/-]/g) || [];
+    return separators[0];
   }
 
   /**
    *Infer regex pattern from selected string
    */
   inferRegexPatternFromString(timestamp: string): string {
-    const specialCharacter = this.getSpecialCharacters(timestamp);
+    const separator = this.getSeparator(timestamp);
 
-    if (specialCharacter) {
-      let parts = timestamp.split(specialCharacter);
+    if (separator) {
+      let parts = timestamp.split(separator);
       parts = parts.map((part) => `[0-9]{${part.length}}`);
-      return parts.join(specialCharacter);
+      return parts.join(separator);
+    } else {
+      return `[0-9]{${this.selectedString.length}}`;
     }
   }
 

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -42,15 +42,11 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
 
   supportedRegex = [
     {
-      regex: /[0-9]{8}T[0-9]{9}Z/,
-      timeregex: '([0-9]{8})T([0-9]{9})Z',
+      regex: /^[0-9]{8}T([0-9]{6}([0-9]{3})?)(Z)?$/,
+      timeregex: '([0-9]{8})T([0-9]{X})',
     },
     {
-      regex: /[0-9]{8}T[0-9]{9}/,
-      timeregex: '([0-9]{8})T([0-9]{9})',
-    },
-    {
-      regex: /^[0-9T._/-]+(?<![a-zA-Z])$/,
+      regex: /^[0-9._/-]+(?<![a-zA-Z])$/,
       timeregex: undefined,
     },
   ];
@@ -161,14 +157,16 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
    *Infer regex pattern from selected string
    */
   inferRegexPatternFromString(timestamp: string, regex: string): string {
-    if (regex !== '^[0-9T._/-]+(?<![a-zA-Z])$') {
-      return this.supportedRegex.find(
-        (val) => val.regex.toString().replace(/\//g, '') == regex
-      ).timeregex;
+    if (regex !== '^[0-9._/-]+(?<![a-zA-Z])$') {
+      const match = timestamp.match(regex);
+      return (
+        this.supportedRegex[0].timeregex.replace(
+          'X',
+          match[1].length.toString()
+        ) + (match[3] ? 'Z' : '')
+      );
     }
     const separator = this.getSeparator(timestamp);
-    // /[0-9]{8}T[0-9]{9}Z/.test(this.selectedString)
-    // /[0-9]{8}T[0-9]{9}/.test(this.selectedString)
     if (separator) {
       let parts = timestamp.split(separator);
       parts = parts.map((part) => `([0-9]{${part.length}})`);

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -53,9 +53,20 @@ export class RasterTimeseriesComponent implements OnInit {
     // `format=${this.form.controls.format.value}`;
   }
 
+  /**
+   * Checks the validity of the selected string
+   * String is valid if:
+   * - matches one of the following regex datetime formats
+   *    -[0-9]{8}T[0-9]{9}Z eg 20220510T050948Z
+   *    -[0-9]{8}T[0-9]{9} eg. 20220510T050948
+   * - consist of digits only or digits and separators  ., _, /, or -
+   */
   private checkStringValidity(): boolean {
     return (
-      !/[a-zA-Z]/.test(this.selectedString) && this.selectedString.length > 0
+      this.selectedString.length > 0 &&
+      (/^[0-9T._/-]+(?<![a-zA-Z])$/.test(this.selectedString) ||
+        /[0-9]{8}T[0-9]{9}Z/.test(this.selectedString) ||
+        /[0-9]{8}T[0-9]{9}/.test(this.selectedString))
     );
   }
 
@@ -79,7 +90,7 @@ export class RasterTimeseriesComponent implements OnInit {
 
       this.hsToastService.createToastPopupMessage(
         'Selected string is invalid',
-        'Selected string is missing or contains alphabetical characters.',
+        'Selected string is missing or is not supported.',
         {
           toastStyleClasses: 'bg-danger text-light',
           customDelay: 7000,
@@ -102,7 +113,8 @@ export class RasterTimeseriesComponent implements OnInit {
    */
   inferRegexPatternFromString(timestamp: string): string {
     const separator = this.getSeparator(timestamp);
-
+    // /[0-9]{8}T[0-9]{9}Z/.test(this.selectedString)
+    // /[0-9]{8}T[0-9]{9}/.test(this.selectedString)
     if (separator) {
       let parts = timestamp.split(separator);
       parts = parts.map((part) => `[0-9]{${part.length}}`);

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -49,12 +49,8 @@ export class RasterTimeseriesComponent implements OnInit {
     this.form.patchValue({verified: true});
     this.accordionComponent.expand('hs-timeseries-acc');
     this.data.timeRegex = `${this.form.controls.regex.value}`;
-    this.data.format = `format=${this.form.controls.format.value}`;
-    /**
-     * TODO:
-     * - If raster-ts active its neccessary for verified control to be true
-     * to be able to 'Add' layer
-     */
+    //Will be used as a part of timeRegex directly
+    // `format=${this.form.controls.format.value}`;
   }
 
   private checkStringValidity(): boolean {

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -1,0 +1,63 @@
+import {Component, Input, OnInit} from '@angular/core';
+
+import {loadAsync} from 'jszip';
+
+import {FileDataObject} from '../../types/file-data-object.type';
+import {FileDescriptor} from '../../types/file-descriptor.type';
+
+@Component({
+  selector: 'hs-file-raster-timeseries',
+  templateUrl: './raster-timeseries.component.html',
+  styleUrls: ['./raster-timeseries.component.scss'],
+})
+export class RasterTimeseriesComponent implements OnInit {
+  @Input() data: FileDataObject;
+
+  tsData: FileDescriptor;
+  fileTitle: string;
+
+  selectedString: string;
+  constructor() {}
+
+  ngOnInit() {
+    this.tsData = this.data.files[0];
+
+    loadAsync(this.tsData.content).then((zip) => {
+      // Get an array of filenames within the zip archive
+      const filenames = Object.keys(zip.files);
+      this.fileTitle = filenames[0];
+    });
+  }
+
+  getSelectedString(e: MouseEvent) {
+    e.preventDefault();
+    const selection = window.getSelection();
+    this.selectedString = selection.toString();
+
+    this.inferRegexPatternFromString(this.selectedString);
+  }
+
+  /**
+   * Get first special character from string selected by user
+   * Assuming its separator
+   */
+  private getSpecialCharacters(input: string): string {
+    const specialCharacters = input.match(/[._\/-]/g) || [];
+    return specialCharacters[0];
+  }
+
+  /**
+   *
+   */
+  inferRegexPatternFromString(timestamp: string): string {
+    const specialCharacter = this.getSpecialCharacters(timestamp);
+
+    if (specialCharacter) {
+      let parts = timestamp.split(specialCharacter);
+      parts = parts.map((part) => {
+        return `[0-9]{${part.length}}`;
+      });
+      return parts.join('');
+    }
+  }
+}

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -48,11 +48,12 @@ export class RasterTimeseriesComponent implements OnInit {
   verifyInputs(): void {
     this.form.patchValue({verified: true});
     this.accordionComponent.expand('hs-timeseries-acc');
+    this.data.timeRegex = `${this.form.controls.regex.value}`;
+    this.data.format = `format=${this.form.controls.format.value}`;
     /**
      * TODO:
      * - If raster-ts active its neccessary for verified control to be true
      * to be able to 'Add' layer
-     * - use options object for constructFormData
      */
   }
 
@@ -78,6 +79,7 @@ export class RasterTimeseriesComponent implements OnInit {
     } else {
       this.selectedString = undefined;
       this.formVisible = false;
+      this.data.timeRegex = undefined;
 
       this.hsToastService.createToastPopupMessage(
         'Selected string is invalid',

--- a/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -9,14 +9,14 @@ import {
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {NgbAccordion} from '@ng-bootstrap/ng-bootstrap';
 
+import {Subject} from 'rxjs';
 import {loadAsync} from 'jszip';
+import {takeUntil} from 'rxjs/operators';
 
 import {FileDataObject} from '../../types/file-data-object.type';
 import {FileDescriptor} from '../../types/file-descriptor.type';
 import {HsAddDataCommonFileService} from '../../../common/common-file.service';
 import {HsToastService} from '../../../../layout/toast/toast.service';
-import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'hs-file-raster-timeseries',
@@ -61,7 +61,7 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
     private hsAddDataCommonFileService: HsAddDataCommonFileService
   ) {
     this.form = this.fb.group({
-      /* Regex string encoding of date patter used in file name  */
+      /* Regex string encoding of date pattern used in file name  */
       regex: ['', Validators.required],
       verified: [false, Validators.requiredTrue],
     });
@@ -97,7 +97,7 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** On click handler used by user to mark infered inputs as verified */
+  /** On click handler used by user to mark inferred inputs as verified */
   verifyInputs(): void {
     this.form.patchValue({verified: true});
     this.accordionComponent.expand('hs-timeseries-acc');
@@ -122,7 +122,7 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
 
   selectDateString(e: MouseEvent): void {
     e.preventDefault();
-    //Reset verified control and data value (its added on verify to control form submition)
+    //Reset verified control and data value (it's added on verify to control form submission)
     this.form.patchValue({verified: false});
     this.data.timeRegex = undefined;
     //Get selected string
@@ -150,7 +150,7 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
 
   /**
    * Get first special character from string selected by user
-   * Assuming its separator
+   * Assuming it's separator
    */
   private getSeparator(input: string): string {
     const separators = input.match(/[._\/-]/g) || [];
@@ -180,7 +180,7 @@ export class RasterTimeseriesComponent implements OnInit, OnDestroy {
 
   /**
    * Extract selected text from element.
-   * Necessarry workaround because of Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=85686
+   * Necessary workaround because of Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=85686
    */
   private getSelectedText(): string {
     const inputElement = this.fileTitleInput.nativeElement;

--- a/projects/hslayers/src/components/add-data/file/raster/raster.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster.component.html
@@ -14,6 +14,7 @@
         <p *ngFor="let file of data.files">{{file.name}}</p>
       </div>
     </div>
+    <hs-file-raster-timeseries *ngIf="fileType === 'raster-ts'" [data]="data"> </hs-file-raster-timeseries>
     <hs-new-layer-form [data]="data" [app]="app"></hs-new-layer-form>
     <hs-add-layer-authorized [data]="data" [app]="app"></hs-add-layer-authorized>
   </div>

--- a/projects/hslayers/src/components/add-data/file/raster/raster.component.html
+++ b/projects/hslayers/src/components/add-data/file/raster/raster.component.html
@@ -14,7 +14,7 @@
         <p *ngFor="let file of data.files">{{file.name}}</p>
       </div>
     </div>
-    <hs-file-raster-timeseries *ngIf="fileType === 'raster-ts'" [data]="data"> </hs-file-raster-timeseries>
+    <hs-file-raster-timeseries *ngIf="fileType === 'raster-ts'" [data]="data" [app]="app"> </hs-file-raster-timeseries>
     <hs-new-layer-form [data]="data" [app]="app"></hs-new-layer-form>
     <hs-add-layer-authorized [data]="data" [app]="app"></hs-add-layer-authorized>
   </div>

--- a/projects/hslayers/src/components/add-data/file/raster/raster.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster.component.ts
@@ -14,8 +14,9 @@ import {HsUploadedFiles} from '../../../../common/upload/upload.component';
 })
 export class HsFileRasterComponent
   extends HsAddDataFileBaseComponent
-  implements OnInit {
-  fileType: AddDataFileType = 'raster';
+  implements OnInit
+{
+  @Input() fileType: Extract<AddDataFileType, 'raster' | 'raster-ts'>;
   constructor(
     public hsFileService: HsFileService,
     public hsAddDataCommonService: HsAddDataCommonService,
@@ -27,7 +28,9 @@ export class HsFileRasterComponent
   ngOnInit(): void {
     this.baseFileType = this.fileType;
     this.acceptedFormats =
-      '.tif, .tifw, .tiff, .tiffw, .gtiff, .gtiffw, .tfw, .png, .pngw, .pgw, .png.aux.xml, .jpg, .jpgw, .jgw, .jpg.aux.xml, .jp2, .jp2w, .j2w, .zip, .wld';
+      this.fileType === 'raster-ts'
+        ? '.zip'
+        : '.tif, .tifw, .tiff, .tiffw, .gtiff, .gtiffw, .tfw, .png, .pngw, .pgw, .png.aux.xml, .jpg, .jpgw, .jgw, .jpg.aux.xml, .jp2, .jp2w, .j2w, .zip, .wld';
     super.ngOnInit();
   }
 

--- a/projects/hslayers/src/components/add-data/file/raster/raster.component.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster.component.ts
@@ -32,6 +32,7 @@ export class HsFileRasterComponent
         ? '.zip'
         : '.tif, .tifw, .tiff, .tiffw, .gtiff, .gtiffw, .tfw, .png, .pngw, .pgw, .png.aux.xml, .jpg, .jpgw, .jgw, .jpg.aux.xml, .jp2, .jp2w, .j2w, .zip, .wld';
     super.ngOnInit();
+    this.data.allowedStyles = 'sld';
   }
 
   async handleFileUpload(evt: HsUploadedFiles): Promise<void> {

--- a/projects/hslayers/src/components/add-data/file/raster/raster.module.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster.module.ts
@@ -1,12 +1,14 @@
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
+import {NgbAccordionModule} from '@ng-bootstrap/ng-bootstrap';
 
 import {HsAddDataCommonModule} from '../../common/common.module';
 import {HsCommonUrlModule} from '../../common/url/url.module';
 import {HsFileRasterComponent} from './raster.component';
 import {HsLanguageModule} from '../../../language/language.module';
 import {HsUploadModule} from '../../../../common/upload/upload.module';
+import {RasterTimeseriesComponent} from './raster-timeseries/raster-timeseries.component';
 
 @NgModule({
   imports: [
@@ -16,9 +18,10 @@ import {HsUploadModule} from '../../../../common/upload/upload.module';
     HsCommonUrlModule,
     HsLanguageModule,
     HsUploadModule,
+    NgbAccordionModule,
   ],
   exports: [HsFileRasterComponent],
-  declarations: [HsFileRasterComponent],
+  declarations: [HsFileRasterComponent, RasterTimeseriesComponent],
   providers: [],
 })
 export class HsFileRasterModule {}

--- a/projects/hslayers/src/components/add-data/file/raster/raster.module.ts
+++ b/projects/hslayers/src/components/add-data/file/raster/raster.module.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 import {NgbAccordionModule} from '@ng-bootstrap/ng-bootstrap';
 
@@ -14,6 +14,7 @@ import {RasterTimeseriesComponent} from './raster-timeseries/raster-timeseries.c
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     HsAddDataCommonModule,
     HsCommonUrlModule,
     HsLanguageModule,

--- a/projects/hslayers/src/components/add-data/file/types/file-data-object.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file-data-object.type.ts
@@ -1,22 +1,14 @@
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
 
-import {FileDescriptor} from './file-descriptor.type';
-import {accessRightsModel} from '../../common/access-rights.model';
+import {FileFormDataObject} from './file-form-data.type';
 
-export type FileDataObject = {
-  abstract?: string;
-  access_rights?: accessRightsModel;
+export type FileDataObject = FileFormDataObject & {
   addUnder?: Layer<Source>;
   extract_styles?: boolean;
-  files?: FileDescriptor[];
   folder_name?: string;
   loadAsType?: 'wms' | 'wfs';
-  name?: string;
   saveAvailable?: boolean;
   saveToLayman?: boolean;
-  serializedStyle?: FileDescriptor;
-  srs?: string;
-  title?: string;
   type?: string;
 };

--- a/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
@@ -10,7 +10,6 @@ export type FileFormData = {
   srs: string;
   title: string;
   timeRegex?: string;
-  format?: string;
 };
 
 type Optional<T> = {[P in keyof T]?: T[P]};

--- a/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
@@ -1,12 +1,16 @@
 import {FileDescriptor} from './file-descriptor.type';
 import {accessRightsModel} from '../../common/access-rights.model';
 
+/**
+ * @param allowedStyles Allowed file formats (SLD, QML or both)
+ */
 export type FileFormData = {
   abstract: string;
   access_rights: accessRightsModel;
   files: FileDescriptor[];
   name: string;
   serializedStyle: FileDescriptor;
+  allowedStyles?: string;
   srs: string;
   title: string;
   timeRegex?: string;

--- a/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
@@ -1,0 +1,18 @@
+import {FileDescriptor} from './file-descriptor.type';
+import {accessRightsModel} from '../../common/access-rights.model';
+
+export type FileFormData = {
+  abstract: string;
+  access_rights: accessRightsModel;
+  files: FileDescriptor[];
+  name: string;
+  serializedStyle: FileDescriptor;
+  srs: string;
+  title: string;
+  timeRegex?: string;
+  format?: string;
+};
+
+type Optional<T> = {[P in keyof T]?: T[P]};
+
+export type FileFormDataObject = Optional<FileFormData>;

--- a/projects/hslayers/src/components/add-data/file/types/file.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file.type.ts
@@ -4,6 +4,7 @@ export const filesSupported = [
   'geojson',
   'shp',
   'raster',
+  'raster-ts',
 ] as const;
-export type AddDataFileType = typeof filesSupported[number];
+export type AddDataFileType = (typeof filesSupported)[number];
 //https://stackoverflow.com/questions/40863488/how-can-i-iterate-over-a-custom-literal-type-in-typescript

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -287,8 +287,12 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
     if (layers.length == 0) {
       return undefined;
     }
-    const layerExtents = layers.map((lyr) => [...lyr.getExtent()]); //Spread need to not create reference
-    return this.hsAddDataUrlService.calcCombinedExtent(layerExtents);
+    try {
+      const layerExtents = layers.map((lyr) => [...lyr.getExtent()]); //Spread needed to not create reference
+      return this.hsAddDataUrlService.calcCombinedExtent(layerExtents);
+    } catch (error) {
+      console.warn(`Empty extent for ${layers}`, error);
+    }
   }
 
   getLayerExtent(serviceLayer: any, crs: string, app: string): number[] {
@@ -328,7 +332,14 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
         boundingbox = serviceLayer.LatLonBoundingBox;
       }
     }
-    return boundingbox;
+    return (
+      boundingbox ||
+      transformExtent(
+        [-180, -90, 180, 90],
+        'EPSG:4326',
+        this.hsMapService.getCurrentProj(app)
+      )
+    );
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -280,7 +280,7 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
   /**
    * For given array of layers (service layer definitions) it calculates a cumulative bounding box which encloses all the layers
    */
-  calcAllLayersExtent(layers: Layer<Source>[] | Layer<Source>): any {
+  calcAllLayersExtent(layers: Layer<Source>[] | Layer<Source>) {
     if (!Array.isArray(layers)) {
       return [...layers.getExtent()];
     }

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -260,11 +260,6 @@ export class HsCompositionsParserService {
         return l.className;
       });
     }
-
-    // "user": {
-    //   "email": "leitnerfilip@gmail.com",
-    //   "name": "Filip Leitner"
-    // }
     return composition;
   }
 
@@ -361,7 +356,7 @@ export class HsCompositionsParserService {
         app,
       });
     }
-    this.hsEventBusService.currentComposition.next(obj); //Doesnt seems to be used
+    this.hsEventBusService.currentComposition.next(obj); //Doesn't seem to be used
     this.get(app).current_composition_title = titleFromContainer || obj.title;
     const possibleExtent = extentFromContainer || obj.extent;
     if (
@@ -382,7 +377,7 @@ export class HsCompositionsParserService {
       }
     }
 
-    //CSW serviceType compostitions
+    //CSW serviceType compositions
     const layers = await this.jsonToLayers(obj, app);
 
     const confirmed = obj.services

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -382,7 +382,7 @@ export class HsCompositionsParserService {
       }
     }
 
-    //CSW serviceType compositions
+    //CSW serviceType compostitions
     const layers = await this.jsonToLayers(obj, app);
 
     const confirmed = obj.services
@@ -734,11 +734,7 @@ export class HsCompositionsParserService {
       case 'Vector':
       case 'hs.format.LaymanWfs':
         if (lyr_def.protocol?.format == 'hs.format.externalWFS') {
-          resultLayer =
-            await this.hsCompositionsLayerParserService.createWFSLayer(
-              lyr_def,
-              app
-            );
+          this.hsCompositionsLayerParserService.createWFSLayer(lyr_def, app);
         } else {
           resultLayer =
             await this.hsCompositionsLayerParserService.createVectorLayer(
@@ -758,7 +754,7 @@ export class HsCompositionsParserService {
         return;
     }
     if (resultLayer) {
-      resultLayer = await resultLayer; //createWMTSLayer returns Promise which needs to be resolved first
+      resultLayer = await resultLayer; //createWMTSLayer returns Promise which need to be resolved first
       setMetadata(resultLayer, lyr_def.metadata);
       setSwipeSide(resultLayer, lyr_def.swipeSide);
     }

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -30,7 +30,6 @@ import {HsAddDataCommonService} from '../../add-data/common/common.service';
 import {HsAddDataVectorService} from '../../add-data/vector/vector.service';
 import {HsLanguageService} from '../../language/language.service';
 import {HsLaymanBrowserService} from '../../add-data/catalogue/layman/layman.service';
-import {HsLogService} from '../../../common/log/log.service';
 import {HsMapService} from '../../map/map.service';
 import {HsStylerService} from '../../styles/styler.service';
 import {HsToastService} from '../../layout/toast/toast.service';
@@ -50,7 +49,6 @@ export class HsCompositionsLayerParserService {
     private HsStylerService: HsStylerService,
     private HsWmtsGetCapabilitiesService: HsWmtsGetCapabilitiesService,
     private HsLanguageService: HsLanguageService,
-    private hsLog: HsLogService,
     private HsToastService: HsToastService,
     private HsUrlWfsService: HsUrlWfsService,
     private hsWfsGetCapabilitiesService: HsWfsGetCapabilitiesService,
@@ -62,27 +60,19 @@ export class HsCompositionsLayerParserService {
    * @public
    * @param lyr_def - Layer definition object
    * @param app - App identifier
-   * Initiate creation of WFS layer through HsUrlWfsService
+   * Initiate creation of WFS layer thorough HsUrlWfsService
    */
-  async createWFSLayer(lyr_def, app: string): Promise<Layer<Source>> {
+  async createWFSLayer(lyr_def, app: string): Promise<Layer<Source>[]> {
     this.hsAddDataCommonService.get(app).layerToSelect = lyr_def.name;
     const wrapper = await this.hsWfsGetCapabilitiesService.request(
       lyr_def.protocol.url,
       app
     );
-    const layers = await this.HsUrlWfsService.listLayerFromCapabilities(
+    return await this.HsUrlWfsService.listLayerFromCapabilities(
       wrapper,
       app,
       lyr_def.style
     );
-    if (layers?.length != 1) {
-      this.hsLog.error(
-        'createWFSLayer failed due to unexpected number of returned layers'
-      );
-      this.hsLog.log('lyr_def', lyr_def);
-      return;
-    }
-    return layers[0];
   }
 
   /**

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -60,7 +60,7 @@ export class HsCompositionsLayerParserService {
    * @public
    * @param lyr_def - Layer definition object
    * @param app - App identifier
-   * Initiate creation of WFS layer thorough HsUrlWfsService
+   * Initiate creation of WFS layer through HsUrlWfsService
    */
   async createWFSLayer(lyr_def, app: string): Promise<Layer<Source>[]> {
     this.hsAddDataCommonService.get(app).layerToSelect = lyr_def.name;

--- a/projects/hslayers/src/components/compositions/schema.json
+++ b/projects/hslayers/src/components/compositions/schema.json
@@ -317,7 +317,7 @@
                   "hs.format.externalWFS",
                   "hs.format.Sparql"
                 ],
-                "title": "Layer procol format"
+                "title": "Layer protocol format"
               },
               "url": {
                 "$id": "#/properties/layers/items/properties/protocol/properties/url",

--- a/projects/hslayers/src/components/compositions/schema.json
+++ b/projects/hslayers/src/components/compositions/schema.json
@@ -317,7 +317,7 @@
                   "hs.format.externalWFS",
                   "hs.format.Sparql"
                 ],
-                "title": "Layer protocol format"
+                "title": "Layer procol format"
               },
               "url": {
                 "$id": "#/properties/layers/items/properties/protocol/properties/url",

--- a/projects/hslayers/src/components/map/map.service.ts
+++ b/projects/hslayers/src/components/map/map.service.ts
@@ -544,7 +544,29 @@ export class HsMapService {
       proj4.defs('EPSG:4258')
     );
 
+    proj4.defs(
+      'EPSG:32633',
+      '+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs +type=crs'
+    );
+    proj4.defs(
+      'http://www.opengis.net/gml/srs/epsg.xml#32633',
+      proj4.defs('EPSG:32633')
+    );
+    proj4.defs(
+      'EPSG:32634',
+      '+proj=utm +zone=34 +datum=WGS84 +units=m +no_defs +type=crs'
+    );
+    proj4.defs(
+      'http://www.opengis.net/gml/srs/epsg.xml#32634',
+      proj4.defs('EPSG:32634')
+    );
+
     proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs');
+    proj4.defs(
+      'http://www.opengis.net/gml/srs/epsg.xml#4326',
+      proj4.defs('EPSG:4326')
+    );
+
     proj4.defs(
       'EPSG:3995',
       '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs'

--- a/projects/hslayers/src/components/map/map.service.ts
+++ b/projects/hslayers/src/components/map/map.service.ts
@@ -561,12 +561,6 @@ export class HsMapService {
       proj4.defs('EPSG:32634')
     );
 
-    proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs');
-    proj4.defs(
-      'http://www.opengis.net/gml/srs/epsg.xml#4326',
-      proj4.defs('EPSG:4326')
-    );
-
     proj4.defs(
       'EPSG:3995',
       '+proj=stere +lat_0=90 +lat_ts=71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs'

--- a/projects/hslayers/src/components/save-map/interfaces/layman-layer-descriptor.interface.ts
+++ b/projects/hslayers/src/components/save-map/interfaces/layman-layer-descriptor.interface.ts
@@ -23,6 +23,7 @@ export interface HsLaymanLayerDescriptor {
     error?: {
       code?: number;
       message?: string;
+      detail?: any;
     };
   };
   //Only for vector layers

--- a/projects/hslayers/src/components/save-map/layman.service.ts
+++ b/projects/hslayers/src/components/save-map/layman.service.ts
@@ -73,7 +73,7 @@ export class HsLaymanService implements HsSaverService {
   laymanLayerPending: Subject<string[]> = new Subject();
   totalProgress = 0;
   deleteQuery: Subscription;
-  supportedCRRList = SUPPORTED_SRS_LIST.slice(0, 2);
+  supportedCRRList: string[] = SUPPORTED_SRS_LIST;
   constructor(
     private hsUtilsService: HsUtilsService,
     private http: HttpClient,

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -392,7 +392,7 @@ export class HslayersAppComponent {
             },
           ],
           proxyPrefix: window.location.hostname.includes('localhost')
-            ? `${window.location.protocol}//${window.location.hostname}:8085/`
+            ? `${window.location.protocol}//127.0.0.1:8085/`
             : '/proxy/',
           panelsEnabled: app.panelsEnabled,
           mapSwipeOptions: {


### PR DESCRIPTION
## Description
- Implement raster series upload to Layman

    Currently works with raster series files that:
      - matche one of the following regex datetime formats 
           -[0-9]{8}T[0-9]{9}Z eg 20220510T050948Z
           -[0-9]{8}T[0-9]{9} eg. 20220510T050948
       - consist of digits only or digits and separators  ., _, /, or -
       
    For the regex patterns listed  I dont really know wether these are the most used . I took those from [layman docs](https://github.com/LayerManager/layman/blob/v1.18.0/doc/rest.md#post-workspace-layers). 
     We can always add/edit this.

 - Allow all CRS from supported CRS list to be used with rasters.

## Related issues or pull requests

closes #3755 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
