### PR TITLE
Issue 4058

### DIFF
--- a/projects/hslayers/src/common/queues/queues.service.ts
+++ b/projects/hslayers/src/common/queues/queues.service.ts
@@ -17,13 +17,11 @@ export class HsQueuesService {
   /**
    * Get the params saved by the queues service for the current app
    * @param useCase - Queue for
-   
    * @param customConcurrency - (Optional) custom concurrency
    * @param timeout - (Optional) Timeout of one queue item
    */
   ensureQueue(
     useCase: string,
-
     customConcurrency?: number,
     timeout?: number
   ): queue {

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
@@ -2,7 +2,7 @@ import {Injectable, NgZone} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
-import {forkJoin} from 'rxjs';
+import {Observable, forkJoin} from 'rxjs';
 
 import {DatasetType, HsAddDataService} from '../add-data.service';
 import {EndpointsWithDatasourcesPipe} from '../../../common/widgets/endpoints-with-datasources.pipe';
@@ -181,8 +181,7 @@ export class HsAddDataCatalogueService extends HsAddDataCatalogueParams {
       this.hsMapService.loaded().then(() => {
         this.dataLoading = true;
         this.hsAddDataCatalogueMapService.clearExtentLayer();
-        const observables = [];
-
+        const observables: Observable<any>[] = [];
         //TODO Mark non functional endpoint
         for (const endpoint of this.endpointsWithDatasources) {
           if (!this.data.onlyMine || endpoint.type.includes('layman')) {

--- a/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wms/wms.service.ts
@@ -411,8 +411,10 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
         `<a href="${layer.Attribution.OnlineResource}">${layer.Attribution.Title}</a>`,
       ];
     }
-    const dimensions = {};
+
+    let dimensions;
     if (layer.Dimension) {
+      dimensions = {};
       for (const val of layer.Dimension) {
         dimensions[val.name] = val;
       }

--- a/projects/hslayers/src/components/compositions/compositions-catalogue.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-catalogue.service.ts
@@ -158,7 +158,7 @@ export class HsCompositionsCatalogueService {
     this.clearLoadedData();
     this.dataLoading = true;
     this.hsMapService.loaded().then(() => {
-      const observables = [];
+      const observables: Observable<any>[] = [];
       for (const endpoint of this.filteredEndpoints) {
         observables.push(this.loadCompositionFromEndpoint(endpoint));
       }

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -285,7 +285,7 @@ export class HsCompositionsParserService {
     for (const layer of res.LayerList.Layer) {
       const layerToAdd = {
         className: 'HSLayers.Layer.WMS',
-        dimensions: {},
+        dimensions: undefined,
         legends: [''],
         maxResolution: null,
         metadata: {},

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -280,7 +280,9 @@ export class HsLayerManagerService {
         const que = this.hsQueuesService.ensureQueue(
           'wmsGetCapabilities',
           1,
-          5000
+          //In case of slow request give 10s for other tasks to complete before
+          //making another request that might be blocking otherwise
+          10000
         );
         que.push(async (cb) => {
           try {

--- a/projects/hslayers/src/components/map/map.spec.ts
+++ b/projects/hslayers/src/components/map/map.spec.ts
@@ -11,6 +11,7 @@ import Point from 'ol/geom/Point';
 import {Vector as VectorLayer} from 'ol/layer';
 import {Vector as VectorSource} from 'ol/source';
 
+import {HsCommonLaymanService} from '../../common/layman/layman.service';
 import {HsConfig} from '../../config.service';
 import {HsConfigMock} from '../../config.service.mock';
 import {HsCoreService} from '../core/core.service';
@@ -59,6 +60,12 @@ describe('HsMapService', () => {
         {provide: HsUtilsService, useValue: new HsUtilsServiceMock()},
         {provide: HsConfig, useValue: new HsConfigMock()},
         {provide: HsLanguageService, useValue: mockLanguageService()},
+        {
+          provide: HsCommonLaymanService,
+          useValue: {
+            layman: null,
+          },
+        },
       ],
     }); //.compileComponents();
     fixture = TestBed.createComponent(HsMapComponent);

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -353,6 +353,7 @@ export class HslayersAppComponent {
       panelWidths: {
         custom: 555,
       },
+      open_lm_after_comp_loaded: false,
       queryPopupWidgets: ['layer-name', 'feature-info', 'clear-layer'],
       datasources: [
         {
@@ -437,217 +438,217 @@ export class HslayersAppComponent {
       status_manager_url: 'http://localhost:8086',
       popUpDisplay: 'hover',
       errorToastDuration: 1000,
-      default_layers: [
-        new Tile({
-          source: new OSM(),
-          visible: true,
-          properties: {
-            title: 'OpenStreet Map',
-            base: true,
-            removable: false,
-          },
-        }),
-        new VectorLayer({
-          properties: {
-            title: 'POIs from SPOI in Italy',
-            cluster: true,
-            editor: {editable: false},
-            editable: false,
-          },
-          source: new SparqlJson({
-            geomAttribute: '?geom',
-            endpointUrl: 'https://www.foodie-cloud.org/sparql',
-            query: `SELECT ?s ?p ?o ?geom
-                FROM <http://www.sdi4apps.eu/poi.rdf>
-                WHERE {
-                  ?s <http://www.opengis.net/ont/geosparql#asWKT> ?geom.
-                  ?s geo:sfWithin <http://www.geonames.org/3175395>.
-                  FILTER(isBlank(?geom) = false).
-                  <extent> ?s ?p ?o.
-                } ORDER BY ?s`,
-            optimization: 'virtuoso',
-            projection: 'EPSG:3857',
-          }),
-          minZoom: 12,
-          visible: false,
-        }),
-        new VectorLayer({
-          properties: {
-            title: 'Cafés from SPOI (world-wide)',
-            cluster: true,
-            editor: {editable: false},
-            editable: false,
-          },
-          source: new SPOI({
-            category: 'cafe',
-            projection: 'EPSG:3857',
-          }),
-          style: new Style({
-            image: new Circle({
-              fill: new Fill({
-                color: 'rgba(255, 204, 102, 0.7)',
-              }),
-              stroke: new Stroke({
-                color: 'rgb(230, 46, 0)',
-                width: 1,
-              }),
-              radius: 5,
-            }),
-          }),
-          minZoom: 11,
-          visible: false,
-        }),
-        new VectorLayer({
-          visible: true,
-          properties: {
-            title: 'Clusters without SLD',
-            synchronize: false,
-            cluster: true,
-            inlineLegend: true,
-            popUp: {
-              attributes: ['name', 'population'],
-            },
-            editor: {editable: false},
-            path: 'User generated',
-          },
-          style: new Style({
-            image: new Circle({
-              fill: new Fill({
-                color: 'rgba(0, 157, 87, 0.5)',
-              }),
-              stroke: new Stroke({
-                color: 'rgb(0, 157, 87)',
-                width: 2,
-              }),
-              radius: 5,
-            }),
-          }),
-          source: new VectorSource({features}),
-        }),
-        new VectorLayer({
-          visible: true,
-          properties: {
-            title: 'Polygons',
-            synchronize: false,
-            cluster: false,
-            inlineLegend: true,
-            popUp: {
-              attributes: ['name'],
-              widgets: ['layer-name', 'clear-layer'],
-            },
-            domFeatureLinks: [
-              {
-                domSelector: '#poly1',
-                feature: 'poly1',
-                event: 'mouseover',
-                actions: ['zoomToExtent', 'select'],
-              },
-              {
-                domSelector: '#poly2',
-                feature: 'poly2',
-                event: 'mouseover',
-                actions: ['zoomToExtent', 'showPopup'],
-              },
-            ],
-            editor: {
-              editable: true,
-              defaultAttributes: {
-                name: 'New polygon',
-                description: 'none',
-              },
-            },
-            sld: polygonSld,
-            path: 'User generated',
-          },
-          source: new VectorSource({
-            features: new GeoJSON().readFeatures(geojsonObject),
-          }),
-        }),
-        new VectorLayer({
-          visible: true,
-          properties: {
-            title: 'Polygons with display f-n',
-            synchronize: false,
-            cluster: false,
-            inlineLegend: true,
-            popUp: {
-              attributes: ['name'],
-              widgets: ['layer-name', 'clear-layer'], //Will be ignored due to display function
-              displayFunction: function (feature) {
-                return `<a>${feature.get(
-                  'name'
-                )} with population of ${feature.get('population')}</a>`;
-              },
-            },
-            editor: {
-              editable: true,
-              defaultAttributes: {
-                name: 'New polygon',
-                description: 'none',
-              },
-            },
-            sld: polygonSld,
-            path: 'User generated',
-          },
-          source: new VectorSource({
-            features: new GeoJSON().readFeatures(geojsonObject),
-          }),
-        }),
-        polygons,
-        points,
-        new Tile({
-          visible: false,
-          properties: {
-            title: 'Latvian municipalities (parent layer)',
-            queryFilter: (map, layer, pixel) => {
-              return true;
-            },
-          },
-          source: new TileWMS({
-            url: 'https://lvmgeoserver.lvm.lv/geoserver/ows',
-            params: {
-              LAYERS: 'publicwfs:LV_admin_vienibas',
-              INFO_FORMAT: undefined,
-              FORMAT: 'image/png; mode=8bit',
-            },
-            crossOrigin: 'anonymous',
-          }),
-        }),
-        new Tile({
-          visible: false,
-          properties: {
-            title: 'Latvian municipalities (1 sub-layer)',
-            sublayers: 'publicwfs:arisparish',
-          },
-          source: new TileWMS({
-            url: 'https://lvmgeoserver.lvm.lv/geoserver/ows',
-            params: {
-              LAYERS: 'publicwfs:LV_admin_vienibas',
-              INFO_FORMAT: undefined,
-              FORMAT: 'image/png; mode=8bit',
-            },
-            crossOrigin: 'anonymous',
-          }),
-        }),
-        new Tile({
-          visible: false,
-          properties: {
-            title: 'EVI',
-          },
-          source: new TileWMS({
-            url: 'https://eo.lesprojekt.cz/geoserver/nemecek/wms',
-            params: {
-              LAYERS: 'EVI',
-              INFO_FORMAT: undefined,
-              FORMAT: 'image/png; mode=8bit',
-            },
-            crossOrigin: 'anonymous',
-          }),
-        }),
-        opticalMap,
-        idwLayer,
-        idwVectorLayer,
-      ],
+      // default_layers: [
+      //   new Tile({
+      //     source: new OSM(),
+      //     visible: true,
+      //     properties: {
+      //       title: 'OpenStreet Map',
+      //       base: true,
+      //       removable: false,
+      //     },
+      //   }),
+      //   new VectorLayer({
+      //     properties: {
+      //       title: 'POIs from SPOI in Italy',
+      //       cluster: true,
+      //       editor: {editable: false},
+      //       editable: false,
+      //     },
+      //     source: new SparqlJson({
+      //       geomAttribute: '?geom',
+      //       endpointUrl: 'https://www.foodie-cloud.org/sparql',
+      //       query: `SELECT ?s ?p ?o ?geom
+      //           FROM <http://www.sdi4apps.eu/poi.rdf>
+      //           WHERE {
+      //             ?s <http://www.opengis.net/ont/geosparql#asWKT> ?geom.
+      //             ?s geo:sfWithin <http://www.geonames.org/3175395>.
+      //             FILTER(isBlank(?geom) = false).
+      //             <extent> ?s ?p ?o.
+      //           } ORDER BY ?s`,
+      //       optimization: 'virtuoso',
+      //       projection: 'EPSG:3857',
+      //     }),
+      //     minZoom: 12,
+      //     visible: false,
+      //   }),
+      //   new VectorLayer({
+      //     properties: {
+      //       title: 'Cafés from SPOI (world-wide)',
+      //       cluster: true,
+      //       editor: {editable: false},
+      //       editable: false,
+      //     },
+      //     source: new SPOI({
+      //       category: 'cafe',
+      //       projection: 'EPSG:3857',
+      //     }),
+      //     style: new Style({
+      //       image: new Circle({
+      //         fill: new Fill({
+      //           color: 'rgba(255, 204, 102, 0.7)',
+      //         }),
+      //         stroke: new Stroke({
+      //           color: 'rgb(230, 46, 0)',
+      //           width: 1,
+      //         }),
+      //         radius: 5,
+      //       }),
+      //     }),
+      //     minZoom: 11,
+      //     visible: false,
+      //   }),
+      //   new VectorLayer({
+      //     visible: true,
+      //     properties: {
+      //       title: 'Clusters without SLD',
+      //       synchronize: false,
+      //       cluster: true,
+      //       inlineLegend: true,
+      //       popUp: {
+      //         attributes: ['name', 'population'],
+      //       },
+      //       editor: {editable: false},
+      //       path: 'User generated',
+      //     },
+      //     style: new Style({
+      //       image: new Circle({
+      //         fill: new Fill({
+      //           color: 'rgba(0, 157, 87, 0.5)',
+      //         }),
+      //         stroke: new Stroke({
+      //           color: 'rgb(0, 157, 87)',
+      //           width: 2,
+      //         }),
+      //         radius: 5,
+      //       }),
+      //     }),
+      //     source: new VectorSource({features}),
+      //   }),
+      //   new VectorLayer({
+      //     visible: true,
+      //     properties: {
+      //       title: 'Polygons',
+      //       synchronize: false,
+      //       cluster: false,
+      //       inlineLegend: true,
+      //       popUp: {
+      //         attributes: ['name'],
+      //         widgets: ['layer-name', 'clear-layer'],
+      //       },
+      //       domFeatureLinks: [
+      //         {
+      //           domSelector: '#poly1',
+      //           feature: 'poly1',
+      //           event: 'mouseover',
+      //           actions: ['zoomToExtent', 'select'],
+      //         },
+      //         {
+      //           domSelector: '#poly2',
+      //           feature: 'poly2',
+      //           event: 'mouseover',
+      //           actions: ['zoomToExtent', 'showPopup'],
+      //         },
+      //       ],
+      //       editor: {
+      //         editable: true,
+      //         defaultAttributes: {
+      //           name: 'New polygon',
+      //           description: 'none',
+      //         },
+      //       },
+      //       sld: polygonSld,
+      //       path: 'User generated',
+      //     },
+      //     source: new VectorSource({
+      //       features: new GeoJSON().readFeatures(geojsonObject),
+      //     }),
+      //   }),
+      //   new VectorLayer({
+      //     visible: true,
+      //     properties: {
+      //       title: 'Polygons with display f-n',
+      //       synchronize: false,
+      //       cluster: false,
+      //       inlineLegend: true,
+      //       popUp: {
+      //         attributes: ['name'],
+      //         widgets: ['layer-name', 'clear-layer'], //Will be ignored due to display function
+      //         displayFunction: function (feature) {
+      //           return `<a>${feature.get(
+      //             'name'
+      //           )} with population of ${feature.get('population')}</a>`;
+      //         },
+      //       },
+      //       editor: {
+      //         editable: true,
+      //         defaultAttributes: {
+      //           name: 'New polygon',
+      //           description: 'none',
+      //         },
+      //       },
+      //       sld: polygonSld,
+      //       path: 'User generated',
+      //     },
+      //     source: new VectorSource({
+      //       features: new GeoJSON().readFeatures(geojsonObject),
+      //     }),
+      //   }),
+      //   polygons,
+      //   points,
+      //   new Tile({
+      //     visible: false,
+      //     properties: {
+      //       title: 'Latvian municipalities (parent layer)',
+      //       queryFilter: (map, layer, pixel) => {
+      //         return true;
+      //       },
+      //     },
+      //     source: new TileWMS({
+      //       url: 'https://lvmgeoserver.lvm.lv/geoserver/ows',
+      //       params: {
+      //         LAYERS: 'publicwfs:LV_admin_vienibas',
+      //         INFO_FORMAT: undefined,
+      //         FORMAT: 'image/png; mode=8bit',
+      //       },
+      //       crossOrigin: 'anonymous',
+      //     }),
+      //   }),
+      //   new Tile({
+      //     visible: false,
+      //     properties: {
+      //       title: 'Latvian municipalities (1 sub-layer)',
+      //       sublayers: 'publicwfs:arisparish',
+      //     },
+      //     source: new TileWMS({
+      //       url: 'https://lvmgeoserver.lvm.lv/geoserver/ows',
+      //       params: {
+      //         LAYERS: 'publicwfs:LV_admin_vienibas',
+      //         INFO_FORMAT: undefined,
+      //         FORMAT: 'image/png; mode=8bit',
+      //       },
+      //       crossOrigin: 'anonymous',
+      //     }),
+      //   }),
+      //   new Tile({
+      //     visible: false,
+      //     properties: {
+      //       title: 'EVI',
+      //     },
+      //     source: new TileWMS({
+      //       url: 'https://eo.lesprojekt.cz/geoserver/nemecek/wms',
+      //       params: {
+      //         LAYERS: 'EVI',
+      //         INFO_FORMAT: undefined,
+      //         FORMAT: 'image/png; mode=8bit',
+      //       },
+      //       crossOrigin: 'anonymous',
+      //     }),
+      //   }),
+      //   opticalMap,
+      //   idwLayer,
+      //   idwVectorLayer,
+      // ],
       timeDisplayFormat: 'dd.MM.yyyy.',
       translationOverrides: {
         lv: {


### PR DESCRIPTION
## Description

Queue map content loading. Tried using same que for both tiled and non-tiled image layers but it seems like having two ques works better. Slow images can occupy 4 request 'slots' while tiles are still able to load alongside. In case of one queue image layers can block everything which doesn't feel great from the user perspective. 
So I decided for:
- tiled images: could request capped at 6 as these are normally pretty quick and frequent so  if any other requests are made its easy for them to sneak through. These would probably be ok even without a queue 
 - image layers. 4 requests without timeout so it'll just wait until at least one finishes before creating new req.

- another small thing in here is change of default layer.dimenions value from empty object to undefined as empty object is truth so `if(getDimensions(lyr))` would be almost always true.  Was not sure if we should add some condition for laers from composition as well but there it should be better as missing definition in composition would be result in undefined.

## Related issues or pull requests

closes #4058

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
