### PR TITLE
Fix cluster style with multiple clustered layers

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -1,10 +1,9 @@
-import Feature from 'ol/Feature';
-import LayerGroup from 'ol/layer/Group';
+import BaseLayer from 'ol/layer/Base';
+import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
 import {Group, Layer} from 'ol/layer';
 import {Source} from 'ol/source';
 
-import BaseLayer from 'ol/layer/Base';
 import {DOMFeatureLink} from './dom-feature-link.type';
 import {HsLaymanLayerDescriptor} from '../components/save-map/interfaces/layman-layer-descriptor.interface';
 import {accessRightsModel} from '../components/add-data/common/access-rights.model';
@@ -502,7 +501,7 @@ export function getOnFeatureSelected(layer: Layer<Source>): FeatureSelector {
 }
 
 /**
- * Used internaly by hslayers. Store the original LAYERS param
+ * Used internally by hslayers. Store the original LAYERS param
  * when overriding LAYERS by subLayers property. This is needed for metadata
  * parsing after page has refreshed and LAYERS are read from cookie or map compositions.
  * @param layer - OL layer
@@ -613,7 +612,7 @@ export function setThumbnail(layer: Layer<Source>, thumbnail: string): void {
   layer.set(THUMBNAIL, thumbnail);
 }
 
-export function getThumbnail(layer: Layer<Source> | LayerGroup): string {
+export function getThumbnail(layer: Layer<Source> | Group): string {
   return layer.get(THUMBNAIL);
 }
 

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -1,18 +1,19 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 
-import ImageSource from 'ol/source/Image';
-import TileSource from 'ol/source/Tile';
 import WMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
 import {GeoJSON} from 'ol/format';
 import {Geometry} from 'ol/geom';
 import {
   ImageArcGISRest,
+  Image as ImageSource,
   ImageStatic,
   ImageWMS,
   Source,
   TileArcGISRest,
+  Tile as TileSource,
   TileWMS,
+  Vector as VectorSource,
   XYZ,
 } from 'ol/source';
 import {
@@ -21,9 +22,10 @@ import {
   Tile,
   Vector as VectorLayer,
 } from 'ol/layer';
+// eslint-disable-next-line import/named
 import {Options as ImageOptions} from 'ol/layer/BaseImage';
+// eslint-disable-next-line import/named
 import {Options as TileOptions} from 'ol/layer/BaseTile';
-import {Vector as VectorSource} from 'ol/source';
 import {WMTSCapabilities} from 'ol/format';
 
 import SparqlJson from '../../../common/layers/hs.source.SparqlJson';
@@ -62,10 +64,10 @@ export class HsCompositionsLayerParserService {
   ) {}
 
   /**
+   * Initiate creation of WFS layer through HsUrlWfsService
+   *
    * @public
    * @param lyr_def - Layer definition object
-   
-   * Initiate creation of WFS layer through HsUrlWfsService
    */
   async createWFSLayer(lyr_def): Promise<Layer<Source>> {
     const newLayer = new VectorLayer({

--- a/projects/hslayers/src/components/core/event-bus.service.ts
+++ b/projects/hslayers/src/components/core/event-bus.service.ts
@@ -1,10 +1,9 @@
 import {BehaviorSubject, Subject} from 'rxjs';
 import {Injectable} from '@angular/core';
 
-import Feature from 'ol/Feature';
+import {Feature, Map} from 'ol';
 import {Geometry} from 'ol/geom';
 import {Layer, Vector as VectorLayer} from 'ol/layer';
-import {Map} from 'ol';
 import {Select} from 'ol/interaction';
 import {Source} from 'ol/source';
 
@@ -43,8 +42,8 @@ export class HsEventBusService {
    * @event compositionLoads
    */
   compositionLoads: Subject<any> = new Subject();
-  layerRemovals: Subject<Layer<Source>> = new Subject();
   compositionEdits: Subject<void> = new Subject();
+  layerRemovals: Subject<Layer<Source>> = new Subject();
   layerAdditions: Subject<HsLayerDescriptor> = new Subject();
   LayerManagerBaseLayerVisibilityChanges: Subject<any> = new Subject();
   LayerManagerLayerVisibilityChanges: Subject<any> = new Subject();
@@ -70,7 +69,7 @@ export class HsEventBusService {
     time: string;
   }> = new Subject();
   /**
-   * Used to listen for changes either in "time" property in HsLayerDescrtiptor
+   * Used to listen for changes either in "time" property in HsLayerDescriptor
    * or in "dimensions" property in OL Layer object
    */
   layerDimensionDefinitionChanges: Subject<Layer<Source>> = new Subject();

--- a/projects/hslayers/src/components/draw/draw.service.ts
+++ b/projects/hslayers/src/components/draw/draw.service.ts
@@ -2,16 +2,16 @@ import {Injectable, NgZone} from '@angular/core';
 import {lastValueFrom} from 'rxjs';
 
 import {Circle, Geometry} from 'ol/geom';
-import {Cluster, Source} from 'ol/source';
+import {Cluster, Source, Vector as VectorSource} from 'ol/source';
 import {DragBox, Draw, Modify, Snap} from 'ol/interaction';
 import {DrawEvent} from 'ol/interaction/Draw';
-import {Layer} from 'ol/layer';
-import {Vector as VectorLayer} from 'ol/layer';
-import {Vector as VectorSource} from 'ol/source';
+// eslint-disable-next-line import/named
+import {EventsKey} from 'ol/events';
+import {Layer, Vector as VectorLayer} from 'ol/layer';
 import {fromCircle} from 'ol/geom/Polygon';
 import {platformModifierKeyOnly} from 'ol/events/condition';
+import {unByKey} from 'ol/Observable';
 
-import {EventsKey} from 'ol/events';
 import {HsAddDataOwsService} from '../add-data/url/add-data-ows.service';
 import {HsAddDataVectorService} from '../add-data/vector/vector.service';
 import {HsCommonLaymanService} from '../../common/layman/layman.service';
@@ -48,7 +48,6 @@ import {
   setTitle,
   setWorkspace,
 } from '../../common/layer-extensions';
-import {unByKey} from 'ol/Observable';
 
 type activateParams = {
   onDrawStart?;
@@ -358,7 +357,7 @@ export class HsDrawService extends HsDrawServiceParams {
 
   /**
    * @param changeStyle - controller callback function
-   * Update draw style without neccessity to reactivate drawing interaction
+   * Update draw style without necessity to reactivate drawing interaction
    */
   updateStyle(changeStyle): void {
     if (this.draw) {
@@ -667,7 +666,7 @@ export class HsDrawService extends HsDrawServiceParams {
   }
 
   /**
-   * Determines whether rightclick should finish the drawing or not
+   * Determines whether right-click should finish the drawing or not
    * @param typeNum - Number used in calculation of minimal number of vertexes. Depends on geom type (polygon/line)
    * @param vertexCount - Number of vertexes the sketch has
    * @returns return boolean value if right mouse button was clicked

--- a/projects/hslayers/src/components/feature-table/feature-table.service.ts
+++ b/projects/hslayers/src/components/feature-table/feature-table.service.ts
@@ -1,10 +1,9 @@
 import {Injectable} from '@angular/core';
 
-import {Cluster, Source} from 'ol/source';
+import {Cluster, Source, Vector as VectorSource} from 'ol/source';
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
 import {Layer, Vector as VectorLayer} from 'ol/layer';
-import {Vector as VectorSource} from 'ol/source';
 
 import {HsLanguageService} from '../language/language.service';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
@@ -42,8 +41,9 @@ export class HsFeatureTableService {
   ) {}
 
   /**
-   * @param layer - Layer from HsConfig.layersInFeatureTable
    * Checks if layer is vectorLayer and is visible in layer_manager, to exclude layers, such as, point Clicked
+   *
+   * @param layer - Layer from HsConfig.layersInFeatureTable
    * @returns Returns layer
    */
   addLayer(layer: Layer<Source>): any {
@@ -57,9 +57,11 @@ export class HsFeatureTableService {
     }
     return;
   }
+
   /**
-   * @param layer - Layer from HsConfig.layersInFeatureTable
    * Wrap layer object
+   *
+   * @param layer - Layer from HsConfig.layersInFeatureTable
    * @returns Returns wrapped layer object
    */
   wrapLayer(layer: Layer<Source>): any {
@@ -69,10 +71,11 @@ export class HsFeatureTableService {
       type: 'vector',
     };
   }
+
   /**
-   * @param layer - Layer from HsConfig.layersInFeatureTable
-   
    * Search all layers feature attributes and map them into new objects for html table
+   *
+   * @param layer - Layer from HsConfig.layersInFeatureTable
    */
   fillFeatureList(layer: Layer<Source>): void {
     const source: VectorSource<Geometry> =
@@ -86,9 +89,9 @@ export class HsFeatureTableService {
   }
 
   /**
-   * @param feature - Feature selected
-   
    * Update feature description
+   *
+   * @param feature - Feature selected
    */
   updateFeatureDescription(feature: Feature<Geometry>): void {
     const newDescriptor = this.describeFeature(feature);
@@ -99,9 +102,9 @@ export class HsFeatureTableService {
   }
 
   /**
-   * @param feature - Feature selected
-   
    * Add feature description
+   *
+   * @param feature - Feature selected
    */
   addFeatureDescription(feature: Feature<Geometry>): void {
     const newDescriptor = this.describeFeature(feature);
@@ -111,9 +114,9 @@ export class HsFeatureTableService {
   }
 
   /**
-   * @param feature - Feature selected
-   
    * Remove feature description
+   *
+   * @param feature - Feature selected
    */
   removeFeatureDescription(feature: Feature<Geometry>): void {
     const currentIx = this.features.findIndex((f) => f.feature == feature);
@@ -123,9 +126,9 @@ export class HsFeatureTableService {
   }
 
   /**
-   * @param feature - Feature selected
-   
    * Describe feature
+   *
+   * @param feature - Feature selected
    */
   describeFeature(feature: Feature<Geometry>): FeatureDescriptor {
     const attribWrapper = this.hsQueryVectorService
@@ -143,8 +146,9 @@ export class HsFeatureTableService {
   }
 
   /**
+   * Find feature name attribute and separate it from other attributes for html table purposes
+   *
    * @param attributes - layers feature attributes
-   * Find feature name attribute and seperate it from other attributes for html table purposes
    * @returns feature name
    */
   setFeatureName(attributes: any): string {
@@ -160,18 +164,21 @@ export class HsFeatureTableService {
       return 'Feature';
     }
   }
+
   /**
-   * @param attributes - layers feature attributes
    * Remove feature name attribute from feature attributes array
+   *
+   * @param attributes - layers feature attributes
    * @returns feature attributes
    */
   attributesWithoutFeatureName(attributes: any): any {
     return attributes.filter((attr) => attr.name !== 'name');
   }
+
   /**
-   * @param valueName - Requested value to sort the feature table list
-   
    * Sort features by requested value
+   *
+   * @param valueName - Requested value to sort the feature table list
    */
   sortFeaturesBy(valueName): void {
     if (this.features !== undefined && this.features.length > 1) {
@@ -183,12 +190,13 @@ export class HsFeatureTableService {
       );
     }
   }
+
   /**
+   * Sorting algorithm
+   *
    * @param a - First input feature
    * @param b - second input feature
    * @param valueName - Sorting value
-   
-   * Sorting algorithm
    * @returns Returns each features relative position in the table
    */
   sortFeatures(a, b, valueName): number {
@@ -223,10 +231,12 @@ export class HsFeatureTableService {
     this.lastSortValue = valueName;
     return position;
   }
+
   /**
+   * Get requested features attribute value, which will be used in the sorting algorithm
+   *
    * @param attributes - features attributes
    * @param valueName - Sorting value
-   * Get requested features attribute value, which will be used in the sorting algorithm
    * @returns Returns attributes value
    */
   getValue(attributes: any, valueName: string): string | number {

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor-vector-layer.service.ts
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor-vector-layer.service.ts
@@ -1,8 +1,8 @@
-import {Circle, Geometry, LineString, Point, Polygon} from 'ol/geom';
-import {Cluster, Source} from 'ol/source';
 import {Injectable} from '@angular/core';
+
+import {Circle, Geometry, LineString, Point, Polygon} from 'ol/geom';
+import {Cluster, Source, Vector as VectorSource} from 'ol/source';
 import {Layer, Vector as VectorLayer} from 'ol/layer';
-import {Vector as VectorSource} from 'ol/source';
 
 import {HsConfig} from './../../../config.service';
 import {HsMapService} from '../../map/map.service';
@@ -15,18 +15,20 @@ import {HsUtilsService} from '../../utils/utils.service';
 export class HsLayerEditorVectorLayerService {
   layersClusteredFromStart = [];
   constructor(
-    public HsMapService: HsMapService,
-    public HsUtilsService: HsUtilsService,
-    public HsStylerService: HsStylerService,
-    public HsConfig: HsConfig
+    public hsConfig: HsConfig,
+    public hsMapService: HsMapService,
+    public hsStylerService: HsStylerService,
+    public hsUtilsService: HsUtilsService
   ) {}
 
   /**
-   * Convert layer to clustered state where it's source gets nested in another
+   * Convert layer to clustered state where its source gets nested in another
    * VectorSource and first level sources features contain 'features' attribute
    * with the original features in it as an array
    * @param newValue - Cluster or not to cluster
+   * @param layer - OL Layer to cluster or de-cluster
    * @param distance - Minimum distance in pixels between clusters
+   * @param generateStyle - Whether a default cluster style shall be generated for the layer
    */
   async cluster(
     newValue: boolean,
@@ -35,10 +37,10 @@ export class HsLayerEditorVectorLayerService {
     generateStyle: boolean
   ): Promise<void> {
     if (newValue == true) {
-      if (!this.HsUtilsService.instOf(layer.getSource(), Cluster)) {
+      if (!this.hsUtilsService.instOf(layer.getSource(), Cluster)) {
         layer.setSource(this.createClusteredSource(layer, distance));
         if (generateStyle) {
-          await this.HsStylerService.styleClusteredLayer(
+          await this.hsStylerService.styleClusteredLayer(
             layer as VectorLayer<Cluster>
           );
         }
@@ -46,7 +48,7 @@ export class HsLayerEditorVectorLayerService {
           layer as VectorLayer<VectorSource<Geometry>>
         );
       }
-    } else if (this.HsUtilsService.instOf(layer.getSource(), Cluster)) {
+    } else if (this.hsUtilsService.instOf(layer.getSource(), Cluster)) {
       layer.setSource((layer.getSource() as Cluster).getSource());
     }
   }
@@ -76,12 +78,13 @@ export class HsLayerEditorVectorLayerService {
       },
     });
   }
+
   updateFeatureTableLayers(layer: VectorLayer<VectorSource<Geometry>>): void {
-    const currentLayerIndex = this.HsConfig.layersInFeatureTable?.findIndex(
+    const currentLayerIndex = this.hsConfig.layersInFeatureTable?.findIndex(
       (l) => l == layer
     );
     if (layer && currentLayerIndex > -1) {
-      this.HsConfig.layersInFeatureTable[currentLayerIndex] = layer;
+      this.hsConfig.layersInFeatureTable[currentLayerIndex] = layer;
     }
   }
 }

--- a/projects/hslayers/src/components/legend/legend.service.ts
+++ b/projects/hslayers/src/components/legend/legend.service.ts
@@ -1,17 +1,21 @@
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {Injectable} from '@angular/core';
 
-import Feature from 'ol/Feature';
 import LegendRenderer from 'geostyler-legend/dist/LegendRenderer/LegendRenderer';
-import RenderFeature from 'ol/render/Feature';
+import {Feature} from 'ol';
 import {Style as GeoStylerStyle} from 'geostyler-style';
 import {Geometry} from 'ol/geom';
 import {Image as ImageLayer, Layer, Vector as VectorLayer} from 'ol/layer';
 import {OlStyleParser} from 'geostyler-openlayers-parser';
 import {SldStyleParser as SLDParser} from 'geostyler-sld-parser';
-import {Source, ImageStatic as Static, XYZ} from 'ol/source';
+import {
+  Source,
+  ImageStatic as Static,
+  Vector as VectorSource,
+  XYZ,
+} from 'ol/source';
 import {Style} from 'ol/style';
-import {Vector as VectorSource} from 'ol/source';
+import {StyleFunction, StyleLike} from 'ol/style/Style';
 
 import {HsLayerSelectorService} from '../layermanager/editor/layer-selector.service';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';
@@ -30,13 +34,6 @@ import {
   getTitle,
 } from '../../common/layer-extensions';
 import {getLaymanFriendlyLayerName} from '../../common/layman/layman-utils';
-
-//Following type-defs are missing in the OL export
-declare type StyleFunction = (
-  feature: Feature<any> | RenderFeature,
-  number?: number
-) => void | Style | Style[];
-declare type StyleLike = Style | Array<Style> | StyleFunction;
 
 @Injectable({
   providedIn: 'root',

--- a/projects/hslayers/src/components/query/feature-common.service.ts
+++ b/projects/hslayers/src/components/query/feature-common.service.ts
@@ -1,11 +1,10 @@
+import {BehaviorSubject, Observable} from 'rxjs';
 import {Injectable} from '@angular/core';
 
-import {BehaviorSubject, Observable} from 'rxjs';
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
 import {Layer} from 'ol/layer';
-import {Source} from 'ol/source';
-import {Vector as VectorSource} from 'ol/source';
+import {Source, Vector as VectorSource} from 'ol/source';
 
 import {HsLanguageService} from '../language/language.service';
 import {HsLayerUtilsService} from '../utils/layer-utils.service';

--- a/projects/hslayers/src/components/query/query-base.service.ts
+++ b/projects/hslayers/src/components/query/query-base.service.ts
@@ -1,14 +1,15 @@
 import {DomSanitizer} from '@angular/platform-browser';
 import {Injectable, NgZone} from '@angular/core';
+import {Subject} from 'rxjs';
 
-import {Circle, Fill, Stroke, Style} from 'ol/style';
-import {Circle as CircleStyle} from 'ol/style';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
+// eslint-disable-next-line import/named
 import {Coordinate, createStringXY, toStringHDMS} from 'ol/coordinate';
 import {Feature, Map} from 'ol';
+// eslint-disable-next-line import/named
 import {FeatureLike} from 'ol/Feature';
 import {Geometry, Point} from 'ol/geom';
 import {Select} from 'ol/interaction';
-import {Subject} from 'rxjs';
 import {Vector} from 'ol/source';
 import {Vector as VectorLayer} from 'ol/layer';
 import {transform} from 'ol/proj';
@@ -119,7 +120,6 @@ export class HsQueryBaseService {
    * Get features under the mouse pointer on the map
    * @param map - Current map object
    * @param pixel - Target pixel
-   
    * @returns Array with features
    */
   getFeaturesUnderMouse(map: Map, pixel: number[]): FeatureLike[] {
@@ -144,7 +144,6 @@ export class HsQueryBaseService {
   /**
    * Push a new feature info html content to other htmls array
    * @param html - Feature info html content
-   
    */
   pushFeatureInfoHtml(html: string): void {
     this.featureInfoHtmls.push(this.domSanitizer.bypassSecurityTrustHtml(html));
@@ -155,7 +154,6 @@ export class HsQueryBaseService {
    * Fill popup iframe and resize it to fit the content
    * @param response - Response of GetFeatureInfoRequest
    * @param append - If true, the response will be appended to iframe's inner HTML, otherwise its content will be replaced
-   
    */
   fillIframeAndResize(response: string, append: boolean): void {
     const iframe = this.getInvisiblePopup();
@@ -186,7 +184,6 @@ export class HsQueryBaseService {
   /**
    * Get coordinates in multiple projections
    * @param coordinate - Coordinates from map single click interaction
-   
    * @returns Object with coordinates in multiple projections
    */
   getCoordinate(coordinate: Coordinate): {
@@ -228,7 +225,6 @@ export class HsQueryBaseService {
 
   /**
    * Activate queries for the current OL map
-   
    */
   activateQueries(): void {
     if (this.queryActive) {
@@ -242,7 +238,6 @@ export class HsQueryBaseService {
 
   /**
    * Deactivate queries for the current OL map
-   
    */
   deactivateQueries(): void {
     if (!this.queryActive) {
@@ -255,7 +250,6 @@ export class HsQueryBaseService {
 
   /**
    * Check if current app panel is queryable
-   
    * @returns - True or false
    */
   currentPanelQueryable(): boolean {
@@ -267,12 +261,11 @@ export class HsQueryBaseService {
 
   /**
    * Get style for point clicked on the map
-   
    * @returns - OL style
    */
   pointClickedStyle(): Style {
     const defaultStyle = new Style({
-      image: new Circle({
+      image: new CircleStyle({
         fill: new Fill({
           color: 'rgba(255, 156, 156, 0.4)',
         }),

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -9,7 +9,7 @@ import {
   SldStyleParser as SLDParser,
   SldVersion,
 } from 'geostyler-sld-parser';
-import {getUid, Feature} from 'ol';
+import {Feature, getUid} from 'ol';
 import {
   FillSymbolizer,
   Filter,
@@ -21,7 +21,8 @@ import {Geometry} from 'ol/geom';
 import {Icon, Style} from 'ol/style';
 import {OlStyleParser as OpenLayersParser} from 'geostyler-openlayers-parser';
 import {QGISStyleParser} from 'geostyler-qgis-parser';
-import {createDefaultStyle, StyleFunction, StyleLike} from 'ol/style/Style';
+// eslint-disable-next-line import/named
+import {StyleFunction, StyleLike, createDefaultStyle} from 'ol/style/Style';
 import {Vector as VectorLayer} from 'ol/layer';
 
 import {HsCommonLaymanService} from '../../common/layman/layman.service';
@@ -223,7 +224,6 @@ export class HsStylerService {
   async initLayerStyle(
     layer: VectorLayer<VectorSource<Geometry>>
   ): Promise<void> {
-    console.log("initLayerStyle");
     if (!this.isVectorLayer(layer)) {
       return;
     }
@@ -241,9 +241,13 @@ export class HsStylerService {
       }
       if (getCluster(layer)) {
         if (!this.hsUtilsService.instOf(layer.getSource(), Cluster)) {
-          this.hsLogService.warn(`Layer ${getTitle(layer)} is meant to be clustered but not an instance of Cluster source! Waiting for a change:source event...`)
+          this.hsLogService.warn(
+            `Layer ${getTitle(
+              layer
+            )} is meant to be clustered but not an instance of Cluster source! Waiting for a change:source event...`
+          );
           await new Promise((resolve) => {
-            layer.once('change:source', (evt) => resolve(evt.target))
+            layer.once('change:source', (evt) => resolve(evt.target));
           });
         }
         //await is necessary because of consecutive code (this.fill())


### PR DESCRIPTION
## Description

This PR addresses issue #4042 , namely the situation when multiple clustered layers are added to map. In that case, styling code is faster then the code responsible for changing the layer's source from `VectorLayer` to `Cluster`. That leads to improper style application (see #4042). I am addressing it by manually waiting for a `change:source` event if such situation occurs. On my machine, the issue was present when 6 or more clustered layers were in the map (from the beginning, via HsConfig). Now tested with 100 layers with no problem.

## Related issues or pull requests

resolves #4042

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
