### PR TITLE
fix: Make sure both style and service is ready after file upload

### DIFF
--- a/projects/hslayers/src/components/add-data/common/common-file.service.ts
+++ b/projects/hslayers/src/components/add-data/common/common-file.service.ts
@@ -529,6 +529,7 @@ export class HsAddDataCommonFileService extends HsAddDataCommonFileServiceParams
     const descriptor = await this.describeNewLayer(
       this.endpoint,
       response.name,
+      ['wms', 'style'],
     );
     if (descriptor?.file.error) {
       const error = descriptor.file.error;
@@ -583,7 +584,7 @@ export class HsAddDataCommonFileService extends HsAddDataCommonFileServiceParams
   async describeNewLayer(
     endpoint: HsEndpoint,
     layerName: string,
-    pendingParam: string = 'wms',
+    pendingParams: string[] = ['wms'],
   ): Promise<HsLaymanLayerDescriptor> {
     try {
       const descriptor = await this.hsLaymanService.describeLayer(
@@ -591,10 +592,14 @@ export class HsAddDataCommonFileService extends HsAddDataCommonFileServiceParams
         layerName,
         endpoint.user,
       );
-      if (layerParamPendingOrStarting(descriptor, pendingParam)) {
+      if (
+        pendingParams.some((param) =>
+          layerParamPendingOrStarting(descriptor, param),
+        )
+      ) {
         return new Promise((resolve) => {
           setTimeout(() => {
-            resolve(this.describeNewLayer(endpoint, layerName, pendingParam));
+            resolve(this.describeNewLayer(endpoint, layerName, pendingParams));
           }, 2000);
         });
       } else {

--- a/projects/hslayers/src/components/add-data/vector/vector.service.ts
+++ b/projects/hslayers/src/components/add-data/vector/vector.service.ts
@@ -333,7 +333,7 @@ export class HsAddDataVectorService {
     const descriptor = await this.hsAddDataCommonFileService.describeNewLayer(
       this.hsAddDataCommonFileService.endpoint,
       layerName,
-      'style',
+      ['style'],
     );
     data.serializedStyle = await this.hsCommonLaymanService.getStyleFromUrl(
       descriptor.style.url,


### PR DESCRIPTION
## Description

Make sure both service and style urls are ready when loading layer created by uploading file.

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
