### PR TITLE
URL replacement in Layman's publication descriptions

### DIFF
--- a/projects/hslayers/src/hslayers.layman.interceptor.ts
+++ b/projects/hslayers/src/hslayers.layman.interceptor.ts
@@ -1,0 +1,53 @@
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {Observable, map} from 'rxjs';
+
+import {HsCommonLaymanService} from './common/layman/layman.service';
+
+@Injectable()
+export class HslayersLaymanInterceptor implements HttpInterceptor {
+  constructor(private commonLayman: HsCommonLaymanService) {}
+
+  /**
+   * Intercept every request to backend
+   * @param request request
+   * @param next next
+   */
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    if (this.commonLayman.layman?.type.includes('wagtail')) {
+      return next.handle(request).pipe(
+        map((evt: HttpEvent<any>) => {
+          if (
+            evt instanceof HttpResponse &&
+            evt.url.includes(this.commonLayman.layman.url)
+          ) {
+            const strBody = JSON.stringify(evt.body);
+            const layman = this.commonLayman.layman.url; //eg. https://watlas.lesprojekt.cz/layman-proxy
+            const baseUrl = layman.split('layman')[0]; //Take only base
+
+            const pattern = new RegExp(`${baseUrl}(geoserver|rest)/`, 'g');
+            const replacement = `${layman}/$1/`;
+
+            const response = new HttpResponse({
+              ...evt,
+              body: JSON.parse(strBody.replace(pattern, replacement)),
+            });
+            return response;
+          }
+          return evt;
+        })
+      );
+    }
+
+    return next.handle(request);
+  }
+}

--- a/projects/hslayers/src/hslayers.module.ts
+++ b/projects/hslayers/src/hslayers.module.ts
@@ -1,3 +1,4 @@
+import {HTTP_INTERCEPTORS} from '@angular/common/http';
 import {NgModule} from '@angular/core';
 
 import {HsAddDataModule} from './components/add-data/add-data.module';
@@ -22,6 +23,8 @@ import {HsStylerModule} from './components/styles/styles.module';
 import {HsToolbarModule} from './components/toolbar/toolbar.module';
 import {HsTripPlannerModule} from './components/trip-planner/trip-planner.module';
 import {HslayersComponent} from './hslayers.component';
+import {HslayersLaymanInterceptor} from './hslayers.layman.interceptor';
+
 @NgModule({
   declarations: [HslayersComponent],
   imports: [
@@ -48,5 +51,12 @@ import {HslayersComponent} from './hslayers.component';
     HsMapSwipeModule,
   ],
   exports: [HslayersComponent],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HslayersLaymanInterceptor,
+      multi: true,
+    },
+  ],
 })
 export class HslayersModule {}

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -344,10 +344,11 @@ export class HslayersAppComponent {
         mapSwipe: true,
       },
       sidebarPosition: 'right',
-      base_layers: {
-        url: 'https://hub.lesprojekt.cz/rest/workspaces/leitnerfilip/maps/corine_layerorder/file',
-        default: 'CORINE Land Cover 2006',
-      },
+      //TODO: Migrate to watlas
+      // base_layers: {
+      //   url: 'https://hub.lesprojekt.cz/rest/workspaces/leitnerfilip/maps/corine_layerorder/file',
+      //   default: 'CORINE Land Cover 2006',
+      // },
       /*defaultComposition:
             'https://atlas2.kraj-lbc.cz/rest/workspaces/fzadrazil/maps/vodstvo',*/
       panelWidths: {


### PR DESCRIPTION
fix: Returned layman urls not pointing on layman-proxy if used

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
