### PR TITLE
fix: Decode proxyfied url in case client send it that way

### DIFF
--- a/projects/hslayers-server/src/proxy.js
+++ b/projects/hslayers-server/src/proxy.js
@@ -30,6 +30,7 @@ require('http')
         res.end();
       }
       else {
+        req.url = decodeURIComponent(req.url);
         req.url = req.url.replace('/proxy', '');
         if (req.url.indexOf('api.geonames.org/searchJSON') > -1) {
           const params = querystring.decode(req.url.split('?')[1]);


### PR DESCRIPTION
## Description

Some other clients using our proxy can send encoded URI (old HSLayers). Decode the URI in that case.


- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)
