### PR TITLE
Merge unedited compositions (Issue 4029)

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -326,7 +326,7 @@
     },
     "dialogoverwriteConfirm": {
       "mergeCompositions": "Spojit kompozice",
-      "overwriteExistingMap": "Přepsat existující mapovú kompozici?",
+      "overwriteExistingMap": "Přepsat existující mapovou kompozici?",
       "saveChangesFirst": "Nejprve uložit změny",
       "thereAreCurrentlyUnsavedChanges": "V mapovém okně jsou neuložené změny.",
       "whatDoYouWant": "Co chcete provést před otevřením vybrané mapové kompozice?",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -326,7 +326,7 @@
     },
     "dialogoverwriteConfirm": {
       "mergeCompositions": "Spojit kompozice",
-      "overwriteExistingMap": "Přepsat existující mapu?",
+      "overwriteExistingMap": "Přepsat existující mapovú kompozici?",
       "saveChangesFirst": "Nejprve uložit změny",
       "thereAreCurrentlyUnsavedChanges": "V mapovém okně jsou neuložené změny.",
       "whatDoYouWant": "Co chcete provést před otevřením vybrané mapové kompozice?",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -326,7 +326,7 @@
     },
     "dialogoverwriteConfirm": {
       "mergeCompositions": "Merge compositions",
-      "overwriteExistingMap": "Overwrite existing map?",
+      "overwriteExistingMap": "Overwrite existing map composition?",
       "saveChangesFirst": "Save changes first",
       "thereAreCurrentlyUnsavedChanges": "There are currently unsaved changes.",
       "whatDoYouWant": "What do you want to do before opening the selected map composition?",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -329,7 +329,7 @@
       "overwriteExistingMap": "Overwrite existing map composition?",
       "saveChangesFirst": "Save changes first",
       "thereAreCurrentlyUnsavedChanges": "There are currently unsaved changes.",
-      "whatDoYouWant": "What do you want to do before opening the selected map composition?",
+      "whatDoYouWant": "What do you want to do before opening selected map composition?",
       "youAreOpeningMap": "You are opening map"
     },
     "dialogShare": {

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -326,7 +326,7 @@
     },
     "dialogoverwriteConfirm": {
       "mergeCompositions": "Spojiť kompozície",
-      "overwriteExistingMap": "Prepísať existujúcu mapu?",
+      "overwriteExistingMap": "Prepísať existujúcu mapovú kompozíciu?",
       "saveChangesFirst": "Najskôr uložiť zmeny",
       "thereAreCurrentlyUnsavedChanges": "V mapovom okne sú neuložené zmeny.",
       "whatDoYouWant": "Čo chcete vykonať pred otvorením vybranej mapovej kompozície?",

--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -24,6 +24,7 @@ const EVENTS_SUSPENDED = 'eventsSuspended';
 const EXCLUSIVE = 'exclusive';
 const FEATURE_INFO_LANG = 'featureInfoLang';
 const FROM_COMPOSITION = 'fromComposition';
+const FROM_BASE_COMPOSITION = 'fromBaseComposition';
 const GET_FEATURE_INFO_TARGET = 'getFeatureInfoTarget';
 const GREYSCALE = 'greyscale';
 const HS_LAYMAN_SYNCHRONIZING = 'hsLaymanSynchronizing';
@@ -338,6 +339,17 @@ export function setFromComposition(
 
 export function getFromComposition(layer: Layer<Source>): boolean {
   return layer.get(FROM_COMPOSITION);
+}
+
+export function setFromBaseComposition(
+  layer: Layer<Source>,
+  fromComposition: boolean
+): void {
+  layer.set(FROM_BASE_COMPOSITION, fromComposition);
+}
+
+export function getFromBaseComposition(layer: BaseLayer): boolean {
+  return layer.get(FROM_BASE_COMPOSITION);
 }
 
 export function setFeatureInfoTarget(

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -147,7 +147,7 @@ export class HsCompositionsParserService {
         response = await pre_parse(response);
       }
       /**
-       * Dont set composition_loaded for basemap composition as its just special way
+       * Don't set composition_loaded for basemap composition as it's just special way
        * of setting intial state of the map similarly to default_layers
        */
       if (!response.basemapComposition) {

--- a/projects/hslayers/src/components/compositions/compositions.component.ts
+++ b/projects/hslayers/src/components/compositions/compositions.component.ts
@@ -98,7 +98,7 @@ export class HsCompositionsComponent
    */
   addCompositionUrl(url: string): void {
     if (
-      this.hsCompositionsParserService.composition_edited == true ||
+      this.hsCompositionsParserService.composition_edited ||
       this.hsCompositionsParserService.composition_loaded
     ) {
       this.hsCompositionsService.notSavedOrEditedCompositionLoading.next({

--- a/projects/hslayers/src/components/compositions/compositions.component.ts
+++ b/projects/hslayers/src/components/compositions/compositions.component.ts
@@ -65,12 +65,12 @@ export class HsCompositionsComponent
       this.hsCompositionsCatalogueService.loadFilteredCompositions();
     this.hsCompositionsService.notSavedOrEditedCompositionLoading
       .pipe(takeUntil(this.end))
-      .subscribe((url) => {
+      .subscribe(({url, record}) => {
         this.hsCompositionsService.compositionToLoad = {
           url,
-          title: '',
+          title: record.title,
         };
-        this.loadUnsavedDialogBootstrap('');
+        this.loadUnsavedDialogBootstrap(record);
       });
   }
 
@@ -96,13 +96,15 @@ export class HsCompositionsComponent
    * @param url -
    * Load selected composition in map, if current composition was edited display Overwrite dialog
    */
-
   addCompositionUrl(url: string): void {
     if (
       this.hsCompositionsParserService.composition_edited == true ||
       this.hsCompositionsParserService.composition_loaded
     ) {
-      this.hsCompositionsService.notSavedOrEditedCompositionLoading.next(url);
+      this.hsCompositionsService.notSavedOrEditedCompositionLoading.next({
+        url,
+        record: {title: 'Composition from URL'},
+      });
     } else {
       this.hsCompositionsService.loadComposition(url, true).then((_) => {
         this.addCompositionUrlVisible = false;
@@ -136,12 +138,10 @@ export class HsCompositionsComponent
    * Open overwrite dialog
    * @param title - Dialog title
    */
-  loadUnsavedDialogBootstrap(title: string): void {
+  loadUnsavedDialogBootstrap(record: any): void {
     this.hsDialogContainerService.create(
       HsCompositionsOverwriteDialogComponent,
-      {
-        composition_name_to_be_loaded: title,
-      }
+      record
     );
   }
 

--- a/projects/hslayers/src/components/compositions/compositions.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions.service.ts
@@ -30,7 +30,8 @@ import {HsUtilsService} from '../utils/utils.service';
 export class HsCompositionsService {
   data: any = {};
   compositionToLoad: {url: string; title: string};
-  notSavedOrEditedCompositionLoading: Subject<string> = new Subject();
+  notSavedOrEditedCompositionLoading: Subject<{url: string; record?: any}> =
+    new Subject();
   compositionNotFoundAtUrl: Subject<any> = new Subject();
   shareId: string;
   constructor(
@@ -320,7 +321,10 @@ export class HsCompositionsService {
         this.hsCompositionsParserService.composition_edited == true ||
         this.hsCompositionsParserService.composition_loaded
       ) {
-        this.notSavedOrEditedCompositionLoading.next(url);
+        this.notSavedOrEditedCompositionLoading.next({
+          url: url as string,
+          record,
+        });
       } else {
         this.loadComposition(url, true);
       }

--- a/projects/hslayers/src/components/compositions/compositions.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions.service.ts
@@ -30,7 +30,7 @@ import {HsUtilsService} from '../utils/utils.service';
 export class HsCompositionsService {
   data: any = {};
   compositionToLoad: {url: string; title: string};
-  notSavedCompositionLoading: Subject<string> = new Subject();
+  notSavedOrEditedCompositionLoading: Subject<string> = new Subject();
   compositionNotFoundAtUrl: Subject<any> = new Subject();
   shareId: string;
   constructor(
@@ -316,8 +316,11 @@ export class HsCompositionsService {
       //Provide save-map comoData workspace property and distinguish between editable and non-editable compositions
       this.hsCompositionsParserService.current_composition_workspace =
         record.editable ? record.workspace : null;
-      if (this.hsCompositionsParserService.composition_edited == true) {
-        this.notSavedCompositionLoading.next(url);
+      if (
+        this.hsCompositionsParserService.composition_edited == true ||
+        this.hsCompositionsParserService.composition_loaded
+      ) {
+        this.notSavedOrEditedCompositionLoading.next(url);
       } else {
         this.loadComposition(url, true);
       }
@@ -391,11 +394,7 @@ export class HsCompositionsService {
    
    * @param overwrite - Overwrite existing map composition with the new one
    */
-  loadComposition(
-    url: string,
-
-    overwrite?: boolean
-  ): Promise<void> {
+  loadComposition(url: string, overwrite?: boolean): Promise<void> {
     return this.hsCompositionsParserService.loadUrl(url, overwrite);
   }
 

--- a/projects/hslayers/src/components/compositions/compositions.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions.service.ts
@@ -318,7 +318,7 @@ export class HsCompositionsService {
       this.hsCompositionsParserService.current_composition_workspace =
         record.editable ? record.workspace : null;
       if (
-        this.hsCompositionsParserService.composition_edited == true ||
+        this.hsCompositionsParserService.composition_edited ||
         this.hsCompositionsParserService.composition_loaded
       ) {
         this.notSavedOrEditedCompositionLoading.next({

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_overwriteconfirm.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_overwriteconfirm.html
@@ -8,19 +8,20 @@
                     [attr.aria-label]="'COMMON.close' | translateHs ">
                 </button>
             </div>
-            <div class="modal-body" style="max-height: 600px; overflow-y: auto">
+            <div class="modal-body d-flex flex-column gap-1" style="max-height: 600px; overflow-y: auto">
                 {{'COMPOSITIONS.dialogoverwriteConfirm.youAreOpeningMap' | translateHs }}
-                <b>{{data.composition_name_to_be_loaded}}</b>
-                <br>{{'COMPOSITIONS.dialogoverwriteConfirm.thereAreCurrentlyUnsavedChanges' | translateHs}}
-                <br>{{'COMPOSITIONS.dialogoverwriteConfirm.whatDoYouWant' | translateHs }}
+                <p>{{data.composition_name_to_pe_loaded}}</p>
+                <p *ngIf="hsCompositionParserService.composition_edited" >{{'COMPOSITIONS.dialogoverwriteConfirm.thereAreCurrentlyUnsavedChanges'| translateHs}}</p>
+                <p>{{'COMPOSITIONS.dialogoverwriteConfirm.whatDoYouWant' | translateHs }}</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary compositions-btn-overwrite" (click)="overwrite()"
-                    data-dismiss="modal">{{'COMMON.continue' | translateHs }}</button>
+                    data-dismiss="modal">{{'SAVECOMPOSITION.form.overwrite' | translateHs }}</button>
                 <button type="button" class="btn btn-primary compositions-btn-add" (click)="add();"
                     data-dismiss="modal">{{'COMPOSITIONS.dialogoverwriteConfirm.mergeCompositions' |
                     translateHs}}</button>
-                <button type="button" class="btn btn-primary compositions-btn-save" (click)="save()"
+                <button *ngIf="hsCompositionParserService.composition_edited" type="button"
+                    class="btn btn-primary compositions-btn-save" (click)="save()"
                     data-dismiss="modal">{{'COMPOSITIONS.dialogoverwriteConfirm.saveChangesFirst' |
                     translateHs}}</button>
                 <button type="button" class="btn btn-secondary compositions-btn-cancel" (click)="close()"

--- a/projects/hslayers/src/components/compositions/dialogs/dialog_overwriteconfirm.html
+++ b/projects/hslayers/src/components/compositions/dialogs/dialog_overwriteconfirm.html
@@ -2,29 +2,46 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title">{{'COMPOSITIONS.dialogoverwriteConfirm.overwriteExistingMap' | translateHs}}
+                <h4 class="modal-title">{{'COMPOSITIONS.dialogoverwriteConfirm.whatDoYouWant' | translateHs }}
                 </h4>
                 <button type="button" (click)="close()" class="btn-close" data-dismiss="modal"
                     [attr.aria-label]="'COMMON.close' | translateHs ">
                 </button>
             </div>
-            <div class="modal-body d-flex flex-column gap-1" style="max-height: 600px; overflow-y: auto">
-                {{'COMPOSITIONS.dialogoverwriteConfirm.youAreOpeningMap' | translateHs }}
-                <p>{{data.composition_name_to_pe_loaded}}</p>
-                <p *ngIf="hsCompositionParserService.composition_edited" >{{'COMPOSITIONS.dialogoverwriteConfirm.thereAreCurrentlyUnsavedChanges'| translateHs}}</p>
-                <p>{{'COMPOSITIONS.dialogoverwriteConfirm.whatDoYouWant' | translateHs }}</p>
+            <div  class="container py-2 gap-2 d-flex flex-column" style="max-height: 600px; overflow-y: auto">
+                <div class="row">
+                    <div class="col-4" style="text-align: right;">{{'COMPOSITIONS.dialogoverwriteConfirm.youAreOpeningMap' | translateHs }}:</div>
+                    <div class="fw-bold col-5 flex-grow-1">{{data.title}}</div>
+                </div>
+                <div class="row">
+                    <div class="col-4" style="text-align: right;">
+                        {{'COMMON.abstract' | translateHs }}:
+                    </div>
+                    <div class="col-5 flex-grow-1">
+                        {{data.abstract}}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-4" style="text-align: right;">
+                        {{'COMMON.date' | translateHs }}:
+                    </div>
+                    <div class="col-5">
+                        {{data.dateStamp}}
+                    </div>
+                </div>
+                
             </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary compositions-btn-overwrite" (click)="overwrite()"
+            <div class="modal-footer flex-nowrap">
+                <button type="button" class="btn btn-primary compositions-btn-overwrite align-self-stretch" (click)="overwrite()"
                     data-dismiss="modal">{{'SAVECOMPOSITION.form.overwrite' | translateHs }}</button>
                 <button type="button" class="btn btn-primary compositions-btn-add" (click)="add();"
                     data-dismiss="modal">{{'COMPOSITIONS.dialogoverwriteConfirm.mergeCompositions' |
                     translateHs}}</button>
                 <button *ngIf="hsCompositionParserService.composition_edited" type="button"
-                    class="btn btn-primary compositions-btn-save" (click)="save()"
+                    class="btn btn-primary compositions-btn-save" (click)="save()" style="white-space: break-spaces;"
                     data-dismiss="modal">{{'COMPOSITIONS.dialogoverwriteConfirm.saveChangesFirst' |
                     translateHs}}</button>
-                <button type="button" class="btn btn-secondary compositions-btn-cancel" (click)="close()"
+                <button type="button" class="btn btn-secondary compositions-btn-cancel align-self-stretch" (click)="close()"
                     data-dismiss="modal">{{'COMMON.cancel' | translateHs }}</button>
             </div>
         </div>

--- a/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.ts
+++ b/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.ts
@@ -25,6 +25,9 @@ export class HsCompositionsOverwriteDialogComponent
     this.HsDialogContainerService.destroy(this);
   }
 
+  ngOnInit() {
+    console.log(this.data);
+  }
   /**
    * @public
    * Load new composition without saving old composition

--- a/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.ts
+++ b/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.ts
@@ -1,8 +1,10 @@
 import {Component, ViewRef} from '@angular/core';
+import {HsCompositionsParserService} from '../compositions-parser.service';
 import {HsCompositionsService} from '../compositions.service';
 import {HsDialogComponent} from '../../layout/dialogs/dialog-component.interface';
 import {HsDialogContainerService} from '../../layout/dialogs/dialog-container.service';
 import {HsSaveMapManagerService} from '../../save-map/save-map-manager.service';
+
 @Component({
   selector: 'hs-compositions-overwrite-dialog',
   templateUrl: './dialog_overwriteconfirm.html',
@@ -15,7 +17,8 @@ export class HsCompositionsOverwriteDialogComponent
   constructor(
     public HsDialogContainerService: HsDialogContainerService,
     public HsCompositionsService: HsCompositionsService,
-    public HsSaveMapManagerService: HsSaveMapManagerService
+    public HsSaveMapManagerService: HsSaveMapManagerService,
+    public hsCompositionParserService: HsCompositionsParserService
   ) {}
 
   close(): void {

--- a/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.ts
+++ b/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.ts
@@ -25,9 +25,6 @@ export class HsCompositionsOverwriteDialogComponent
     this.HsDialogContainerService.destroy(this);
   }
 
-  ngOnInit() {
-    console.log(this.data);
-  }
   /**
    * @public
    * Load new composition without saving old composition

--- a/projects/hslayers/src/components/layermanager/layermanager.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.component.ts
@@ -31,6 +31,7 @@ import {HsUtilsService} from '../utils/utils.service';
 import {
   getActive,
   getAttribution,
+  getFromBaseComposition,
   getShowInLayerManager,
   getThumbnail,
   getTitle,
@@ -42,7 +43,8 @@ import {
 })
 export class HsLayerManagerComponent
   extends HsPanelBaseComponent
-  implements OnInit, OnDestroy, AfterViewInit {
+  implements OnInit, OnDestroy, AfterViewInit
+{
   @ViewChild('layerEditor', {static: false, read: ElementRef})
   layerEditorRef: ElementRef;
   map: any;
@@ -184,7 +186,10 @@ export class HsLayerManagerComponent
           if (getShowInLayerManager(e.element) == false) {
             return;
           }
-          this.hsLayerManagerService.layerAdded(e as any);
+          this.hsLayerManagerService.layerAdded(
+            e as any,
+            getFromBaseComposition(e.element)
+          );
         });
       this.hsLayerManagerService.removeLayerHandler = map
         .getLayers()

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -205,7 +205,7 @@ export class HsLayerManagerService {
    * Each layer is also inserted in correct layer list and inserted into folder structure.
    * @private
    * @param e - Event object emitted by OL add layer event
-   * @param suspendEvents - If set to true, no new values for layerAdditions, layerManagerUpdates or compositionEdits observables will be emitted. Otherwise will.
+   * @param suspendEvents - If set to true, no new values for layerAdditions, layerManagerUpdates or compositionEdits observables will be emitted.
    */
   async layerAdded(
     e: {element: Layer<Source>},


### PR DESCRIPTION
## Description

Add possiblity to merge unedited compositions.
Fixed - Basemap composition is not 'composition' in the true sense but rather a specific way of defining initial map content and thus it should be handled specifically eg. not compositon_loaded should be assigned, added layers should not trigger composition layer events
Small adjustment of composition overwrite dialog UI/content

## Related issues or pull requests

closes #4029

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
