### PR TITLE
Reusable add-to-map button component

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -2,7 +2,6 @@
   "ADDDATA": {
     "catalogue": "Datový katalog",
     "CATALOGUE": {
-      "addAs": "Přidat jako",
       "DESC": {
         "WFS": "Web Feature Service - stahovací: slouží pro práci s geografickými daty ve vektorové reprezentaci. Je výkonostne naročnejší, především při rozsáhlejších vrstvách, umožňuje však editaci, či zobrazení individuálních informacií ke každému prvku zvlášť.",
         "WMS": "Web Map Service - prohlížecí: data nahraje v podobě rastru. Přenášená data jsou obvykle menší co má za následek rychlejší načítání, no na druhou stranu ich není možné upravovat."
@@ -134,7 +133,6 @@
       "extractStyles": "Extrahovat styly"
     },
     "WFS": {
-      "addToMap": "Přidat do mapy",
       "loadingToManyAtOnce": "prvků. Načítání příliš mnoha prvků najednou (při oddálení) může ovlivnit výkon aplikace",
       "selectedLayerContains": "Vybraná vrstva obsahuje",
       "featureCountError": "Nelze načíst počet prvků vrstvy. \nV případě jejich nadměrného počtu může vrstva ovlivnit výkon"
@@ -458,7 +456,6 @@
     },
     "datasourceListItem": {
       "abortAdd": "Zrušit přidání",
-      "addToMap": "Přidat do mapy",
       "notAllowedToEditLayer": "Tuto datovou sadu nemáte oprávnění editovat",
       "whatDoesItMean": "Co to znamená?"
     },

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -309,7 +309,8 @@
     "confirmReset": "Potvrďte reset",
     "saving": "Ukládání",
     "asNew": "jako nové",
-    "createdBy": "Vytvořil"
+    "createdBy": "Vytvořil",
+    "addToMap": "Přidat do mapy"
   },
   "COMPOSITIONS": {
     "addByAddress": "Přidat kompozici z adresy",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -2,7 +2,6 @@
   "ADDDATA": {
     "catalogue": "Data Catalogue",
     "CATALOGUE": {
-      "addAs": "Add as",
       "DESC": {
         "WFS": "Web Feature Service: it adds the layer as a set of vector features. It is more power-consuming, especially with large layers, but it allows to edit features or to display individual feature info.",
         "WMS": "Web Map Service: it adds the layer as a raster image. The transferred data is usually smaller so it generally loads faster. Yet it does not give you the access to the underlying layer features."
@@ -144,7 +143,6 @@
       "extractStyles": "Extract styles"
     },
     "WFS": {
-      "addToMap": "Add to map",
       "loadingToManyAtOnce": "features. Loading too many at once (while zoomed out) may affect app performance",
       "selectedLayerContains": "Selected layer contains",
       "featureCountError": "Could not retrieve layer's feature count. In case of excesive number of features the layer may affect performance"
@@ -162,6 +160,7 @@
     "access": "Access",
     "add": "Add",
     "addAs": "Add as",
+    "addToMap": "Add to map",
     "advancedOptions": "Advanced options",
     "all": "All",
     "application": "Application",
@@ -458,7 +457,6 @@
     },
     "datasourceListItem": {
       "abortAdd": "Abort add",
-      "addToMap": "Add to map",
       "notAllowedToEditLayer": "You are not allowed to edit this layer",
       "whatDoesItMean": "What does it mean?"
     },

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -289,7 +289,8 @@
     "query": "Vaicājums",
     "composition": "Kompozīcija",
     "remove": "Noņemt",
-    "saving": "Saglabā"
+    "saving": "Saglabā",
+    "addToMap": "Pievienot kartei"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pievienot kompozīciju pēc adreses",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -2,7 +2,6 @@
   "ADDDATA": {
     "catalogue": "Datu katalogs",
     "CATALOGUE": {
-      "addAs": "Pievienot kā",
       "DESC": {
         "WFS": "Web Feature Service - pievieno slāni kā vektoru grafisko objektu kopumu. Tas ir vairāk resursu patērējošs, it īpaši ar lieliem slāņiem, taču tas ļauj rediģēt objektus vai parādīt atsevišķu informāciju par objektiem",
         "WMS": "Web Map Service - pievieno slāni kā rastra attēlu. Pārsūtītie dati parasti ir mazāki, tāpēc tie parasti tiek ielādēti ātrāk. Tomēr tas nedod Jums piekļuvi pamata slāņa funkcijām."
@@ -128,7 +127,6 @@
       "extractStyles": "Izvilkt stilus"
     },
     "WFS": {
-      "addToMap": "Pievienot kartei",
       "loadingToManyAtOnce": "grafiskie objekti. Pārāk daudzu objektu ielāde vienlaikus (kamēr karte ir tālināta) var ietekmēt lietotnes veiktspēju",
       "selectedLayerContains": "Atlasītajā slānī ir"
     },
@@ -438,7 +436,6 @@
     },
     "datasourceListItem": {
       "abortAdd": "Atcelt pievienošanu",
-      "addToMap": "Pievienot kartei",
       "notAllowedToEditLayer": "Jums nav rediģēšanas tiesību, lai labotu šo slāni",
       "whatDoesItMean": "Ko tas nozīmē?"
     },

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -2,7 +2,6 @@
   "ADDDATA": {
     "catalogue": "Dátový katalóg",
     "CATALOGUE": {
-      "addAs": "Pridať ako",
       "DESC": {
         "WFS": "Web Feature Service - sťahovacia: slúži na prácu s geografickými dátami vo vektorovej reprezentácií. Je výkonostne naročnejšia, predovšetkým pri rozsiahlejšich vrstvách, umožňuje však editáciu, či zobrazenie individuálnych informacií ku každému prvku zvlášť.",
         "WMS": "Web Map Service - prehliadacia: dáta nahráva v podobe rastru. Prenášané dáta sú obvykle menie čo má za následok rychlejšie načítanie, no na druhú stranu neumožňuje ich editáciu."
@@ -133,7 +132,6 @@
       "extractStyles": "Extrahovať štýly"
     },
     "WFS": {
-      "addToMap": "Pridať do mapy",
       "loadingToManyAtOnce": "prvkov. Načítanie příliš veľkého množstva prvkov naraz (pri oddialení) môže ovplyvniť výkon aplikácie",
       "selectedLayerContains": "Vybraná vrstva obsahuje",
       "featureCountError": "Nepodarilo sa načítať počet prvkov vrstvy. \nV prípade ich nadmerného počtu môže vrstva ovplyvniť výkon"
@@ -458,7 +456,6 @@
     },
     "datasourceListItem": {
       "abortAdd": "Zrušiť pridanie",
-      "addToMap": "Pridať do mapy",
       "notAllowedToEditLayer": "Nemáte oprávnenie editovať túto dátovú sadu",
       "whatDoesItMean": "Čo to znamená?"
     },

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -309,7 +309,8 @@
     "confirmReset": "Potvrďte reset",
     "saving": "Ukladanie",
     "asNew": "ako nové",
-    "createdBy": "Vytvoril"
+    "createdBy": "Vytvoril",
+    "addToMap": "Pridať do mapy"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pridať kompozíciu z adresy",

--- a/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
+++ b/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
@@ -1,5 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+
 import {HsLanguageModule} from '../../components/language/language.module';
 
 @Component({

--- a/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
+++ b/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
@@ -1,0 +1,60 @@
+import {CommonModule} from '@angular/common';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {HsLanguageModule} from '../../components/language/language.module';
+
+@Component({
+  selector: 'hs-add-to-map',
+  standalone: true,
+  template: `
+    <button
+      class="btn btn-primary w-100"
+      [disabled]="disabled"
+      [title]="title | translateHs"
+      (click)="addLayer()"
+      [ngClass]="classes"
+    >
+      <span
+        *ngIf="!loading; else loader"
+        class="d-flex justify-content-center align-items-baseline gap-1"
+      >
+        <i class="icon-plus"> </i>{{ 'COMMON.addToMap' | translateHs }}
+      </span>
+      <ng-template #loader>
+        <span>
+          <span class="hs-loader"></span>&emsp;
+          {{ 'COMMON.uploading' | translateHs }}
+        </span>
+      </ng-template>
+      <ng-content></ng-content>
+    </button>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+    `,
+  ],
+  imports: [CommonModule, HsLanguageModule],
+})
+/**
+ * title: Translation string to be used title
+ */
+// eslint-disable-next-line @angular-eslint/component-class-suffix
+export class HsAddToMapButton {
+  @Input() disabled: boolean;
+  @Input() title: string;
+  @Input() loading: boolean = false;
+  @Input() classes: string;
+
+  @Output() add = new EventEmitter<void>();
+
+  constructor() {}
+
+  /**
+   * Emit add event to trigger bind action
+   */
+  addLayer() {
+    this.add.emit();
+  }
+}

--- a/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
+++ b/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
@@ -42,9 +42,9 @@ import {HsLanguageModule} from '../../components/language/language.module';
  * title: Translation string to be used title
  */
 // eslint-disable-next-line @angular-eslint/component-class-suffix
-export class HsAddToMapButton {
+export class HsAddToMapButtonComponent {
   @Input() disabled: boolean;
-  @Input() title: string;
+  @Input() title: string = 'COMMON.addToMap';
   @Input() loading: boolean = false;
   @Input() classes: string;
 

--- a/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
+++ b/projects/hslayers/src/common/add-to-map/add-to-map.component.ts
@@ -38,12 +38,11 @@ import {HsLanguageModule} from '../../components/language/language.module';
   ],
   imports: [CommonModule, HsLanguageModule],
 })
-/**
- * title: Translation string to be used title
- */
-// eslint-disable-next-line @angular-eslint/component-class-suffix
 export class HsAddToMapButtonComponent {
   @Input() disabled: boolean;
+  /**
+   * Translation string to be used as title
+   */
   @Input() title: string = 'COMMON.addToMap';
   @Input() loading: boolean = false;
   @Input() classes: string;

--- a/projects/hslayers/src/common/add-to-map/public-api.ts
+++ b/projects/hslayers/src/common/add-to-map/public-api.ts
@@ -1,0 +1,1 @@
+export * from './add-to-map.component';

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -12,20 +12,12 @@
         *ngIf="hsAddDataCatalogueService.selectedLayer?.id === layer.id">
         <hr class="hs-dotted-line w-100 ">
         <div class="d-flex flex-row justify-content-around align-items-end">
-            <!-- <div class="p-0" [hidden]="(selectTypeToAddLayerVisible)">
-                            <button type="button" class="btn btn-sm btn-primary align-middle" (click)="addLayerToMap(layer.endpoint, layer)"
-                                data-toggle="tooltip" [title]="'DATASOURCE_SELECTOR.datasourceListItem.addToMap' | translateHs "
-                                [ngClass]="{' btn-light text-primary' : layer.highlighted }">
-                                <i class="icon-plus"></i>
-                            </button>
-                            <span class="ms-2">{{'DATASOURCE_SELECTOR.datasourceListItem.addToMap' | translateHs }}</span>
-                        </div> -->
             <a class="btn btn-sm border-0" [class.disabled]="!layerAvailable" [hidden]="selectTypeToAddLayerVisible"
                 [ngClass]="{'text-muted': layerAvailable}"
                 (click)="$event.stopPropagation();addLayerToMap(layer.endpoint, layer)">
                 <i [hidden]="loadingInfo" class="icon-plus icon-primary"></i>
                 <span [hidden]="!loadingInfo" class="hs-loader"></span>
-                <span *ngIf="layerAvailable" class="ms-1">{{'DATASOURCE_SELECTOR.datasourceListItem.addToMap' |
+                <span *ngIf="layerAvailable" class="ms-1">{{'COMMON.addToMap' |
                     translateHs }}</span>
             </a>
             <a class="btn btn-sm border-0" [title]="'DATASOURCE_SELECTOR.datasourceListItem.abortAdd' | translateHs "
@@ -83,7 +75,7 @@
         <div class="d-flex flex-row justify-content-between align-items-center w-100">
             <div class="px-3">
                 <span class="btn btn-sm disabled border-0" disabled="true" aria-disabled="true">{{
-                    'ADDDATA.CATALOGUE.addAs' |
+                    'COMMON.addAs' |
                     translateHs }}&nbsp;</span>
                 <div class="btn-group btn-group-toggle h-100 pe-2 align-items-center" data-toggle="buttons">
                     <label class="btn btn-sm btn-outline-secondary" *ngFor="let type of whatToAddTypes"

--- a/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
+++ b/projects/hslayers/src/components/add-data/common/add-layer-authorized/add-layer-authorized.component.html
@@ -1,11 +1,7 @@
 <div class="w-100 mt-2" style="display: inline-block;" data-toggle="tooltip" data-placement="top"
   [title]="hsAddDataCommonFileService.getToolTipText(data)">
   <!-- TODO: Remove function call from template -->
-  <button *ngIf="hsAddDataCommonFileService.isAuthenticated()" class="btn btn-primary w-100" [disabled]="!canAdd()"
-    (click)="add()">
-    <i class="icon-plus" [hidden]="hsAddDataCommonFileService.loadingToLayman"></i>
-    <span class="hs-loader" [hidden]="!hsAddDataCommonFileService.loadingToLayman"></span>
-    <span [hidden]="hsAddDataCommonFileService.loadingToLayman">{{'COMMON.add' | translateHs }}</span>
+  <hs-add-to-map [disabled]="!canAdd()" (add)="add()" [loading]="hsAddDataCommonFileService.loadingToLayman">
     <span
       *ngIf="hsAddDataCommonFileService.loadingToLayman && hsAddDataCommonFileService.asyncLoading">&emsp;{{'COMMON.uploading'
       |
@@ -18,7 +14,7 @@
       *ngIf="hsAddDataCommonFileService.loadingToLayman && (hsAddDataCommonFileService.asyncLoading || hsAddDataCommonFileService.readingData)"
       showValue="true" class="rounded-0 mb-1" type="secondary" [max]="1" [value]="hsLaymanService.totalProgress">
     </ngb-progressbar>
-  </button>
+  </hs-add-to-map>
 </div>
 <div *ngIf="!hsAddDataCommonFileService.isAuthenticated()"
   class="alert alert-warning d-flex align-items-center mt-2 justify-content-between">

--- a/projects/hslayers/src/components/add-data/common/common.module.ts
+++ b/projects/hslayers/src/components/add-data/common/common.module.ts
@@ -5,7 +5,7 @@ import {NgModule} from '@angular/core';
 import {NgbProgressbarModule} from '@ng-bootstrap/ng-bootstrap';
 
 import {HsAddLayerAuthorizedComponent} from './add-layer-authorized/add-layer-authorized.component';
-import {HsAddToMapButton} from '../../../common/add-to-map/add-to-map.component';
+import {HsAddToMapButtonComponent} from '../../../common/add-to-map/add-to-map.component';
 import {HsAdvancedOptionsComponent} from './advanced-options/advanced-options.component';
 import {HsGetCapabilitiesErrorComponent} from './capabilities-error-dialog/capabilities-error-dialog.component';
 import {HsLanguageModule} from '../../language/language.module';
@@ -24,7 +24,7 @@ import {HsUiExtensionsModule} from '../../../common/widgets/ui-extensions.module
     HsLaymanModule,
     HsUiExtensionsModule,
     NgbProgressbarModule,
-    HsAddToMapButton,
+    HsAddToMapButtonComponent,
   ],
   exports: [
     HsGetCapabilitiesErrorComponent,

--- a/projects/hslayers/src/components/add-data/common/common.module.ts
+++ b/projects/hslayers/src/components/add-data/common/common.module.ts
@@ -5,6 +5,7 @@ import {NgModule} from '@angular/core';
 import {NgbProgressbarModule} from '@ng-bootstrap/ng-bootstrap';
 
 import {HsAddLayerAuthorizedComponent} from './add-layer-authorized/add-layer-authorized.component';
+import {HsAddToMapButton} from '../../../common/add-to-map/add-to-map.component';
 import {HsAdvancedOptionsComponent} from './advanced-options/advanced-options.component';
 import {HsGetCapabilitiesErrorComponent} from './capabilities-error-dialog/capabilities-error-dialog.component';
 import {HsLanguageModule} from '../../language/language.module';
@@ -23,6 +24,7 @@ import {HsUiExtensionsModule} from '../../../common/widgets/ui-extensions.module
     HsLaymanModule,
     HsUiExtensionsModule,
     NgbProgressbarModule,
+    HsAddToMapButton,
   ],
   exports: [
     HsGetCapabilitiesErrorComponent,

--- a/projects/hslayers/src/components/add-data/common/url/add/add.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/add/add.component.html
@@ -2,7 +2,6 @@
                 bottom: 0">
   <button class="btn btn-primary" (click)="selectAll()">{{'ADDDATA.URL.selectAll' |
     translateHs }}</button>
-  <button class="btn btn-primary" [disabled]="!hsAddDataUrlService.addingAllowed"
-    [title]="'ADDLAYERS.addSelected' | translateHs " (click)="add()">{{'ADDLAYERS.WFS.addToMap' |
-    translateHs }}</button>
+  <hs-add-to-map [disabled]="!hsAddDataUrlService.addingAllowed" (add)="add()"
+    [title]="'ADDLAYERS.addSelected'"></hs-add-to-map>
 </div>

--- a/projects/hslayers/src/components/add-data/common/url/details/details.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/details/details.component.html
@@ -64,7 +64,7 @@
   </ng-container>
   <div class="d-flex flex-column my-3">
     <div class="d-flex flex-row justify-content-start align-items-baseline m-1 mb-2">
-      {{'ADDDATA.CATALOGUE.addAs' | translateHs }}
+      {{'COMMON.addAs' | translateHs }}
       <div class="btn-group ms-2">
         <button type="button" class="btn btn-sm btn-light  btn-outline-secondary" (click)="data.base = true"
           [ngClass]="{'active':data.base}">

--- a/projects/hslayers/src/components/add-data/common/url/layer-table/layer-table.component.html
+++ b/projects/hslayers/src/components/add-data/common/url/layer-table/layer-table.component.html
@@ -87,7 +87,7 @@
                             class="align-items-center bottom-50 d-flex end-0 h-75 me-3 p-2 position-absolute rounded-1 text-bg-warning">i</span>
                         <div *ngIf="layer.checked && type === 'wmts'"
                             class="d-flex flex-row justify-content-end align-items-baseline mt-1">
-                            {{'ADDDATA.CATALOGUE.addAs' | translateHs }}
+                            {{'COMMON.addAs' | translateHs }}
                             <div class="btn-group ms-2">
                                 <button type="button" class="btn btn-sm btn-light  btn-outline-secondary"
                                     (click)="layer.base = true" [ngClass]="{'active':layer.base}">

--- a/projects/hslayers/src/components/add-data/common/url/url.module.ts
+++ b/projects/hslayers/src/components/add-data/common/url/url.module.ts
@@ -3,6 +3,7 @@ import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 
+import {HsAddToMapButton} from '../../../../common/add-to-map/add-to-map.component';
 import {HsCommonUrlComponent} from './url.component';
 import {HsHistoryListModule} from './../../../../common/history-list/history-list.module';
 import {HsLanguageModule} from '../../../language/language.module';
@@ -22,6 +23,7 @@ import {WmsLayerHighlightDirective} from './wms-layer-highlight.directive';
     HsLanguageModule,
     HsHistoryListModule,
     HsUiExtensionsModule,
+    HsAddToMapButton,
   ],
   exports: [
     HsUrlAddComponent,

--- a/projects/hslayers/src/components/add-data/common/url/url.module.ts
+++ b/projects/hslayers/src/components/add-data/common/url/url.module.ts
@@ -3,7 +3,7 @@ import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 
-import {HsAddToMapButton} from '../../../../common/add-to-map/add-to-map.component';
+import {HsAddToMapButtonComponent} from '../../../../common/add-to-map/add-to-map.component';
 import {HsCommonUrlComponent} from './url.component';
 import {HsHistoryListModule} from './../../../../common/history-list/history-list.module';
 import {HsLanguageModule} from '../../../language/language.module';
@@ -23,7 +23,7 @@ import {WmsLayerHighlightDirective} from './wms-layer-highlight.directive';
     HsLanguageModule,
     HsHistoryListModule,
     HsUiExtensionsModule,
-    HsAddToMapButton,
+    HsAddToMapButtonComponent,
   ],
   exports: [
     HsUrlAddComponent,

--- a/projects/hslayers/src/components/add-data/url/geosparql/geosparql.component.html
+++ b/projects/hslayers/src/components/add-data/url/geosparql/geosparql.component.html
@@ -49,10 +49,8 @@
 
     <hs-new-layer-form [data]="data"></hs-new-layer-form>
 
-    <button class="btn btn-primary w-100 mt-2" [disabled]="!(data.geomProperty && data.idProperty && data.title)"
-      (click)="add()"><i class="icon-plus"></i>
-      {{'COMMON.add' | translateHs }}
-    </button>
+    <hs-add-to-map [disabled]="!(data.geomProperty && data.idProperty && data.title)" (add)="add()"
+      [title]="'ADDLAYERS.addSelected'"></hs-add-to-map>
   </div>
 
   <!--

--- a/projects/hslayers/src/components/add-data/url/geosparql/geosparql.module.ts
+++ b/projects/hslayers/src/components/add-data/url/geosparql/geosparql.module.ts
@@ -3,7 +3,7 @@ import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 
 import {HsAddDataCommonModule} from '../../common/common.module';
-import {HsAddToMapButton} from '../../../../common/add-to-map/add-to-map.component';
+import {HsAddToMapButtonComponent} from '../../../../common/add-to-map/add-to-map.component';
 import {HsCommonUrlModule} from '../../common/url/url.module';
 import {HsLanguageModule} from '../../../language/language.module';
 import {HsUrlGeoSparqlComponent} from './geosparql.component';
@@ -15,7 +15,7 @@ import {HsUrlGeoSparqlComponent} from './geosparql.component';
     HsAddDataCommonModule,
     HsCommonUrlModule,
     HsLanguageModule,
-    HsAddToMapButton,
+    HsAddToMapButtonComponent,
   ],
   exports: [HsUrlGeoSparqlComponent],
   declarations: [HsUrlGeoSparqlComponent],

--- a/projects/hslayers/src/components/add-data/url/geosparql/geosparql.module.ts
+++ b/projects/hslayers/src/components/add-data/url/geosparql/geosparql.module.ts
@@ -3,6 +3,7 @@ import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 
 import {HsAddDataCommonModule} from '../../common/common.module';
+import {HsAddToMapButton} from '../../../../common/add-to-map/add-to-map.component';
 import {HsCommonUrlModule} from '../../common/url/url.module';
 import {HsLanguageModule} from '../../../language/language.module';
 import {HsUrlGeoSparqlComponent} from './geosparql.component';
@@ -14,6 +15,7 @@ import {HsUrlGeoSparqlComponent} from './geosparql.component';
     HsAddDataCommonModule,
     HsCommonUrlModule,
     HsLanguageModule,
+    HsAddToMapButton,
   ],
   exports: [HsUrlGeoSparqlComponent],
   declarations: [HsUrlGeoSparqlComponent],

--- a/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.html
+++ b/projects/hslayers/src/components/add-data/vector/vector-file/vector-file.component.html
@@ -33,16 +33,8 @@
     <div [hidden]="uploadType === 'existing'">
       <hs-new-layer-form [data]="data"></hs-new-layer-form>
     </div>
-    <button class="btn btn-primary w-100 mt-2" [disabled]="uploadType === 'new' ? !data.title : !data.sourceLayer"
-      (click)="add()">
-      <span [hidden]="hsAddDataCommonFileService.loadingToLayman">
-        <i class="icon-plus"></i>&emsp;
-        {{'COMMON.add' | translateHs }}
-      </span>
-      <span [hidden]="!hsAddDataCommonFileService.loadingToLayman">
-        <span class="hs-loader"></span>&emsp;
-        {{'COMMON.uploading' | translateHs }}
-      </span>
-    </button>
+
+    <hs-add-to-map class="w-100 mt-2" [disabled]="uploadType === 'new' ? !data.title : !data.sourceLayer" (add)="add()"
+      [loading]="hsAddDataCommonFileService.loadingToLayman"></hs-add-to-map>
   </div>
 </form>

--- a/projects/hslayers/src/components/add-data/vector/vector-url/vector-url.component.html
+++ b/projects/hslayers/src/components/add-data/vector/vector-url/vector-url.component.html
@@ -5,9 +5,7 @@
   <div *ngIf="data.showDetails">
     <hs-new-layer-form [data]="data"></hs-new-layer-form>
 
-    <button class="btn btn-primary w-100 mt-2" [disabled]="!data.title" (click)="add()"><i class="icon-plus"></i>
-      {{'COMMON.add' | translateHs }}
-    </button>
+    <hs-add-to-map [disabled]="!data.title" (add)="add()" class="w-100 mt-2"></hs-add-to-map>
   </div>
 
 </form>

--- a/projects/hslayers/src/components/add-data/vector/vector.module.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.module.ts
@@ -5,6 +5,7 @@ import {FormsModule} from '@angular/forms';
 import {HsAddDataCommonModule} from '../common/common.module';
 import {HsAddDataVectorFileComponent} from './vector-file/vector-file.component';
 import {HsAddDataVectorUrlComponent} from './vector-url/vector-url.component';
+import {HsAddToMapButton} from '../../../common/add-to-map/add-to-map.component';
 import {HsCommonUrlModule} from '../common/url/url.module';
 import {HsLanguageModule} from '../../language/language.module';
 import {HsLaymanModule} from '../../../common/layman/layman.module';
@@ -20,6 +21,7 @@ import {HsUploadModule} from '../../../common/upload/upload.module';
     HsCommonUrlModule,
     HsLaymanModule,
     HsUploadModule,
+    HsAddToMapButton,
   ],
   exports: [HsAddDataVectorFileComponent, HsAddDataVectorUrlComponent],
   declarations: [HsAddDataVectorFileComponent, HsAddDataVectorUrlComponent],

--- a/projects/hslayers/src/components/add-data/vector/vector.module.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.module.ts
@@ -5,7 +5,7 @@ import {FormsModule} from '@angular/forms';
 import {HsAddDataCommonModule} from '../common/common.module';
 import {HsAddDataVectorFileComponent} from './vector-file/vector-file.component';
 import {HsAddDataVectorUrlComponent} from './vector-url/vector-url.component';
-import {HsAddToMapButton} from '../../../common/add-to-map/add-to-map.component';
+import {HsAddToMapButtonComponent} from '../../../common/add-to-map/add-to-map.component';
 import {HsCommonUrlModule} from '../common/url/url.module';
 import {HsLanguageModule} from '../../language/language.module';
 import {HsLaymanModule} from '../../../common/layman/layman.module';
@@ -21,7 +21,7 @@ import {HsUploadModule} from '../../../common/upload/upload.module';
     HsCommonUrlModule,
     HsLaymanModule,
     HsUploadModule,
-    HsAddToMapButton,
+    HsAddToMapButtonComponent,
   ],
   exports: [HsAddDataVectorFileComponent, HsAddDataVectorUrlComponent],
   declarations: [HsAddDataVectorFileComponent, HsAddDataVectorUrlComponent],

--- a/projects/hslayers/src/components/draw/draw-layer-metadata/draw-layer-metadata.html
+++ b/projects/hslayers/src/components/draw/draw-layer-metadata/draw-layer-metadata.html
@@ -101,7 +101,7 @@
                                 <b><a data-toggle="tooltip" [title]="layer.description">{{layer.title}}</a></b>
                                 <span class="float-right">
                                     <button type="button" class="btn btn-sm btn-primary" (click)="selectLayer(layer)"
-                                        data-toggle="tooltip" [title]="'ADDLAYERS.WFS.addToMap' | translateHs "><i
+                                        data-toggle="tooltip" [title]="'COMMON.addToMap' | translateHs "><i
                                             class="icon-plus"></i></button>
                                 </span>
                             </li>

--- a/projects/hslayers/src/public-api.ts
+++ b/projects/hslayers/src/public-api.ts
@@ -9,6 +9,7 @@ export * from './hslayers.module';
 /*
  * COMMON
  */
+export * from './common/add-to-map/public-api';
 export * from './common/confirm/public-api';
 export * from './common/download/public-api';
 export * from './common/endpoints/public-api';


### PR DESCRIPTION
## Description

Unify naming of the same action ("add to map") by reusing the same component

## Related issues or pull requests

closes #4464 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
