### PR TITLE
Request current-user only for Layman endpoint (12.x)

### DIFF
--- a/projects/hslayers/src/common/layman/layman-current-user.component.ts
+++ b/projects/hslayers/src/common/layman/layman-current-user.component.ts
@@ -1,18 +1,19 @@
 import {Component, OnInit} from '@angular/core';
 import {Input} from '@angular/core';
+import {Observable, map} from 'rxjs';
 
 import {HsCommonEndpointsService} from '../endpoints/endpoints.service';
 import {HsCommonLaymanService} from './layman.service';
 import {HsDialogContainerService} from '../../components/layout/dialogs/dialog-container.service';
+import {HsEndpoint} from '../endpoints/endpoint.interface';
 import {HsLaymanLoginComponent} from './layman-login.component';
-import {Observable, map} from 'rxjs';
 
 @Component({
   selector: 'hs-layman-current-user',
   templateUrl: './layman-current-user.html',
 })
 export class HsLaymanCurrentUserComponent implements OnInit {
-  @Input() endpoint?;
+  @Input() endpoint?: HsEndpoint;
   monitorTries = 0;
   DEFAULT_TIMER_INTERVAL = 2000;
   MAX_MONITOR_TRIES = 100;
@@ -34,9 +35,9 @@ export class HsLaymanCurrentUserComponent implements OnInit {
     this.inAppLogin = this.HsCommonLaymanService.layman$.pipe(
       map((layman) => {
         if (layman) {
-          //Assign recieved layman endpoint to local variable
+          //Assign received layman endpoint to local variable
           this.endpoint = layman;
-          return this.endpoint.type === 'layman';
+          return this.endpoint?.type === 'layman';
         }
       })
     );

--- a/projects/hslayers/src/common/layman/layman.service.ts
+++ b/projects/hslayers/src/common/layman/layman.service.ts
@@ -36,10 +36,9 @@ export class HsCommonLaymanService {
    *  Monitor if authorization state has changed and
    * return true and broadcast authChange event if so .
    * @param endpoint - Endpoint definition - usually Layman
-   
    * @returns Promise<boolean> true if authorization state changed (user logged in or out)
    */
-  async detectAuthChange(endpoint): Promise<boolean> {
+  async detectAuthChange(endpoint: HsEndpoint): Promise<boolean> {
     const url = `${endpoint.url}/rest/current-user`;
     try {
       const res: CurrentUserResponse = await lastValueFrom(
@@ -71,8 +70,8 @@ export class HsCommonLaymanService {
     }
   }
 
-  async getCurrentUserIfNeeded(endpoint): Promise<void> {
-    if (endpoint.user === undefined) {
+  async getCurrentUserIfNeeded(endpoint: HsEndpoint): Promise<void> {
+    if (endpoint.type.includes('layman') && endpoint.user === undefined) {
       await this.detectAuthChange(endpoint);
     }
   }


### PR DESCRIPTION
## Description

Only request current-user for Layman endpoint, as it is not implemented for Micka.

~TODO: solve "Micka 200" toast message.~ Forked into #4215 

## Related issues or pull requests

Port of #3957
Resolves #3915

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
