### PR TITLE
3899 - Don't add layer which cannot be added

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -71,7 +71,8 @@
       "srsNotSupported": "Vybraný souřadnicový systém (CRS/SRS) není podporován. Pokračujte poskytnutím souboru v systému EPSG:3857 nebo EPSG:4326.",
       "thereWasErrorWhile": "Nastala chyba při syntaktické analýze odpovědi Capabilities z dané URL",
       "urlInvalid": "Chybějící nebo neplatná adresa URL požadované vrstvy!",
-      "unsupportedDatasourceType": "Nepodporovaný typ vrstvy"
+      "unsupportedDatasourceType": "Nepodporovaný typ vrstvy",
+      "noValidData": "Nebyla nalezena žádná platná data"
     },
     "externalDataSource": "Zdroj externích dat (URL)",
     "featureCount": "Počet prvků",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -71,7 +71,8 @@
       "srsNotSupported": "Selected Coordinate reference systems (CRS/SRS) is not supported. Please provide file in EPSG:3857 or EPSG:4326 to proceed.",
       "thereWasErrorWhile": "There was error while parsing Capabilities response from given URL",
       "urlInvalid": "Missing or invalid endpoint URL of requested layer!",
-      "unsupportedDatasourceType": "Unsupported datasource type"
+      "unsupportedDatasourceType": "Unsupported datasource type",
+      "noValidData": "No valid data found"
     },
     "externalDataSource": "External data source (URL)",
     "featureCount": "Feature count",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -71,7 +71,8 @@
       "srsNotSupported": "Vybraný súradnícový systém (CRS/SRS) nie je podporovaný.Ak chete pokračovať, zadajte súbor v systéme EPSG:3857 alebo EPSG:4326.",
       "thereWasErrorWhile": "Nastala chyba pri syntaktickej analýze odpovede Capabilities z danej URL",
       "urlInvalid": "Chýbajúca alebo neplatná URL požadovanej vrstvy!",
-      "unsupportedDatasourceType": "Nepodporovaný typ vrstvy"
+      "unsupportedDatasourceType": "Nepodporovaný typ vrstvy",
+      "noValidData": "Nenašli sa žiadne vhodné dáta"
     },
     "externalDataSource": "Zdroj externých dát (URL)",
     "featureCount": "Počet prvkov",

--- a/projects/hslayers/src/common/get-capabilities/arcgis-get-capabilities.service.ts
+++ b/projects/hslayers/src/common/get-capabilities/arcgis-get-capabilities.service.ts
@@ -98,13 +98,23 @@ export class HsArcgisGetCapabilitiesService implements IGetCapabilities {
         this.httpClient
           .get(url, {
             responseType: 'json',
+            observe: 'response', // Set observe to 'response' to get headers as well
           })
           .pipe(takeUntil(this.hsAddDataService.cancelUrlRequest))
       );
-      const wrap = {response: r};
+      const wrap = {response: r.body};
       this.hsCapabilityCacheService.set(url, wrap);
       return wrap;
     } catch (e) {
+      const contentType = e.headers.get('Content-Type');
+      if (contentType.includes('text/html')) {
+        return {
+          error: true,
+          response: {
+            message: 'ERROR.noValidData',
+          },
+        };
+      }
       return {response: e, error: true};
     }
   }

--- a/projects/hslayers/src/common/get-capabilities/wfs-get-capabilities.service.ts
+++ b/projects/hslayers/src/common/get-capabilities/wfs-get-capabilities.service.ts
@@ -106,10 +106,20 @@ export class HsWfsGetCapabilitiesService implements IGetCapabilities {
         this.httpClient
           .get(url, {
             responseType: 'text',
+            observe: 'response', // Set observe to 'response' to get headers as well
           })
           .pipe(takeUntil(this.hsAddDataService.cancelUrlRequest))
       );
-      const wrap = {response: r};
+      const contentType = r.headers.get('Content-Type');
+      if (contentType.includes('text/html')) {
+        return {
+          error: true,
+          response: {
+            message: 'ERROR.noValidData',
+          },
+        };
+      }
+      const wrap = {response: r.body};
       this.hsCapabilityCacheService.set(url, wrap);
       return wrap;
     } catch (e) {

--- a/projects/hslayers/src/common/get-capabilities/wms-get-capabilities.service.ts
+++ b/projects/hslayers/src/common/get-capabilities/wms-get-capabilities.service.ts
@@ -115,10 +115,20 @@ export class HsWmsGetCapabilitiesService implements IGetCapabilities {
             withCredentials: url.includes(
               this.hsCommonLaymanService.layman?.url
             ),
+            observe: 'response', // Set observe to 'response' to get headers as well
           })
           .pipe(takeUntil(this.hsAddDataService.cancelUrlRequest))
       );
-      const wrap = {response: r};
+      const contentType = r.headers.get('Content-Type');
+      if (contentType.includes('text/html')) {
+        return {
+          error: true,
+          response: {
+            message: 'ERROR.noValidData',
+          },
+        };
+      }
+      const wrap = {response: r.body};
       this.hsCapabilityCacheService.set(url, wrap);
       return wrap;
     } catch (e) {

--- a/projects/hslayers/src/common/get-capabilities/wmts-get-capabilities.service.ts
+++ b/projects/hslayers/src/common/get-capabilities/wmts-get-capabilities.service.ts
@@ -111,11 +111,20 @@ export class HsWmtsGetCapabilitiesService implements IGetCapabilities {
         this.httpClient
           .get(url, {
             responseType: 'text',
+            observe: 'response', // Set observe to 'response' to get headers as well
           })
           .pipe(takeUntil(this.hsAddDataService.cancelUrlRequest))
       );
-
-      const wrap = {response: r};
+      const contentType = r.headers.get('Content-Type');
+      if (contentType.includes('text/html')) {
+        return {
+          error: true,
+          response: {
+            message: 'ERROR.noValidData',
+          },
+        };
+      }
+      const wrap = {response: r.body};
       this.hsCapabilityCacheService.set(url, wrap);
       return wrap;
     } catch (error) {

--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -98,7 +98,14 @@ export class HsAddDataCommonFileService {
       const response = await fetch(url, {
         method: 'GET',
       });
+      const contentType = response.headers.get('Content-Type');
       if (response.status === 200) {
+        if (contentType.includes('text/html')) {
+          this.hsAddDataUrlService.apps[app].addDataCapsParsingError.next(
+            'ERROR.noValidData'
+          );
+          return;
+        }
         return true;
       } else {
         this.hsAddDataUrlService.apps[app].addDataCapsParsingError.next(

--- a/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
+++ b/projects/hslayers/src/components/add-data/file/types/file-form-data.type.ts
@@ -10,7 +10,7 @@ export type FileFormData = {
   files: FileDescriptor[];
   name: string;
   serializedStyle: FileDescriptor;
-  allowedStyles?: string;
+  allowedStyles?: 'qml' | 'sld' | 'sldqml';
   srs: string;
   title: string;
   timeRegex?: string;

--- a/projects/hslayers/src/components/add-data/vector/vector-data.type.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-data.type.ts
@@ -33,4 +33,5 @@ export type VectorDataObject = {
   type?: string;
   url?: string;
   vectorLayers?: HsLayerDescriptor[];
+  allowedStyles?: 'qml' | 'sld' | 'sldqml';
 };

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.ts
@@ -316,6 +316,7 @@ export class HsAddDataVectorFileComponent
       },
       sourceLayer: null,
       vectorLayers: null,
+      allowedStyles: 'sldqml',
     };
     this.hsAddDataCommonFileService.clearParams(this.app);
   }

--- a/projects/hslayers/src/components/add-data/vector/vector-url/vector-url.component.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector-url/vector-url.component.ts
@@ -88,6 +88,7 @@ export class HsAddDataVectorUrlComponent implements OnInit, OnDestroy {
       title: '',
       type: this.fileType,
       url: undefined,
+      allowedStyles: 'sldqml',
     };
   }
 }


### PR DESCRIPTION
## Description

- When trying to add data from url that returns HTML document its not expected to include any valid data thus it shold be treated as an error
"+"
- fix: Add allowedStyles adddata param to missing data types introduced in 83d4cdd
- Cancel remaining feature count reqeusts if current fails
## Related issues or pull requests

#3899 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
