### PR TITLE
 Layman image loading + WMS type widget + Micka metadata for datasets

### DIFF
--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -3,7 +3,8 @@
     "CATALOGUE": {
       "DESC": {
         "WFS": "Web Feature Service - stahovací: slouží pro práci s geografickými daty ve vektorové reprezentaci. Je výkonostne naročnejší, především při rozsáhlejších vrstvách, umožňuje však editaci, či zobrazení individuálních informacií ke každému prvku zvlášť.",
-        "WMS": "Web Map Service - prohlížecí: data nahraje v podobě rastru. Přenášená data jsou obvykle menší co má za následek rychlejší načítání, no na druhou stranu ich není možné upravovat."
+        "WMS": "Web Map Service - prohlížecí: data nahraje v podobě rastru. Přenášená data jsou obvykle menší co má za následek rychlejší načítání, no na druhou stranu ich není možné upravovat.",
+        "WMTS": "Web Map Tile Service - slouží pro rastrové obrázky podobně jako WMS . Rozdíl je v tom, že dlaždicová služba slouží pro obsah rozdělený do \"dlaždic\", které se načítají jednotlivě - jsou tedy potenciálně výkonnější."
       },
       "filterType": "Typ vyhledávání",
       "loading": "Načítání dat",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -467,7 +467,8 @@
     "layerRDF": "RDF vrstva",
     "metadataFor": "Metadata o",
     "noResults": "Žádné výsledky",
-    "suggestions": "Návrhy"
+    "suggestions": "Návrhy",
+    "seeFullRecord": "Zobrazit úplný metadatový záznam"
   },
   "DRAW": {
     "activateDrawing": "Aktivujte kreslení výběrem typu prvku",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -312,7 +312,8 @@
     "addToMap": "Přidat do mapy",
     "reorder": "Uspořádat",
     "on": "zapnuto",
-    "off": "vypnuto"
+    "off": "vypnuto",
+    "Tile": "Dlaždice"
   },
   "COMPOSITIONS": {
     "addByAddress": "Přidat kompozici z adresy",
@@ -603,7 +604,10 @@
       "min": "Minimum",
       "colorMap": "Barevná škála",
       "ignoreExtent": "Ignorovat rozsah vrstvy",
-      "ignoreExtentInfo": "Zobrazit prvky nebo jejich části skryté mimo původní rozsah."
+      "ignoreExtentInfo": "Zobrazit prvky nebo jejich části skryté mimo původní rozsah.",
+      "changeLayerType": "Opravdu chcete změnit typ vrstvy?",
+      "layerTypeChangeNote": "Změna může ovlivnit rychlost načítání",
+      "confirmLayerTypeChange": "Potvrďte změnu typu vrstvy"
     },
     "layerList": {
       "layerIsQueryable": "Tato vrstva je dotazovatelná",

--- a/projects/hslayers/src/assets/locales/cs.json
+++ b/projects/hslayers/src/assets/locales/cs.json
@@ -2,9 +2,9 @@
   "ADDDATA": {
     "CATALOGUE": {
       "DESC": {
-        "WFS": "Web Feature Service - stahovací: slouží pro práci s geografickými daty ve vektorové reprezentaci. Je výkonostne naročnejší, především při rozsáhlejších vrstvách, umožňuje však editaci, či zobrazení individuálních informacií ke každému prvku zvlášť.",
-        "WMS": "Web Map Service - prohlížecí: data nahraje v podobě rastru. Přenášená data jsou obvykle menší co má za následek rychlejší načítání, no na druhou stranu ich není možné upravovat.",
-        "WMTS": "Web Map Tile Service - slouží pro rastrové obrázky podobně jako WMS . Rozdíl je v tom, že dlaždicová služba slouží pro obsah rozdělený do \"dlaždic\", které se načítají jednotlivě - jsou tedy potenciálně výkonnější."
+        "WFS": "Web Feature Service - stahovací: slouží pro práci s geografickými daty ve vektorové reprezentaci. Je výkonnostně náročnejší, především při rozsáhlejších vrstvách, umožňuje však editaci či zobrazení individuálních informací ke každému prvku zvlášť.",
+        "WMS": "Web Map Service - prohlížecí: data načte v podobě rastru. Přenášená data jsou obvykle menší, což má za následek rychlejší načítání. Na druhou stranu, načtené prvky nelze upravovat.",
+        "WMTS": "Web Map Tile Service - slouží pro rastrové obrázky podobně jako WMS. Rozdíl je v tom, že dlaždicová služba slouží pro obsah rozdělený do \"dlaždic\", které se načítají jednotlivě - je tedy potenciálně výkonnější."
       },
       "filterType": "Typ vyhledávání",
       "loading": "Načítání dat",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -467,7 +467,8 @@
     "layerRDF": "Layer RDF",
     "metadataFor": "Metadata for",
     "noResults": "No results",
-    "suggestions": "Suggestions"
+    "suggestions": "Suggestions",
+    "seeFullRecord": "See full metadata record"
   },
   "DRAW": {
     "activateDrawing": "Activate drawing by choosing a feature type",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -312,7 +312,8 @@
     "createdBy": "Created by",
     "reorder": "Reorder",
     "on": "on",
-    "off": "off"
+    "off": "off",
+    "Tile": "Tile"
   },
   "COMPOSITIONS": {
     "addByAddress": "Add composition by address",
@@ -603,7 +604,10 @@
       "min": "Min",
       "max": "Max",
       "ignoreExtent": "Ignore layer extent",
-      "ignoreExtentInfo": "Show features or their parts hidden outside of the initial extent."
+      "ignoreExtentInfo": "Show features or their parts hidden outside of the initial extent.",
+      "changeLayerType": "Do you really want to change layer type?",
+      "layerTypeChangeNote": "Change might affect loading performance",
+      "confirmLayerTypeChange": "Confirm layer type change"
     },
     "layerList": {
       "layerIsQueryable": "This layer is queryable",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -3,7 +3,8 @@
     "CATALOGUE": {
       "DESC": {
         "WFS": "Web Feature Service: it adds the layer as a set of vector features. It is more power-consuming, especially with large layers, but it allows to edit features or to display individual feature info.",
-        "WMS": "Web Map Service: it adds the layer as a raster image. The transferred data is usually smaller so it generally loads faster. Yet it does not give you the access to the underlying layer features."
+        "WMS": "Web Map Service: it adds the layer as a raster image. The transferred data is usually smaller so it generally loads faster. Yet it does not give you the access to the underlying layer features.",
+        "WMTS": "Web Map Tile Service - serves raster images simillarliy to WMS . The difference is that tile service serves content divided into 'tile' which are loaded individually - thus being potentially more performant."
       },
       "filterType": "Search within",
       "loading": "Loading data",

--- a/projects/hslayers/src/assets/locales/en.json
+++ b/projects/hslayers/src/assets/locales/en.json
@@ -4,7 +4,7 @@
       "DESC": {
         "WFS": "Web Feature Service: it adds the layer as a set of vector features. It is more power-consuming, especially with large layers, but it allows to edit features or to display individual feature info.",
         "WMS": "Web Map Service: it adds the layer as a raster image. The transferred data is usually smaller so it generally loads faster. Yet it does not give you the access to the underlying layer features.",
-        "WMTS": "Web Map Tile Service - serves raster images simillarliy to WMS . The difference is that tile service serves content divided into 'tile' which are loaded individually - thus being potentially more performant."
+        "WMTS": "Web Map Tile Service - serves raster images similarly to WMS. The difference is that tile service serves content divided into 'tiles' which are loaded individually - thus being potentially more performant."
       },
       "filterType": "Search within",
       "loading": "Loading data",

--- a/projects/hslayers/src/assets/locales/lv.json
+++ b/projects/hslayers/src/assets/locales/lv.json
@@ -3,7 +3,8 @@
     "CATALOGUE": {
       "DESC": {
         "WFS": "Web Feature Service - pievieno slāni kā vektoru grafisko objektu kopumu. Tas ir vairāk resursu patērējošs, it īpaši ar lieliem slāņiem, taču tas ļauj rediģēt objektus vai parādīt atsevišķu informāciju par objektiem",
-        "WMS": "Web Map Service - pievieno slāni kā rastra attēlu. Pārsūtītie dati parasti ir mazāki, tāpēc tie parasti tiek ielādēti ātrāk. Tomēr tas nedod Jums piekļuvi pamata slāņa funkcijām."
+        "WMS": "Web Map Service - pievieno slāni kā rastra attēlu. Pārsūtītie dati parasti ir mazāki, tāpēc tie parasti tiek ielādēti ātrāk. Tomēr tas nedod Jums piekļuvi pamata slāņa funkcijām.",
+        "WMTS": "Web Map Tile Service - apkalpo rastra attēlus līdzīgi kā WMS . Atšķirība ir tāda, ka flīžu pakalpojums apkalpo saturu, kas sadalīts \"flīzēs\", kuras tiek ielādētas atsevišķi - tādējādi tas ir potenciāli jaudīgāks."
       },
       "filterType": "Meklēt pēc",
       "loading": "Notiek ielāde",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -3,7 +3,8 @@
     "CATALOGUE": {
       "DESC": {
         "WFS": "Web Feature Service - sťahovacia: slúži na prácu s geografickými dátami vo vektorovej reprezentácií. Je výkonostne naročnejšia, predovšetkým pri rozsiahlejšich vrstvách, umožňuje však editáciu, či zobrazenie individuálnych informacií ku každému prvku zvlášť.",
-        "WMS": "Web Map Service - prehliadacia: dáta nahráva v podobe rastru. Prenášané dáta sú obvykle menie čo má za následok rychlejšie načítanie, no na druhú stranu neumožňuje ich editáciu."
+        "WMS": "Web Map Service - prehliadacia: dáta nahráva v podobe rastru. Prenášané dáta sú obvykle menie čo má za následok rychlejšie načítanie, no na druhú stranu neumožňuje ich editáciu.",
+        "WMTS": "Web Map Tile Service - slúži na zobrazovanie rastrových obrázkov podobne ako služba WMS. Rozdiel je v tom, že dlaždicová služba poskytuje obsah rozdelený na \"dlaždice\", ktoré sa načítavajú jednotlivo - sú teda potenciálne výkonnejšie."
       },
       "filterType": "Typ vyhľadávania",
       "loading": "Načítanie dát",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -312,7 +312,8 @@
     "addToMap": "Pridať do mapy",
     "reorder": "Usporiadať",
     "on": "zapnuté",
-    "off": "vypnuté"
+    "off": "vypnuté",
+    "Tile": "Dlaždica"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pridať kompozíciu z adresy",
@@ -603,7 +604,10 @@
       "max": "Max",
       "min": "Min",
       "ignoreExtent": "Ignorovať rozsah vrstvy",
-      "ignoreExtentInfo": "Zobraziť prvky alebo ich časti skryté mimo pôvodného rozsahu."
+      "ignoreExtentInfo": "Zobraziť prvky alebo ich časti skryté mimo pôvodného rozsahu.",
+      "changeLayerType": "Naozaj chcete zmeniť typ vrstvy?",
+      "layerTypeChangeNote": "Zmena môže ovplyvniť rýchlosť načítania",
+      "confirmLayerTypeChange": "Potvrďte zmenu typu vrstvy"
     },
     "layerList": {
       "layerIsQueryable": "Táto vrstva je dotazovateľná",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -467,7 +467,8 @@
     "layerRDF": "RDF vrstva",
     "metadataFor": "Metadáta o",
     "noResults": "Žiadne výsledky",
-    "suggestions": "Návrhy"
+    "suggestions": "Návrhy",
+    "seeFullRecord": "Zobraziť úplný metaddátový záznam"
   },
   "DRAW": {
     "activateDrawing": "Aktivujte kreslenie výberom typu prvku",

--- a/projects/hslayers/src/assets/locales/sk.json
+++ b/projects/hslayers/src/assets/locales/sk.json
@@ -468,7 +468,7 @@
     "metadataFor": "Metadáta o",
     "noResults": "Žiadne výsledky",
     "suggestions": "Návrhy",
-    "seeFullRecord": "Zobraziť úplný metaddátový záznam"
+    "seeFullRecord": "Zobraziť úplný metadátový záznam"
   },
   "DRAW": {
     "activateDrawing": "Aktivujte kreslenie výberom typu prvku",

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -53,19 +53,9 @@
                 [href]='hsAddDataCatalogueService.layerDownload(layer.endpoint, layer)' data-toggle="tooltip"
                 [title]="'COMMON.download' | translateHs "><i class="icon-download"></i></a>
         </div>
-        <!-- <div class="p-0" [hidden]='getEndpoint(layer.endpoint).type != "micka" || layerRDF(layer.endpoint, layer) == "#"'>
-            <a class="btn btn-sm btn-secondary" [href]='layerRDF(layer.endpoint, layer)'
-                data-toggle="tooltip" title="GeoDCAT-AP" target="_blank"><i class="icon-share-alt"></i></a>
-        </div> -->
     </div>
 </div>
 <div>
-    <!-- <div class="p-0" [hidden]="!selectTypeToAddLayerVisible || selectedType">
-        <button type="button" class="btn btn-sm btn-danger" (click)="$event.stopPropagation();abortAdd()" data-toggle="tooltip"
-            [title]="'DATASOURCE_SELECTOR.datasourceListItem.abortAdd' | translateHs ">
-            <i class="icon-remove"></i>
-        </button>
-    </div> -->
     <div [hidden]="!loadingInfo" class="list-group-item text-primary text-center py-2">
         <span class="pe-2 hs-loader hs-loader-dark"></span>
         &emsp;{{'ADDDATA.CATALOGUE.loading' | translateHs }}
@@ -73,7 +63,7 @@
     <div class="card bg-light align-items-center"
         [hidden]="!selectTypeToAddLayerVisible || loadingInfo || hsAddDataCatalogueService.selectedLayer?.id !== layer.id">
         <div class="d-flex flex-row justify-content-between align-items-center w-100">
-            <div class="px-3">
+            <div class="px-3 py-2">
                 <span class="btn btn-sm disabled border-0" disabled="true" aria-disabled="true">{{
                     'COMMON.addAs' |
                     translateHs }}&nbsp;</span>
@@ -100,5 +90,4 @@
             </ul>
         </div>
     </div>
-
 </div>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -12,20 +12,21 @@
         *ngIf="hsAddDataCatalogueService.selectedLayer?.id === layer.id">
         <hr class="hs-dotted-line w-100 ">
         <div class="d-flex flex-row justify-content-around align-items-end">
-            <a class="btn btn-sm border-0" [class.disabled]="!layerAvailable" [hidden]="selectTypeToAddLayerVisible"
-                [ngClass]="{'text-muted': layerAvailable}"
-                (click)="$event.stopPropagation();addLayerToMap(layer.endpoint, layer)">
-                <i [hidden]="loadingInfo" class="icon-plus icon-primary"></i>
-                <span [hidden]="!loadingInfo" class="hs-loader"></span>
-                <span *ngIf="layerAvailable" class="ms-1">{{'COMMON.addToMap' |
-                    translateHs }}</span>
-            </a>
-            <a class="btn btn-sm border-0" [title]="'DATASOURCE_SELECTOR.datasourceListItem.abortAdd' | translateHs "
-                (click)="$event.stopPropagation();abortAdd()" [hidden]="!selectTypeToAddLayerVisible">
-                <i class="icon-remove text-danger"></i><span
-                    class="ms-1">{{'DATASOURCE_SELECTOR.datasourceListItem.abortAdd' |
-                    translateHs }}</span>
-            </a>
+            <div class="btn-group" (click)="$event.stopPropagation()">
+                <button type="button" class="btn btn-sm border-0" [class.disabled]="!layerAvailable"
+                    (click)="selectTypeAndAdd('WMTS',$event)">
+                    <i class="icon-plus icon-primary"></i>
+                    <span *ngIf="layerAvailable" class="ms-1">{{'COMMON.addToMap' |
+                        translateHs }}</span>
+                </button>
+                <div class="btn-group" role="group" *ngIf="layerAvailable">
+                    <button type="button"
+                        class="btn btn-sm dropdown-toggle-split btn-outline-primary border-0 dropdown-toggle"
+                        (click)="$event.stopPropagation();toggleAddOptions(layer.endpoint, layer)">
+                    </button>
+                </div>
+            </div>
+
             <a class="btn btn-sm border-0" (click)="showMetadata(layer.endpoint, layer)">
                 <i class="icon-info-sign icon-primary"></i><span class="ms-1">{{'COMMON.metadata' |
                     translateHs }}</span>
@@ -73,19 +74,22 @@
                         {{type}}
                     </label>
                 </div>
-            </div>
-            <div>
-                <a class="btn btn-sm border-0" (click)="$event.stopPropagation();toggleExplanations()"
+                <a class="btn btn-sm border-0 px-0" style="margin-top: -1rem;"
+                    (click)="$event.stopPropagation();toggleExplanations()"
                     [title]="'DATASOURCE_SELECTOR.datasourceListItem.whatDoesItMean' | translateHs ">
                     <i class="icon-question-sign text-primary"></i>
                 </a>
             </div>
+            <a class="btn btn-sm border-0" [title]="'COMMON.close' | translateHs " style="margin-top: -1rem;"
+                (click)="$event.stopPropagation();abortAdd()" [hidden]="!selectTypeToAddLayerVisible">
+                <i class="icon-remove text-danger"></i>
+            </a>
         </div>
         <div class="d-flex">
             <ul class="ms-auto p-2 list-unstyled" [hidden]="!explanationsVisible">
                 <li class="text-secondary small" *ngFor="let type of whatToAddTypes">
                     {{type}} &ndash; {{translateString('ADDDATA.CATALOGUE.DESC', type)}}
-                    <!-- TODO: Remove function call from template -->
+
                 </li>
             </ul>
         </div>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -3,6 +3,7 @@
         <a class="hs-catalogue-list-item-title" data-toggle="tooltip" [title]="layer.abstract || ''">{{layer.title ||
             layer.abstract}}</a>
         <!-- STATUS BADGE -->
+        <span *ngIf="loadingMetadata" class="pe-2 hs-loader hs-loader-dark"></span>
         <span class="badge rounded-pill w-auto" *ngIf="!layerAvailable" [ngClass]="{
             'bg-danger':layer.wfsWmsStatus === 'NOT_AVAILABLE',
             'bg-warning':layer.wfsWmsStatus === 'PREPARING'

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -14,7 +14,7 @@
         <div class="d-flex flex-row justify-content-around align-items-end">
             <div class="btn-group" (click)="$event.stopPropagation()">
                 <button type="button" class="btn btn-sm border-0" [class.disabled]="!layerAvailable"
-                    (click)="selectTypeAndAdd('WMTS',$event)">
+                    (click)="selectTypeAndAdd('WMS',$event)">
                     <i class="icon-plus icon-primary"></i>
                     <span *ngIf="layerAvailable" class="ms-1">{{'COMMON.addToMap' |
                         translateHs }}</span>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.html
@@ -10,7 +10,6 @@
     </div>
     <div class="hs-catalogue-item-body d-flex flex-column w-100 justify-content-around mt-2"
         *ngIf="hsAddDataCatalogueService.selectedLayer?.id === layer.id">
-        <hr class="hs-dotted-line w-100 ">
         <div class="d-flex flex-row justify-content-around align-items-end">
             <div class="btn-group" (click)="$event.stopPropagation()">
                 <button type="button" class="btn btn-sm border-0" [class.disabled]="!layerAvailable"
@@ -80,7 +79,7 @@
                     <i class="icon-question-sign text-primary"></i>
                 </a>
             </div>
-            <a class="btn btn-sm border-0" [title]="'COMMON.close' | translateHs " style="margin-top: -1rem;"
+            <a class="btn btn-sm border-0" [title]="'COMMON.close' | translateHs "
                 (click)="$event.stopPropagation();abortAdd()" [hidden]="!selectTypeToAddLayerVisible">
                 <i class="icon-remove text-danger"></i>
             </a>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
@@ -16,6 +16,7 @@ import {HsLaymanService} from '../../../save-map/layman.service';
 import {HsLogService} from '../../../../common/log/log.service';
 import {HsSetPermissionsDialogComponent} from './../../../../common/layman/dialog-set-permissions/set-permissions.component';
 import {HsUtilsService} from '../../../utils/utils.service';
+
 @Component({
   selector: 'hs-catalogue-list-item',
   templateUrl: 'catalogue-list-item.component.html',
@@ -49,6 +50,19 @@ export class HsCatalogueListItemComponent implements OnInit {
       this.layer.endpoint.type === 'micka' ||
       this.layer.wfsWmsStatus === 'AVAILABLE';
   }
+
+  /**
+   * Toggle add layer options
+   */
+  toggleAddOptions(endpoint: HsEndpoint, layer: HsAddDataLayerDescriptor) {
+    if (!this.selectTypeToAddLayerVisible) {
+      this.loadingInfo = true;
+      this.addLayerToMap(endpoint, layer);
+      return;
+    }
+    this.abortAdd();
+  }
+
   /**
    * Add selected layer to map (into layer manager) if possible (supported formats: WMS, WFS, Sparql, kml, geojson, json)
    * @param endpoint - Datasource of selected layer
@@ -58,7 +72,6 @@ export class HsCatalogueListItemComponent implements OnInit {
     endpoint: HsEndpoint,
     layer: HsAddDataLayerDescriptor,
   ): Promise<void> {
-    this.loadingInfo = true;
     const availableTypes = await this.hsAddDataCatalogueService.addLayerToMap(
       endpoint,
       layer,

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
@@ -66,6 +66,12 @@ export class HsCatalogueListItemComponent implements OnInit {
     );
     this.loadingInfo = false;
     if (Array.isArray(availableTypes)) {
+      /**
+       * Add third type allowing user to choose image source type
+       */
+      availableTypes.includes('WMS')
+        ? availableTypes.splice(1, 0, 'WMTS')
+        : availableTypes;
       this.whatToAddTypes = availableTypes;
       this.selectTypeToAddLayerVisible = true;
     } else {
@@ -88,8 +94,11 @@ export class HsCatalogueListItemComponent implements OnInit {
    */
   selectTypeAndAdd(type: string, event: MouseEvent): void {
     event.preventDefault();
-    this.selectedType = type;
-    this.addLayerToMap(this.layer.endpoint, this.layer);
+    this.selectedType = type === 'WMS' || type === 'WMTS' ? 'WMS' : type;
+    this.addLayerToMap(this.layer.endpoint, {
+      ...this.layer,
+      useTiles: type === 'WMTS',
+    });
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
@@ -38,6 +38,8 @@ export class HsCatalogueListItemComponent implements OnInit {
   whatToAddTypes: string[];
   loadingInfo = false;
 
+  loadingMetadata = false;
+
   //** Layers wfsWmsStatus is AVAILABLE  */
   layerAvailable: boolean;
   constructor(
@@ -149,15 +151,21 @@ export class HsCatalogueListItemComponent implements OnInit {
     endpoint: HsEndpoint,
     layer: HsAddDataLayerDescriptor,
   ): Promise<void> {
+    let layerWithMetadata;
     if (endpoint.type.includes('layman')) {
-      await this.hsLaymanBrowserService.fillLayerMetadata(endpoint, layer);
+      this.loadingMetadata = true;
+      layerWithMetadata = await this.hsLaymanBrowserService.fillLayerMetadata(
+        endpoint,
+        layer,
+      );
     }
     //this.metadata = this.hsDatasourcesMetadataService.decomposeMetadata(layer);
     //console.log(this.metadata);
     this.hsDialogContainerService.create(HsCatalogueMetadataComponent, {
-      selectedLayer: layer,
+      selectedLayer: layerWithMetadata || layer,
       selectedDS: endpoint,
     });
+    this.loadingMetadata = false;
   }
 
   /**

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
@@ -20,6 +20,14 @@ import {HsUtilsService} from '../../../utils/utils.service';
 @Component({
   selector: 'hs-catalogue-list-item',
   templateUrl: 'catalogue-list-item.component.html',
+  styles: [
+    `
+      .dropdown-toggle::after {
+        font-size: 1.25rem;
+        vertical-align: initial;
+      }
+    `,
+  ],
 })
 export class HsCatalogueListItemComponent implements OnInit {
   @Input() layer: HsAddDataLayerDescriptor;

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
@@ -18,8 +18,9 @@
                 </ng-container>
             </div>
             <div class="modal-footer">
-                <div *ngIf="selectedDS.type === 'micka' || selectedLayer.wfsWmsStatus === 'AVAILABLE'">
-                    <button type="button" class="btn btn-primary ms-2" *ngFor="let type of selectedLayer.availableTypes"
+                <div class="d-flex" *ngIf="selectedDS.type === 'micka' || selectedLayer.wfsWmsStatus === 'AVAILABLE'">
+                    <button type="button" class="btn btn-primary ms-2 d-flex gap-2 align-items-center"
+                        *ngFor="let type of selectedLayer.availableTypes"
                         (click)="addLayerToMap(selectedDS, selectedLayer, type)" data-dismiss="modal">
                         <span class="icon-plus"></span><span>{{'DATASOURCE_SELECTOR.addToMapAs' | translateHs }}
                             {{type}}</span>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.html
@@ -18,26 +18,37 @@
                 </ng-container>
             </div>
             <div class="modal-footer">
-                <a role="button" class="btn btn-success"
-                    [href]='hsAddDataCatalogueService.layerRDF(selectedDS, selectedLayer)' data-toggle="tooltip"
-                    title="GeoDCAT-AP" target="_blank"
-                    [hidden]='selectedDS.type!=="micka" || hsAddDataCatalogueService.layerRDF(selectedDS, selectedLayer) === "#"'>
-                    <i class="icon-share-alt"></i> RDF
-                </a><!-- TODO: Remove function call from template -->
-                <button type="button" class="btn btn-success" [hidden]="selectedLayer.bbox === undefined"
-                    (click)="hsAddDataCatalogueMapService.zoomTo(selectedLayer.bbox)">{{'COMMON.zoomTo' |
-                    translateHs }}</button>
-                <div *ngIf="selectedDS.type.includes('layman') && selectedLayer.wfsWmsStatus === 'AVAILABLE'">
-                    <button type="button" class="btn btn-primary ms-2" *ngFor="let type of selectedLayer.type"
+                <div *ngIf="selectedDS.type === 'micka' || selectedLayer.wfsWmsStatus === 'AVAILABLE'">
+                    <button type="button" class="btn btn-primary ms-2" *ngFor="let type of selectedLayer.availableTypes"
                         (click)="addLayerToMap(selectedDS, selectedLayer, type)" data-dismiss="modal">
                         <span class="icon-plus"></span><span>{{'DATASOURCE_SELECTOR.addToMapAs' | translateHs }}
                             {{type}}</span>
                     </button>
                 </div>
-                <button type="button" class="btn btn-secondary" (click)="close()" data-dismiss="modal"
-                    [title]="'COMMON.close' | translateHs ">
-                    {{'COMMON.close' | translateHs }}
-                </button>
+                <div class="d-flex w-100 justify-content-between">
+                    <ng-container *ngIf="selectedLayer?.metadata?.record_url">
+                        <a target="_blank" [href]="selectedLayer.metadata.record_url" class="btn btn-primary"
+                            (click)="close()">{{'DATASOURCE_SELECTOR.seeFullRecord' | translateHs}} <i
+                                class="icon icon-opennewwindow"></i></a>
+                    </ng-container>
+                    <div class="d-flex gap-2">
+                        <a role="button" class="btn btn-success"
+                            [href]='hsAddDataCatalogueService.layerRDF(selectedDS, selectedLayer)' data-toggle="tooltip"
+                            title="GeoDCAT-AP" target="_blank"
+                            [hidden]='selectedDS.type!=="micka" || hsAddDataCatalogueService.layerRDF(selectedDS, selectedLayer) === "#"'>
+                            <i class="icon-share-alt"></i> RDF
+                        </a><!-- TODO: Remove function call from template -->
+                        <button type="button" class="btn btn-success" [hidden]="selectedLayer.bbox === undefined"
+                            (click)="hsAddDataCatalogueMapService.zoomTo(selectedLayer.bbox)">{{'LAYERMANAGER.layerEditor.zoomToLayer'
+                            |
+                            translateHs }}</button>
+                        <button type="button" class="btn btn-secondary" (click)="close()" data-dismiss="modal"
+                            [title]="'COMMON.close' | translateHs ">
+                            {{'COMMON.close' | translateHs }}
+                        </button>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.module.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.module.ts
@@ -3,11 +3,16 @@ import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 
 import {HsCatalogueMetadataComponent} from './catalogue-metadata.component';
-import {TranslateCustomPipe} from '../../../language/translate-custom.pipe';
 import {HsUiExtensionsModule} from '../../../../common/widgets/ui-extensions.module';
+import {TranslateCustomPipe} from '../../../language/translate-custom.pipe';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, TranslateCustomPipe, HsUiExtensionsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TranslateCustomPipe,
+    HsUiExtensionsModule,
+  ],
   exports: [HsCatalogueMetadataComponent],
   declarations: [HsCatalogueMetadataComponent],
   providers: [],

--- a/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/catalogue.service.ts
@@ -440,6 +440,9 @@ export class HsAddDataCatalogueService extends HsAddDataCatalogueParams {
               ? layer.name
               : whatToAdd.name
             : undefined,
+        layerOptions: {
+          useTiles: layer.useTiles ?? true,
+        },
       });
     } else if (whatToAdd.type == 'WFS') {
       if (ds.type == 'micka') {

--- a/projects/hslayers/src/components/add-data/catalogue/layer-descriptor.model.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layer-descriptor.model.ts
@@ -3,6 +3,8 @@ import {HsEndpoint} from '../../../common/endpoints/endpoint.interface';
 export interface HsAddDataLayerDescriptor {
   abstract?: string;
   bbox;
+  bounding_box?;
+  metadata;
   formats?;
   name?: string;
   serviceType?;
@@ -10,6 +12,7 @@ export interface HsAddDataLayerDescriptor {
   title?: string;
   trida?;
   type: string[];
+  availableTypes: string[];
   file?: {
     path?: string;
     file_type?: string;

--- a/projects/hslayers/src/components/add-data/catalogue/layer-descriptor.model.ts
+++ b/projects/hslayers/src/components/add-data/catalogue/layer-descriptor.model.ts
@@ -37,4 +37,5 @@ export interface HsAddDataLayerDescriptor {
     write: string[];
   };
   wfsWmsStatus?: 'AVAILABLE' | 'PREPARING' | 'NOT_AVAILABLE';
+  useTiles: boolean;
 }

--- a/projects/hslayers/src/components/compositions/compositions.component.html
+++ b/projects/hslayers/src/components/compositions/compositions.component.html
@@ -8,7 +8,7 @@
             </button>
             <extra-buttons>
                 <a class="dropdown-item" (click)="reload()">
-                    <i class="icon-save-floppy"></i>&nbsp;{{'COMMON.reload' | translateHs}}
+                    <i class="icon-fatredo"></i>&nbsp;{{'COMMON.reload' | translateHs}}
                 </a>
                 <label class="dropdown-item cursor-pointer" style="text-wrap: pretty;">
                     <span class="icon-upload"></span><input type="file" (change)="handleFileSelect($event)"

--- a/projects/hslayers/src/components/compositions/compositions.component.html
+++ b/projects/hslayers/src/components/compositions/compositions.component.html
@@ -3,12 +3,12 @@
     <div class="hs-compositions-header">
         <hs-panel-header name="composition_browser" [panelTabs]="'COMPOSITIONS'">
             <button mainButton class="btn btn-sm btn-outline-primary border-0 align-items-center d-flex gap-2"
-                (click)="reload()"> {{'COMMON.reload' | translateHs}}
-                <i class="glyphicon icon-fatredo"></i>
+                (click)="openSaveMapPanel()"> {{'PANEL_HEADER.SAVECOMPOSITION' | translateHs}}
+                <i class="glyphicon icon-save-floppy"></i>
             </button>
             <extra-buttons>
-                <a class="dropdown-item" (click)="openSaveMapPanel()">
-                    <i class="icon-save-floppy"></i>&nbsp;{{'PANEL_HEADER.SAVECOMPOSITION' | translateHs}}
+                <a class="dropdown-item" (click)="reload()">
+                    <i class="icon-save-floppy"></i>&nbsp;{{'COMMON.reload' | translateHs}}
                 </a>
                 <label class="dropdown-item cursor-pointer" style="text-wrap: pretty;">
                     <span class="icon-upload"></span><input type="file" (change)="handleFileSelect($event)"

--- a/projects/hslayers/src/components/compositions/layer-parser/composition-layer-options.type.ts
+++ b/projects/hslayers/src/components/compositions/layer-parser/composition-layer-options.type.ts
@@ -18,6 +18,7 @@ export type LayerOptions = {
   opacity?: number;
 
   //WMS
+  useTiles?: boolean;
   base?: boolean;
   imageFormat?: string;
   queryFormat?: string;

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
@@ -32,7 +32,7 @@ import {HsOpacityWidgetComponent} from '../widgets/opacity-widget.component';
 import {HsScaleWidgetComponent} from '../widgets/scale-widget.component';
 import {HsStylerService} from '../../styles/styler.service';
 import {HsTypeWidgetComponent} from '../widgets/type-widget.component';
-import {WmsSourceWidgetComponent} from '../widgets/wms-source-widget/wms-source-widget.component';
+import {HsWmsSourceWidgetComponent } from '../widgets/wms-source-widget/wms-source-widget.component';
 import {
   getBase,
   getCachedCapabilities,
@@ -89,7 +89,7 @@ export class HsLayerEditorComponent {
       HsLayerEditorDimensionsComponent,
       HsOpacityWidgetComponent,
       HsIdwWidgetComponent,
-      WmsSourceWidgetComponent,
+      HsWmsSourceWidgetComponent ,
     ];
     for (const widgetClass of widgets) {
       this.hsWidgetContainerService.create(widgetClass, {});

--- a/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
+++ b/projects/hslayers/src/components/layermanager/editor/layer-editor.component.ts
@@ -32,6 +32,7 @@ import {HsOpacityWidgetComponent} from '../widgets/opacity-widget.component';
 import {HsScaleWidgetComponent} from '../widgets/scale-widget.component';
 import {HsStylerService} from '../../styles/styler.service';
 import {HsTypeWidgetComponent} from '../widgets/type-widget.component';
+import {WmsSourceWidgetComponent} from '../widgets/wms-source-widget/wms-source-widget.component';
 import {
   getBase,
   getCachedCapabilities,
@@ -88,6 +89,7 @@ export class HsLayerEditorComponent {
       HsLayerEditorDimensionsComponent,
       HsOpacityWidgetComponent,
       HsIdwWidgetComponent,
+      WmsSourceWidgetComponent,
     ];
     for (const widgetClass of widgets) {
       this.hsWidgetContainerService.create(widgetClass, {});

--- a/projects/hslayers/src/components/layermanager/layermanager.module.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.module.ts
@@ -35,8 +35,8 @@ import {HsQueuesModule} from '../../common/queues/queues.module';
 import {HsScaleWidgetComponent} from './widgets/scale-widget.component';
 import {HsTypeWidgetComponent} from './widgets/type-widget.component';
 import {HsUiExtensionsModule} from '../../common/widgets/ui-extensions.module';
+import {HsWmsSourceWidgetComponent} from './widgets/wms-source-widget/wms-source-widget.component';
 import {TranslateCustomPipe} from '../language/translate-custom.pipe';
-import {WmsSourceWidgetComponent} from './widgets/wms-source-widget/wms-source-widget.component';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -76,7 +76,7 @@ import {WmsSourceWidgetComponent} from './widgets/wms-source-widget/wms-source-w
     DragDropModule,
     HsQueuesModule,
     HsColormapPickerModule,
-    WmsSourceWidgetComponent,
+    HsWmsSourceWidgetComponent,
     HsPanelHeaderComponent,
   ],
   exports: [

--- a/projects/hslayers/src/components/layermanager/layermanager.module.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.module.ts
@@ -36,6 +36,7 @@ import {HsScaleWidgetComponent} from './widgets/scale-widget.component';
 import {HsTypeWidgetComponent} from './widgets/type-widget.component';
 import {HsUiExtensionsModule} from '../../common/widgets/ui-extensions.module';
 import {TranslateCustomPipe} from '../language/translate-custom.pipe';
+import {WmsSourceWidgetComponent} from './widgets/wms-source-widget/wms-source-widget.component';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -75,6 +76,7 @@ import {TranslateCustomPipe} from '../language/translate-custom.pipe';
     DragDropModule,
     HsQueuesModule,
     HsColormapPickerModule,
+    WmsSourceWidgetComponent,
     HsPanelHeaderComponent,
   ],
   exports: [

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.html
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.html
@@ -1,0 +1,6 @@
+<div class="btn-group w-100" *ngIf="isEnabled | async">
+    <button *ngFor="let o of options" (click)="changeLayerType()" [ngClass]="{'btn-primary active': o === currentType}"
+        class="btn btn-outline-primary" style="min-width: 7rem;">
+        {{o | translateHs : {module: 'COMMON'} }}
+    </button>
+</div>

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -1,0 +1,116 @@
+import ImageLayer from 'ol/layer/Image';
+import {CommonModule, NgFor} from '@angular/common';
+import {Component} from '@angular/core';
+import {HsConfirmDialogComponent} from '../../../../common/confirm/confirm-dialog.component';
+import {HsConfirmModule} from '../../../../common/confirm/confirm.module';
+import {HsDialogContainerService} from '../../../layout/dialogs/dialog-container.service';
+import {HsLanguageModule} from '../../../language/language.module';
+import {HsLanguageService} from '../../../language/language.service';
+import {HsLayerEditorWidgetBaseComponent} from '../layer-editor-widget-base.component';
+import {HsLayerSelectorService} from '../../editor/layer-selector.service';
+import {HsLayerShiftingService} from '../../../../common/layer-shifting/layer-shifting.service';
+import {HsLayerUtilsService} from '../../../utils/layer-utils.service';
+import {HsMapService} from '../../../map/map.service';
+import {HsUtilsService} from '../../../utils/utils.service';
+import {Image, Tile} from 'ol/layer';
+import {ImageWMS, TileWMS} from 'ol/source';
+import {Observable, map, tap} from 'rxjs';
+
+@Component({
+  selector: 'hs-wms-source-widget',
+  standalone: true,
+  imports: [CommonModule, NgFor, HsConfirmModule, HsLanguageModule],
+  templateUrl: './wms-source-widget.component.html',
+  styleUrl: './wms-source-widget.component.css',
+})
+export class WmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {
+  name = 'wms-source-widget';
+  isEnabled: Observable<boolean>;
+
+  options = ['Tile', 'Image'];
+  currentType: string;
+  constructor(
+    hsLayerSelectorService: HsLayerSelectorService,
+    private hsLayerUtilsService: HsLayerUtilsService,
+    private hsUtilsService: HsUtilsService,
+    private hsMapService: HsMapService,
+    private hsLayerShiftingService: HsLayerShiftingService,
+    private hsDialogContainerService: HsDialogContainerService,
+    private hsLanguageService: HsLanguageService,
+  ) {
+    super(hsLayerSelectorService);
+    this.isEnabled = this.layerDescriptor.pipe(
+      tap((l) => {
+        this.currentType = this.hsUtilsService.instOf(l.layer, ImageLayer)
+          ? 'Image'
+          : 'Tile';
+      }),
+      map((l) => {
+        return this.hsLayerUtilsService.isLayerWMS(l.layer);
+      }),
+    );
+  }
+
+  private getUrls(source: TileWMS): string {
+    return source.getUrls()[0];
+  }
+
+  private getUrl(source: ImageWMS): string[] {
+    return [source.getUrl()];
+  }
+
+  async changeLayerType() {
+    const dialog = this.hsDialogContainerService.create(
+      HsConfirmDialogComponent,
+      {
+        message: this.hsLanguageService.getTranslation(
+          'LAYERMANAGER.layerEditor.changeLayerType',
+          undefined,
+        ),
+        note: this.hsLanguageService.getTranslation(
+          'LAYERMANAGER.layerEditor.layerTypeChangeNote',
+          undefined,
+        ),
+        title: this.hsLanguageService.getTranslation(
+          'LAYERMANAGER.layerEditor.confirmLayerTypeChange',
+          undefined,
+        ),
+      },
+    );
+    const confirmed = await dialog.waitResult();
+    if (confirmed === 'yes') {
+      this.recreateLayer();
+    }
+  }
+
+  /**
+   * Clone layer properties and oarmeters and recreate it as a different type
+   * (Tile or Image)
+   */
+  private recreateLayer() {
+    const source = this.olLayer.getSource() as ImageWMS | TileWMS;
+    const sourceOptions = {
+      attributions: source.getAttributions(),
+      projection: source.getProjection(),
+      params: source.getParams(),
+    };
+
+    const urlTypeToGet = this.currentType == 'Tile' ? 'Urls' : 'Url';
+    const urlTypeToSet = urlTypeToGet == 'Urls' ? 'url' : 'urls';
+
+    sourceOptions[urlTypeToSet] = this[`get${urlTypeToGet}`](source as any);
+
+    const layerProps = {...this.olLayer.getProperties()};
+    layerProps.source =
+      this.currentType == 'Tile'
+        ? new ImageWMS(sourceOptions)
+        : new TileWMS(sourceOptions);
+    layerProps.map = undefined;
+    const lyr =
+      this.currentType == 'Tile' ? new Image(layerProps) : new Tile(layerProps);
+
+    this.hsMapService.getMap().addLayer(lyr);
+    this.hsLayerShiftingService.moveTo(lyr, this.olLayer.getZIndex());
+    this.hsMapService.getMap().removeLayer(this.olLayer);
+  }
+}

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -84,7 +84,7 @@ export class WmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {
   }
 
   /**
-   * Clone layer properties and oarmeters and recreate it as a different type
+   * Clone layer properties and parameters and recreate it as a different type
    * (Tile or Image)
    */
   private recreateLayer() {

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -1,6 +1,10 @@
-import ImageLayer from 'ol/layer/Image';
 import {CommonModule, NgFor} from '@angular/common';
 import {Component} from '@angular/core';
+import {Observable, map, tap} from 'rxjs';
+
+import {Image as ImageLayer, Tile} from 'ol/layer';
+import {ImageWMS, TileWMS} from 'ol/source';
+
 import {HsConfirmDialogComponent} from '../../../../common/confirm/confirm-dialog.component';
 import {HsConfirmModule} from '../../../../common/confirm/confirm.module';
 import {HsDialogContainerService} from '../../../layout/dialogs/dialog-container.service';
@@ -11,9 +15,6 @@ import {HsLayerShiftingService} from '../../../../common/layer-shifting/layer-sh
 import {HsLayerUtilsService} from '../../../utils/layer-utils.service';
 import {HsMapService} from '../../../map/map.service';
 import {HsUtilsService} from '../../../utils/utils.service';
-import {Image, Tile} from 'ol/layer';
-import {ImageWMS, TileWMS} from 'ol/source';
-import {Observable, map, tap} from 'rxjs';
 import {TranslateCustomPipe} from '../../../language/translate-custom.pipe';
 
 @Component({
@@ -106,7 +107,9 @@ export class HsWmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent
         : new TileWMS(sourceOptions);
     layerProps.map = undefined;
     const lyr =
-      this.currentType == 'Tile' ? new Image(layerProps) : new Tile(layerProps);
+      this.currentType == 'Tile'
+        ? new ImageLayer(layerProps)
+        : new Tile(layerProps);
 
     this.hsMapService.getMap().addLayer(lyr);
     this.hsLayerShiftingService.moveTo(lyr, this.olLayer.getZIndex());

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -4,7 +4,6 @@ import {Component} from '@angular/core';
 import {HsConfirmDialogComponent} from '../../../../common/confirm/confirm-dialog.component';
 import {HsConfirmModule} from '../../../../common/confirm/confirm.module';
 import {HsDialogContainerService} from '../../../layout/dialogs/dialog-container.service';
-import {HsLanguageModule} from '../../../language/language.module';
 import {HsLanguageService} from '../../../language/language.service';
 import {HsLayerEditorWidgetBaseComponent} from '../layer-editor-widget-base.component';
 import {HsLayerSelectorService} from '../../editor/layer-selector.service';
@@ -15,11 +14,12 @@ import {HsUtilsService} from '../../../utils/utils.service';
 import {Image, Tile} from 'ol/layer';
 import {ImageWMS, TileWMS} from 'ol/source';
 import {Observable, map, tap} from 'rxjs';
+import {TranslateCustomPipe} from '../../../language/translate-custom.pipe';
 
 @Component({
   selector: 'hs-wms-source-widget',
   standalone: true,
-  imports: [CommonModule, NgFor, HsConfirmModule, HsLanguageModule],
+  imports: [CommonModule, NgFor, HsConfirmModule, TranslateCustomPipe],
   templateUrl: './wms-source-widget.component.html',
 })
 export class HsWmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -21,7 +21,6 @@ import {Observable, map, tap} from 'rxjs';
   standalone: true,
   imports: [CommonModule, NgFor, HsConfirmModule, HsLanguageModule],
   templateUrl: './wms-source-widget.component.html',
-  styleUrl: './wms-source-widget.component.css',
 })
 export class HsWmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {
   name = 'wms-source-widget';

--- a/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/src/components/layermanager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -23,7 +23,7 @@ import {Observable, map, tap} from 'rxjs';
   templateUrl: './wms-source-widget.component.html',
   styleUrl: './wms-source-widget.component.css',
 })
-export class WmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {
+export class HsWmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {
   name = 'wms-source-widget';
   isEnabled: Observable<boolean>;
 

--- a/projects/hslayers/src/css/hslayers-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-bootstrap.scss
@@ -118,7 +118,8 @@ $list-group-item-padding-x: 1.25rem;
   }
 
   .hs-comp-item-body a.btn:hover,
-  .hs-catalogue-item-body a.btn:hover {
+  .hs-catalogue-item-body a.btn:hover,
+  .hs-catalogue-item-body button.btn:hover {
     box-shadow: #0000003d 0px 3px 8px;
   }
 

--- a/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
+++ b/projects/hslayers/src/css/hslayers-wo-bootstrap.scss
@@ -35,6 +35,12 @@ $list-group-item-padding-x: 1.25rem;
     }
   }
 
+  .hs-comp-item-body a.btn:hover,
+  .hs-catalogue-item-body a.btn:hover,
+  .hs-catalogue-item-body button.btn:hover {
+    box-shadow: #0000003d 0px 3px 8px;
+  }
+
   .form-control:not(.form-control-sm):not(.form-control-lg) {
     font-size: 1rem;
   }


### PR DESCRIPTION
## Description
- fix layman image loading function - old que tasks not being cleaned as a result of no returned value
- ~add third add-data option WMTS - which is actually old WMS option (tiled WMS) while, new WMS option creates Image WMS layer~ see comments
- add layer-editor widget allowing switching between the types
<img width="625" alt="image" src="https://github.com/hslayers/hslayers-ng/assets/44566616/57bbafb0-9375-40cf-a9be-8252e9cc425c">

## Related issues or pull requests

https://github.com/hslayers/hslayers-ng/issues/4497

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
