### PR TITLE
fix: Dont zoom on OWS layers from compositions

### DIFF
--- a/projects/hslayers/src/.browserslistrc
+++ b/projects/hslayers/src/.browserslistrc
@@ -1,6 +1,6 @@
 defaults
-not > 0.5%
-not last 2 versions
+not < 0.5%
+safari >= 12
 not Firefox ESR
 not dead
 not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
+++ b/projects/hslayers/src/components/add-data/url/arcgis/arcgis.service.ts
@@ -223,7 +223,9 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
         ...layerOptions,
       }),
     ];
-    this.hsAddDataUrlService.zoomToLayers(this.data);
+    if (!layerOptions.fromComposition) {
+      this.hsAddDataUrlService.zoomToLayers(this.data);
+    }
     this.data.base = false;
     this.hsAddDataCommonService.clearParams();
     this.setDataToDefault();

--- a/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wfs/wfs.service.ts
@@ -97,7 +97,9 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
           'wfs',
         );
         const collection = this.getLayers(true, false, layerOptions);
-        this.hsAddDataUrlService.zoomToLayers(this.data);
+        if (!layerOptions.fromComposition) {
+          this.hsAddDataUrlService.zoomToLayers(this.data);
+        }
         return collection;
       }
     } catch (e) {
@@ -357,7 +359,9 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
       this.getLayersRecursively(layer, {layerOptions}, collection);
     }
     this.data.extent = this.calcAllLayersExtent(collection);
-    this.hsAddDataUrlService.zoomToLayers(this.data);
+    if (!layerOptions.fromComposition) {
+      this.hsAddDataUrlService.zoomToLayers(this.data);
+    }
     this.hsAddDataCommonService.clearParams();
     this.setDataToDefault();
     this.hsAddDataCommonService.setPanelToCatalogue();

--- a/projects/hslayers/src/components/add-data/url/wmts/wmts.service.ts
+++ b/projects/hslayers/src/components/add-data/url/wmts/wmts.service.ts
@@ -144,7 +144,9 @@ export class HsUrlWmtsService implements HsUrlTypeServiceModel {
       this.getLayersRecursively(layer, {layerOptions}, collection);
     }
     this.data.extent = this.hsAddDataUrlService.calcAllLayersExtent(collection);
-    this.hsAddDataUrlService.zoomToLayers(this.data);
+    if (!layerOptions.fromComposition) {
+      this.hsAddDataUrlService.zoomToLayers(this.data);
+    }
     this.hsAddDataCommonService.clearParams();
     this.setDataToDefault();
     this.hsAddDataCommonService.setPanelToCatalogue();

--- a/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/layer-parser.service.ts
@@ -95,6 +95,7 @@ export class HsCompositionsLayerParserService {
           info_format: lyr_def.info_format,
           base: lyr_def.base,
           greyscale: lyr_def.greyscale,
+          fromComposition: true,
         },
       });
       return newLayer[0];
@@ -185,6 +186,7 @@ export class HsCompositionsLayerParserService {
         title: lyr_def.title,
         base: lyr_def.base,
         greyscale: lyr_def.greyscale,
+        fromComposition: true,
       },
     });
     return newLayer[0];


### PR DESCRIPTION
## Description

Zooming onto layers loaded from composition via OWS connection is not desired as it cancel out composition initial view settings.

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
