### PR TITLE
Sync lang

### DIFF
--- a/projects/hslayers/src/components/core/core.service.ts
+++ b/projects/hslayers/src/components/core/core.service.ts
@@ -13,11 +13,7 @@ import {HsLanguageService} from '../language/language.service';
   providedIn: 'root',
 })
 export class HsCoreService {
-  /**
-   * @public
-   */
   embeddedEnabled = true;
-  language = 'en';
   config: any;
   _puremapApp = false;
   initCalled: boolean;
@@ -97,7 +93,9 @@ export class HsCoreService {
     const htmlLangInPath = document.location.pathname.includes(
       `/${documentLang}/`,
     );
-    return htmlLangInPath && translateService.getLangs().includes(documentLang)
+    this.hsLanguageService.langFromCMS =
+      htmlLangInPath && translateService.getLangs().includes(documentLang);
+    return this.hsLanguageService.langFromCMS
       ? documentLang
       : this.hsConfig.language || translateService.getDefaultLang();
   }

--- a/projects/hslayers/src/components/core/core.service.ts
+++ b/projects/hslayers/src/components/core/core.service.ts
@@ -45,7 +45,7 @@ export class HsCoreService {
       }
       const languages = this.hsConfig.enabledLanguages
         ? this.hsConfig.enabledLanguages.split(',').map((lang) => lang.trim())
-        : ['cs', 'lv'];
+        : ['cs', 'sk'];
       const translateService = this.hsLanguageService.getTranslator();
       translateService.addLangs(languages);
       translateService.setDefaultLang(`en`);

--- a/projects/hslayers/src/components/language/language.service.ts
+++ b/projects/hslayers/src/components/language/language.service.ts
@@ -15,9 +15,12 @@ const DEFAULT_LANG = 'en' as const;
 export class HsLanguageService {
   language: string;
   translateServiceFactory: any;
+  //Controls whether hs-lang URL param should override other setting or not
+  //Not in case we are syncing langs with Wagtail
+  langFromCMS: boolean;
   constructor(
     private translationService: CustomTranslationService,
-    private hsConfig: HsConfig
+    private hsConfig: HsConfig,
   ) {
     this.hsConfig.configChanges.subscribe(() => {
       if (this.hsConfig.translationOverrides != undefined) {
@@ -35,10 +38,7 @@ export class HsLanguageService {
    * Set language
    */
   setLanguage(lang: string): void {
-    if (lang.includes('|')) {
-      lang = lang.split('|')[1];
-    }
-    this.translationService.use(lang);
+    this.getTranslator().use(lang);
     this.language = lang;
   }
 
@@ -123,7 +123,7 @@ export class HsLanguageService {
   getTranslationIgnoreNonExisting(
     module: string,
     text: string,
-    params?: any
+    params?: any,
   ): string {
     const tmp = this.getTranslation(module + '.' + text, params || undefined);
     if (tmp.includes(module + '.')) {

--- a/projects/hslayers/src/components/permalink/share-url.service.ts
+++ b/projects/hslayers/src/components/permalink/share-url.service.ts
@@ -49,7 +49,7 @@ export class HsShareUrlService {
     private Location: Location,
     private zone: NgZone,
     private PlatformLocation: PlatformLocation,
-    private HttpClient: HttpClient
+    private HttpClient: HttpClient,
   ) {
     this.keepTrackOfGetParams();
     this.hsMapService.loaded().then((map) => {
@@ -71,8 +71,8 @@ export class HsShareUrlService {
               },
               200,
               false,
-              this
-            )
+              this,
+            ),
           );
         map.getLayers().on('add', (e) => {
           const layer = e.element;
@@ -142,14 +142,14 @@ export class HsShareUrlService {
   async updatePermalinkComposition(data?: MapComposition): Promise<any> {
     const status_url = this.endpointUrl();
     const bbox = this.HsSaveMapService.getBboxFromObject(
-      this.hsMapService.describeExtent()
+      this.hsMapService.describeExtent(),
     );
     this.data = data ?? {
       ...this.data,
       nativeExtent: transformExtent(
         bbox,
         'EPSG:4326',
-        this.hsMapService.getCurrentProj()
+        this.hsMapService.getCurrentProj(),
       ),
       extent: bbox,
     };
@@ -162,8 +162,8 @@ export class HsShareUrlService {
           id: this.id,
           project: this.hsConfig.project_name,
           request: 'save',
-        })
-      )
+        }),
+      ),
     );
     this.statusSaving = false;
     this.permalinkRequestUrl = status_url + '?request=load&id=' + this.id;
@@ -184,7 +184,7 @@ export class HsShareUrlService {
       .map((lyr) => getTitle(lyr));
 
     const addedLayers = externalLayers.filter(
-      (lyr) => !this.hsConfig.default_layers?.includes(lyr)
+      (lyr) => !this.hsConfig.default_layers?.includes(lyr),
     );
     this.updateViewParamsInUrl();
     //This might become useful, but url size is limited, so we are not using it
@@ -238,7 +238,7 @@ export class HsShareUrlService {
       },
       300,
       false,
-      this.updateDebouncer
+      this.updateDebouncer,
     )();
   }
 
@@ -264,13 +264,13 @@ export class HsShareUrlService {
         this.hsConfig.permalinkLocation.origin +
         this.current_url.replace(
           this.pathName(),
-          this.hsConfig.permalinkLocation.pathname
+          this.hsConfig.permalinkLocation.pathname,
         ) +
         `&${HS_PRMS.permalink}=${encodeURIComponent(this.permalinkRequestUrl)}`
       ).replace(this.pathName(), this.hsConfig.permalinkLocation.pathname);
     } else {
       return `${this.current_url}&${HS_PRMS.permalink}=${encodeURIComponent(
-        this.permalinkRequestUrl
+        this.permalinkRequestUrl,
       )}`;
     }
   }

--- a/projects/hslayers/src/components/permalink/share-url.service.ts
+++ b/projects/hslayers/src/components/permalink/share-url.service.ts
@@ -92,7 +92,7 @@ export class HsShareUrlService {
           });
         });
         const lang = this.getParamValue(HS_PRMS.lang);
-        if (lang) {
+        if (lang && !this.HsLanguageService.langFromCMS) {
           this.HsLanguageService.setLanguage(lang);
         }
         const view = this.getParamValue(HS_PRMS.view);
@@ -220,6 +220,7 @@ export class HsShareUrlService {
   private updateURL() {
     this.HsUtilsService.debounce(
       () => {
+        //No updates for multi-apps
         if (document.querySelectorAll('hslayers-app').length == 1) {
           let locationPath = this.pathName();
           const paramsSerialized = Object.keys(this.params)

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -661,6 +661,9 @@ export class HslayersAppComponent {
         cs: {
           'My Cool Panel': 'Můj úžasný panel',
         },
+        sk: {
+          'My Cool Panel': 'Môj úžasný panel',
+        },
       },
     });
 


### PR DESCRIPTION
## Description

Sync Wagtail and HSLayers languages (if language supported)

To not overwrite config.language setting all the time we sync languages only in case HTML `lang` is the same as the language set in` location.path` 

## Related issues or pull requests

closes #4043

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
