### PR TITLE
Prefer QML and SLD styles over custom format when loading layer from composition

### DIFF
--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -200,8 +200,8 @@ export class HsAddDataVectorService {
     Object.assign(
       descriptor.layerParams,
       await this.hsStylerService.parseStyle(
-        descriptor.layerParams.style ??
-          (descriptor.layerParams.sld || descriptor.layerParams.qml),
+        (descriptor.layerParams.sld || descriptor.layerParams.qml) ??
+          descriptor.layerParams.style,
         app
       )
     );

--- a/projects/hslayers/src/components/save-map/save-map.service.ts
+++ b/projects/hslayers/src/components/save-map/save-map.service.ts
@@ -1,7 +1,5 @@
 import {Injectable} from '@angular/core';
-import {SerializedStyle} from './types/serialized-style.type';
 
-import Map from 'ol/Map';
 import {Circle, Icon, RegularShape, Style} from 'ol/style';
 import {
   Cluster,
@@ -19,6 +17,7 @@ import {GeoJSONFeatureCollection} from 'ol/format/GeoJSON';
 import {Geometry} from 'ol/geom';
 import {Image as ImageLayer, Tile, Vector as VectorLayer} from 'ol/layer';
 import {Layer} from 'ol/layer';
+import {Map} from 'ol';
 import {Vector as VectorSource} from 'ol/source';
 import {transformExtent} from 'ol/proj';
 
@@ -32,6 +31,7 @@ import {HsUtilsService} from '../utils/utils.service';
 import {LayerJSON} from './types/layer-json.type';
 import {MapComposition} from './types/map-composition.type';
 import {SerializedImage} from './types/serialized-image.type';
+import {SerializedStyle} from './types/serialized-style.type';
 import {StatusData} from './types/status-data.type';
 import {UserData} from './types/user-data.type';
 import {
@@ -45,6 +45,7 @@ import {
   getName,
   getOrigLayers,
   getPath,
+  getQml,
   getShowInLayerManager,
   getSld,
   getSubLayers,
@@ -234,6 +235,7 @@ export class HsSaveMapService {
    * Convert layer's style object into JSON object, partial function of layer2style
    * (saves Fill color, Stroke color/width, Image fill, stroke, radius, src and type)
    *
+   * @deprecated Parse style to old custom JSON, should not be used and will be removed. Use SLD or QML instead
    * @param style - Style to convert
    * @param app - App identifier
    * @returns Converted JSON object replacing OL style
@@ -462,15 +464,11 @@ export class HsSaveMapService {
       json.projection = 'epsg:4326';
       if (getSld(layer) != undefined) {
         json.style = getSld(layer);
-      } else if (
-        this.hsUtilsService.instOf(
-          (layer as VectorLayer<VectorSource<Geometry>>).getStyle(),
-          Style
-        )
-      ) {
-        json.style = this.serializeStyle(
-          (layer as VectorLayer<VectorSource<Geometry>>).getStyle() as Style,
-          app
+      } else if (getQml(layer) != undefined) {
+        json.style = getQml(layer);
+      } else {
+        this.hsLogService.warn(
+          `Vector layer ${layer.get('title')} is missing style definition`
         );
       }
     }

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -270,6 +270,7 @@ export class HsStylerService {
       !this.hsUtilsService.isFunction(style) &&
       !Array.isArray(style)
     ) {
+      //Backwards compatibility with custom style JSON
       const customJson = this.hsSaveMapService.serializeStyle(
         style as Style,
         app


### PR DESCRIPTION
## Description

Prefer QML and SLD styles over custom format when loading layer from composition

## Related issues or pull requests

backported from #3945 by @FilipLeitner
resolves #3943

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
