### PR TITLE
Dispatch loading events for WfsSource

### DIFF
--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
@@ -7,7 +7,6 @@ import {Layer, Vector as VectorLayer} from 'ol/layer';
 import {Source} from 'ol/source';
 import {get, transformExtent} from 'ol/proj';
 
-import WfsSource from '../../../../common/layers/hs.source.WfsSource';
 import {AddLayersRecursivelyOptions} from '../types/recursive-options.type';
 import {CapabilitiesResponseWrapper} from '../../../../common/get-capabilities/capabilities-response-wrapper';
 import {DuplicateHandling, HsMapService} from '../../../map/map.service';
@@ -21,6 +20,7 @@ import {HsUtilsService} from '../../../utils/utils.service';
 import {HsWfsGetCapabilitiesService} from '../../../../common/get-capabilities/wfs-get-capabilities.service';
 import {LayerOptions} from '../../../compositions/layer-parser/composition-layer-options.type';
 import {UrlDataObject} from '../types/data-object.type';
+import {WfsSource} from '../../../../common/layers/hs.source.WfsSource';
 
 @Injectable({
   providedIn: 'root',

--- a/projects/hslayers/src/components/core/event-bus.service.ts
+++ b/projects/hslayers/src/components/core/event-bus.service.ts
@@ -18,9 +18,9 @@ import {HsMapCompositionDescriptor} from '../compositions/models/composition-des
  * HsEventBusService provides observable events which you can subscribe to or fire them
  *
  * @example
- * HsEventBusService.sizeChanges.subscribe((size) =\> \{
+ * HsEventBusService.sizeChanges.subscribe((size) => {
  *              doSomethingWith(size);
- * \})
+ * })
  * @example
  * HsEventBusService.layerLoads.next();
  */
@@ -31,18 +31,20 @@ export class HsEventBusService {
   sizeChanges: Subject<any> = new Subject();
   /**
    * Fires when map completely reset
-   * @event mapResets
    */
   mapResets: Subject<void> = new Subject();
   compositionLoadStarts: Subject<string> = new Subject();
   compositionDeletes: Subject<HsMapCompositionDescriptor> = new Subject();
   /**
    * Fires when composition is loaded or not loaded with Error message
-   * @event compositionLoads
    */
   compositionLoads: Subject<any> = new Subject();
   compositionEdits: Subject<void> = new Subject();
   layerRemovals: Subject<Layer<Source>> = new Subject();
+  /**
+   * Fires when new layer is added to the app.
+   * Suppressed for layers defined in default_layers in HsConfig.
+   */
   layerAdditions: Subject<HsLayerDescriptor> = new Subject();
   LayerManagerBaseLayerVisibilityChanges: Subject<any> = new Subject();
   LayerManagerLayerVisibilityChanges: Subject<any> = new Subject();
@@ -50,14 +52,18 @@ export class HsEventBusService {
    * Fires when layer is added or removed in LayerManager or its z-index changes or its title changes via rename.
    */
   layerManagerUpdates: Subject<Layer<Source> | void> = new Subject();
+  /**
+   * Fires when layer finishes loading its features or tiles.
+   * Usually triggered once, when all features are loaded, or after all features/tiles in given view/extent are loaded.
+   */
   layerLoads: Subject<Layer<Source>> = new Subject();
   layerLoadings: Subject<{
     layer: Layer<Source>;
     progress: HsLayerLoadProgress;
   }> = new Subject();
   /**
-   * Fires when user enables layer time synchronization in the UI
-   * Used to synchronize time in PARAMS across WM(T)S-t layers
+   * Fires when user enables layer time synchronization in the UI.
+   * Used to synchronize time in PARAMS across WM(T)S-t layers.
    */
   layerTimeSynchronizations: Subject<{
     sync: boolean;
@@ -86,7 +92,6 @@ export class HsEventBusService {
   /**
    * Fires when current mainpanel change - toggle, change of opened panel.
    * replaces 'core.mainpanel_changed'
-   * @event mainPanelChanges
    */
   mainPanelChanges: Subject<string | null> = new Subject();
   /**
@@ -126,7 +131,6 @@ export class HsEventBusService {
   /**
    * Fires when composition is downloaded from server and parsing begins
    * replaces 'compositions.composition_loading'
-   * @event compositionLoading
    * @deprecated
    */
   compositionLoading: Subject<any> = new Subject();
@@ -147,7 +151,6 @@ export class HsEventBusService {
   mapClicked: Subject<any> = new Subject();
   /**
    * Fires when layerSelected parameter is found in the URL
-   * @event layerSelectedFromUrl
    */
   layerSelectedFromUrl: BehaviorSubject<Layer<Source>> = new BehaviorSubject(
     null,

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -193,6 +193,7 @@ export class HsLayerManagerService {
       this.boxLayersInit();
     });
   }
+
   /**
    * Function for adding layer added to map into layer manager structure.
    * In service automatically used after layer is added to map.


### PR DESCRIPTION
## Description

Custom loader in WfsSource never fired (dispatched, casted, ...) `'propertychange'`, `'featuresloadstart'`, `'featuresloadend'` or `'featuresloaderror'` events. Mitigated by dispatching them manually, so the code in [layermanager.service.ts](https://github.com/hslayers/hslayers-ng/blob/2af194b98df263bca70145fe128dafa222d4e3a4/projects/hslayers/src/components/layermanager/layermanager.service.ts#L853) can listen to them.

## Related issues or pull requests
fixes #4041 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
