### PR TITLE
Styler filers and rules order

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -309,7 +309,8 @@
     "PREPARING": "Připravuje se",
     "confirmReset": "Potvrďte reset",
     "saving": "Ukládání",
-    "asNew": "jako nové"
+    "asNew": "jako nové",
+    "createdBy": "Vytvořil"
   },
   "COMPOSITIONS": {
     "addByAddress": "Přidat kompozici z adresy",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -309,7 +309,8 @@
     "PREPARING": "Preparing",
     "confirmReset": "Confirm reset",
     "saving": "Saving",
-    "asNew": "as new"
+    "asNew": "as new",
+    "createdBy": "Created by"
   },
   "COMPOSITIONS": {
     "addByAddress": "Add composition by address",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -309,7 +309,8 @@
     "PREPARING": "Pripravuje sa",
     "confirmReset": "Potvrďte reset",
     "saving": "Ukladanie",
-    "asNew": "ako nové"
+    "asNew": "ako nové",
+    "createdBy": "Vytvoril"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pridať kompozíciu z adresy",

--- a/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.html
+++ b/projects/hslayers/src/components/add-data/common/save-to-layman/save-to-layman.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="data.type !== 'shp' && data.type !== 'raster'">
+<ng-container *ngIf="data.type !== 'shp' && !data.type.includes('raster') ">
   <div class="d-flex flex-row justify-content-between align-items-baseline mb-1 ps-4">
     <div>
       {{'ADDDATA.saveToCatalogue' | translateHs }}

--- a/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.html
+++ b/projects/hslayers/src/components/compositions/dialogs/overwrite-dialog.component.html
@@ -8,13 +8,22 @@
                     [attr.aria-label]="'COMMON.close' | translateHs ">
                 </button>
             </div>
-            <div  class="container py-2 gap-2 d-flex flex-column" style="max-height: 600px; overflow-y: auto">
+            <div class="container py-2 gap-2 d-flex flex-column" style="max-height: 600px; overflow-y: auto">
                 <div class="row">
-                    <div class="col-4" style="text-align: right;">{{'COMPOSITIONS.dialogoverwriteConfirm.youAreOpeningMap' | translateHs }}:</div>
+                    <div class="col-5" style="text-align: right;">
+                        {{'COMPOSITIONS.dialogoverwriteConfirm.youAreOpeningMap' | translateHs }}:</div>
                     <div class="fw-bold col-5 flex-grow-1">{{data.title}}</div>
                 </div>
+                <div class="row" *ngIf="data.workspace">
+                    <div class="col-5" style="text-align: right;">
+                        {{'COMMON.createdBy' | translateHs }}:
+                    </div>
+                    <div class="col-5 flex-grow-1">
+                        {{data.workspace}}
+                    </div>
+                </div>
                 <div class="row">
-                    <div class="col-4" style="text-align: right;">
+                    <div class="col-5" style="text-align: right;">
                         {{'COMMON.abstract' | translateHs }}:
                     </div>
                     <div class="col-5 flex-grow-1">
@@ -22,18 +31,19 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-4" style="text-align: right;">
+                    <div class="col-5" style="text-align: right;">
                         {{'COMMON.date' | translateHs }}:
                     </div>
                     <div class="col-5">
-                        {{data.dateStamp}}
+                        {{data.date}}
                     </div>
                 </div>
-                
+
             </div>
             <div class="modal-footer flex-nowrap">
-                <button type="button" class="btn btn-primary compositions-btn-overwrite align-self-stretch" (click)="overwrite()"
-                    data-dismiss="modal">{{'SAVECOMPOSITION.form.overwrite' | translateHs }}</button>
+                <button type="button" class="btn btn-primary compositions-btn-overwrite align-self-stretch"
+                    (click)="overwrite()" data-dismiss="modal">{{'SAVECOMPOSITION.form.overwrite' | translateHs
+                    }}</button>
                 <button type="button" class="btn btn-primary compositions-btn-add" (click)="add();"
                     data-dismiss="modal">{{'COMPOSITIONS.dialogoverwriteConfirm.mergeCompositions' |
                     translateHs}}</button>
@@ -41,8 +51,8 @@
                     class="btn btn-primary compositions-btn-save" (click)="save()" style="white-space: break-spaces;"
                     data-dismiss="modal">{{'COMPOSITIONS.dialogoverwriteConfirm.saveChangesFirst' |
                     translateHs}}</button>
-                <button type="button" class="btn btn-secondary compositions-btn-cancel align-self-stretch" (click)="close()"
-                    data-dismiss="modal">{{'COMMON.cancel' | translateHs }}</button>
+                <button type="button" class="btn btn-secondary compositions-btn-cancel align-self-stretch"
+                    (click)="close()" data-dismiss="modal">{{'COMMON.cancel' | translateHs }}</button>
             </div>
         </div>
     </div>

--- a/projects/hslayers/src/components/compositions/endpoints/compositions-layman.service.ts
+++ b/projects/hslayers/src/components/compositions/endpoints/compositions-layman.service.ts
@@ -167,6 +167,7 @@ export class HsCompositionsLaymanService {
         url: `${endpoint.url}/rest/workspaces/${record.workspace}/maps/${record.name}`,
         endpoint,
         workspace: record.workspace,
+        date: record.updated_at.split('.')[0],
         id: `m-${record.uuid}`, //m-* to match micka's id structure.
       };
       if (response.body.extentFeatureCreated) {

--- a/projects/hslayers/src/components/compositions/endpoints/compositions-micka.service.ts
+++ b/projects/hslayers/src/components/compositions/endpoints/compositions-micka.service.ts
@@ -126,6 +126,8 @@ export class HsCompositionsMickaService {
     for (const record of endpoint.compositions) {
       record.editable = false;
       record.endpoint = endpoint;
+      record.date = record.dateStamp;
+      delete record.dateStamp;
       if (record.thumbnail == undefined) {
         record.thumbnail = endpoint.url + '?request=loadthumb&id=' + record.id;
       }

--- a/projects/hslayers/src/components/compositions/models/composition-descriptor.model.ts
+++ b/projects/hslayers/src/components/compositions/models/composition-descriptor.model.ts
@@ -22,6 +22,8 @@ export interface HsMapCompositionDescriptor {
     read: string[];
     write: string[];
   };
+  date?: string;
+  dateStamp?: string;
 }
 
 export interface LaymanCompositionDescriptor {

--- a/projects/hslayers/src/components/map/map.service.ts
+++ b/projects/hslayers/src/components/map/map.service.ts
@@ -497,6 +497,15 @@ export class HsMapService {
     this.repopulateLayers(this.visibleLayersInUrl);
 
     proj4.defs(
+      'EPSG:3035',
+      '+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs',
+    );
+    proj4.defs(
+      'http://www.opengis.net/gml/srs/epsg.xml#3035',
+      proj4.defs('EPSG:3035'),
+    );
+
+    proj4.defs(
       'EPSG:5514',
       '+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +towgs84=542.5,89.2,456.9,5.517,2.275,5.516,6.96 +units=m +no_defs',
     );

--- a/projects/hslayers/src/components/query/feature/feature.component.html
+++ b/projects/hslayers/src/components/query/feature/feature.component.html
@@ -9,30 +9,26 @@
     </hs-query-attribute-row>
     <hs-query-attribute-row *ngFor="let stat of feature.stats" [feature]="feature" [attribute]="stat" [readonly]="true">
     </hs-query-attribute-row>
-    <div class="row">
-        <div class="input-group m-1" [hidden]="!newAttribVisible">
-            <div class="input-group m-1">
-                <input class="form-control" [placeholder]="'QUERY.feature.attributeName' | translateHs  "
-                    [(ngModel)]="attributeName" [ngModelOptions]="{standalone: true}">
-            </div>
+
+    <div class="bg-light p-2 my-3" *ngIf="newAttribVisible">
+        <div class="form-floating mb-3">
+            <input class="form-control" [placeholder]="attributeName" [(ngModel)]="attributeName"
+                name="hs-add-feature-attribute-name">
+            <label for="hs-add-feature-attribute-name">{{'QUERY.feature.attributeName' | translateHs }}</label>
+        </div>
+        <div class="form-floating mb-3" [hidden]="!(attributeName && newAttribVisible)">
+            <input class="form-control" [placeholder]="attributeValue" [(ngModel)]="attributeValue"
+                name="hs-add-feature-attribute-value">
+            <label for="hs-add-feature-attribute-value">{{'QUERY.feature.attributeValue' | translateHs }}</label>
+        </div>
+        <div class="row justify-content-end" [hidden]="!(attributeName && attributeValue && newAttribVisible)">
+            <button class="btn btn-primary btn-sm w-auto d-flex gap-2 mx-2"
+                (click)="saveNewAttribute(attributeName,attributeValue)">{{'COMMON.save'
+                | translateHs}}<i class="icon-save-floppy"></i></button>
         </div>
     </div>
-    <div class="row">
-        <div class="input-group m-1" [hidden]="!(attributeName && newAttribVisible)">
-            <div class="input-group m-1">
-                <input class="form-control" [placeholder]="'QUERY.feature.attributeValue' | translateHs  "
-                    [(ngModel)]="attributeValue" [ngModelOptions]="{standalone: true}">
-            </div>
-        </div>
-    </div>
-    <div class="row" [hidden]="!(attributeName && attributeValue && newAttribVisible)">
-        <div class="col-6 mb-2 text-start">
-            <div class="btn-group">
-                <button class="btn btn-primary btn-sm" (click)="saveNewAttribute(attributeName,attributeValue)"><i
-                        class="icon-save-floppy"></i></button>
-            </div>
-        </div>
-    </div>
+
+
 
     <div [hidden]="!editType" class="row p-2 ">
         <div class="d-flex w-100 input-group input-group-sm align-items-baseline">

--- a/projects/hslayers/src/components/styles/filters/add-filter-button.component.ts
+++ b/projects/hslayers/src/components/styles/filters/add-filter-button.component.ts
@@ -19,7 +19,7 @@ export class HsAddFilterButtonComponent implements OnChanges {
   }
 
   activeTab: FilterType;
-  readonly filterOptions: FilterType[] = ['AND', 'OR', 'NOT', 'COMPARE'];
+  readonly filterOptions: FilterType[] = ['COMPARE', 'AND', 'OR', 'NOT'];
   emitClick(type: FilterType): void {
     this.clicks.emit({type});
     this.setActiveTab(type);

--- a/projects/hslayers/src/components/styles/filters/comparison-filter.component.html
+++ b/projects/hslayers/src/components/styles/filters/comparison-filter.component.html
@@ -5,10 +5,13 @@
       {{attr}}
     </option>
   </select>
-  <div>
-    <input class="form-control" name="hs-sld-filter-comparison-sign" [(ngModel)]="filter[0]" (change)="emitChange()" />
-  </div>
-  <div>
+  <select (change)="emitChange()" class="form-control form-select hs-sld-filter-comparison-sign"
+    style="width: min-content" [(ngModel)]="filter[0]" name="hs-sld-filter-comparison-sign">
+    <option [ngValue]="op" *ngFor="let op of operators">
+      {{op}}
+    </option>
+  </select>
+  <div style="min-width: 33%;">
     <input class="form-control" name="hs-sld-filter-value" [(ngModel)]="filter[2]" (change)="emitChange()" />
   </div>
   <div>

--- a/projects/hslayers/src/components/styles/filters/comparison-filter.component.html
+++ b/projects/hslayers/src/components/styles/filters/comparison-filter.component.html
@@ -1,4 +1,4 @@
-<div class="d-flex flex-row form-group">
+<div class="d-flex flex-row form-group p-1">
   <select class="form-control form-select" style="width: 100%" [(ngModel)]="filter[1]" name="hs-sld-filter-attribute">
     <option [ngValue]="undefined" [disabled]="true" selected hidden>Pick an attribute</option>
     <option [ngValue]="attr" *ngFor="let attr of attributes">

--- a/projects/hslayers/src/components/styles/filters/comparison-filter.component.ts
+++ b/projects/hslayers/src/components/styles/filters/comparison-filter.component.ts
@@ -14,6 +14,7 @@ export class HsComparisonFilterComponent extends HsStylerPartBaseComponent {
   @Input() parent;
 
   attributes: string[];
+  operators = ['==', '*=', '!=', '<', '<=', '>', '>='];
 
   constructor(private hsLayerSelectorService: HsLayerSelectorService) {
     super();

--- a/projects/hslayers/src/components/styles/filters/filters.component.ts
+++ b/projects/hslayers/src/components/styles/filters/filters.component.ts
@@ -1,8 +1,8 @@
 import {Component, Input} from '@angular/core';
 
+import {FilterType} from './filter.type';
 import {HsFiltersService} from './filters.service';
 import {HsStylerPartBaseComponent} from '../style-part-base.component';
-import { FilterType } from './filter.type';
 
 @Component({
   selector: 'hs-filters',

--- a/projects/hslayers/src/components/styles/filters/filters.service.ts
+++ b/projects/hslayers/src/components/styles/filters/filters.service.ts
@@ -5,6 +5,8 @@ import {Injectable} from '@angular/core';
   providedIn: 'root',
 })
 export class HsFiltersService {
+  operators = ['==', '*=', '!=', '<', '<=', '>', '>='];
+
   add(type: FilterType, append: boolean, collection: any[]): void {
     let filter;
     switch (type) {

--- a/projects/hslayers/src/components/styles/filters/filters.service.ts
+++ b/projects/hslayers/src/components/styles/filters/filters.service.ts
@@ -9,13 +9,24 @@ export class HsFiltersService {
     let filter;
     switch (type) {
       case 'AND':
-        filter = ['&&', ['==', undefined, '<value>']];
+        filter = [
+          '&&',
+          ['==', undefined, '<value>'],
+          ['==', undefined, '<value>'],
+        ];
         break;
       case 'OR':
-        filter = ['||', ['==', undefined, '<value>']];
+        filter = [
+          '||',
+          ['==', undefined, '<value>'],
+          ['==', undefined, '<value>'],
+        ];
         break;
       case 'COMPARE':
         filter = ['==', undefined, '<value>'];
+        break;
+      case 'NOT':
+        filter = ['!', ['==', undefined, '<value>']];
         break;
       default:
     }
@@ -32,6 +43,6 @@ export class HsFiltersService {
   }
 
   isLogOp(filters: any[]): boolean {
-    return filters?.length > 0 && ['&&', '||'].includes(filters[0]);
+    return filters?.length > 0 && ['&&', '||', '!'].includes(filters[0]);
   }
 }

--- a/projects/hslayers/src/components/styles/styler.component.html
+++ b/projects/hslayers/src/components/styles/styler.component.html
@@ -24,6 +24,10 @@
     </extra-buttons>
   </div>
   <div class="card-body p-1 pe-2 pt-2">
+    <div class="form-group m-3" *ngIf="uploaderVisible">
+      <hs-file-upload (uploaded)="handleFileUpload($event)" uploader="hs-sld-upload" acceptedFormats=".sld, .qml">
+      </hs-file-upload>
+    </div>
     <div class="form-floating pb-1" *ngIf="hsStylerService.styleObject">
       <input type="text" class="form-control" id="hs-styler-style-title"
         [placeholder]="'STYLER.styleName' | translateHs" [(ngModel)]="hsStylerService.styleObject.name">
@@ -64,10 +68,6 @@
     </ng-container>
   </div>
   <div class="card-footer bg-white px-1 border-0">
-    <div class="form-group m-3" *ngIf="uploaderVisible">
-      <hs-file-upload (uploaded)="handleFileUpload($event)" uploader="hs-sld-upload" acceptedFormats=".sld, .qml">
-      </hs-file-upload>
-    </div>
     <div class="d-flex justify-content-end" *ngIf="hsStylerService.isAuthenticated && hsStylerService
     .unsavedChange">
       <div class="p-1 m-0 btn bg-danger bg-opacity-25 btn-sm py-0" role="alert"

--- a/projects/hslayers/src/components/styles/styler.component.ts
+++ b/projects/hslayers/src/components/styles/styler.component.ts
@@ -28,8 +28,7 @@ import {HsUtilsService} from '../utils/utils.service';
 })
 export class HsStylerComponent
   extends HsPanelBaseComponent
-  implements OnDestroy
-{
+  implements OnDestroy {
   layerTitle: string;
   private end = new Subject<void>();
   uploaderVisible = false;
@@ -100,6 +99,7 @@ export class HsStylerComponent
       event.previousIndex,
       event.currentIndex,
     );
+    this.hsStylerService.save();
   }
 
   handleFileUpload(evt: HsUploadedFiles): void {

--- a/projects/hslayers/src/components/styles/styler.service.ts
+++ b/projects/hslayers/src/components/styles/styler.service.ts
@@ -354,8 +354,6 @@ export class HsStylerService {
   /**
    * Prepare current layers style for editing by converting
    * SLD attribute string to JSON and reading layers title
-   *
-   * @param layer - OL layer
    */
   async fill(layer: VectorLayer<VectorSource<Geometry>>): Promise<void> {
     const blankStyleObj = {name: 'untitled style', rules: []};
@@ -382,7 +380,12 @@ export class HsStylerService {
       }
       this.fixSymbolizerBugs(this.styleObject);
       this.geostylerWorkaround();
-      if (this.unsavedChange) {
+      /**
+       * Save (update OL style) layer style
+       * unsavedChange - synced layman layer with changes
+       * layerBeingMonitored - other vector layers
+       */
+      if (this.unsavedChange || !this.layerBeingMonitored) {
         //Update this.sld string in case styler for layer with unsaved changes was opened.
         //Could have been changed by styling other layer in the meantime
         this.save();


### PR DESCRIPTION
## Description

Styler related fixes.
-AND/OR filters were not preserved on panel change or in the resulting SLD because their interface was incorrectly implemented
- fix NOT filter by adding the specific case
-  #4447 seems to be fixed by  recretaing styles on reorder as well
-  make comarison operator dropdwon select. Took values from [here](https://geostyler.github.io/geostyler/#/Components/Filter/FilterTree)

## Related issues or pull requests
closes #4447

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
