### PR TITLE
Permalink malformed & z-index of composition layer

### DIFF
--- a/projects/hslayers/src/common/layer-extensions.ts
+++ b/projects/hslayers/src/common/layer-extensions.ts
@@ -31,6 +31,7 @@ const GREYSCALE = 'greyscale';
 const HS_LAYMAN_SYNCHRONIZING = 'hsLaymanSynchronizing';
 const HS_QML = 'qml';
 const HS_SLD = 'sld';
+const IGNORE_PATH_ZINDEX = 'ignorePathZIndex';
 const INFO_FORMAT = 'info_format';
 const INLINE_LEGEND = 'inlineLegend';
 const LAYMAN_LAYER_DESCRIPTOR = 'laymanLayerDescriptor';
@@ -677,6 +678,21 @@ export function setSwipeSide(
   side: 'left' | 'right',
 ): void {
   layer.set(SWIPE_SIDE, side);
+}
+
+/**
+ * When set to true, prevents z-index to be set based on highest value of layer in
+ * the same layer (which is default). Used for layers from compositions (basic, permalik)
+ */
+export function setIgnorePathZIndex(
+  layer: Layer<Source>,
+  ignorePathZIndex: boolean,
+) {
+  layer.set(IGNORE_PATH_ZINDEX, ignorePathZIndex);
+}
+
+export function getIgnorePathZIndex(layer: Layer<Source>) {
+  return layer.get(IGNORE_PATH_ZINDEX);
 }
 
 export const HsLayerExt = {

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -475,6 +475,7 @@ export class HsCompositionsParserService {
       this.hsLayoutService.setMainPanel('layermanager');
     }
     this.composition_edited = false;
+    this.hsLayerManagerService.updateLayerListPositions();
     this.hsEventBusService.compositionLoads.next(responseData);
   }
 

--- a/projects/hslayers/src/components/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions-parser.service.ts
@@ -36,6 +36,7 @@ import {
 import {
   getTitle,
   setFromBaseComposition,
+  setIgnorePathZIndex,
   setMetadata,
   setSwipeSide,
 } from '../../common/layer-extensions';
@@ -767,6 +768,7 @@ export class HsCompositionsParserService {
       resultLayer = await resultLayer; //createWMTSLayer returns Promise which needs to be resolved first
       setMetadata(resultLayer, lyr_def.metadata);
       setSwipeSide(resultLayer, lyr_def.swipeSide);
+      setIgnorePathZIndex(resultLayer, true);
     }
     return resultLayer;
   }

--- a/projects/hslayers/src/components/compositions/compositions.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions.service.ts
@@ -16,6 +16,7 @@ import {HsConfig} from '../../config.service';
 import {HsEndpoint} from '../../common/endpoints/endpoint.interface';
 import {HsEventBusService} from '../core/event-bus.service';
 import {HsLanguageService} from '../language/language.service';
+import {HsLayerManagerService} from '../layermanager/layermanager.service';
 import {HsLogService} from '../../common/log/log.service';
 import {HsMapCompositionDescriptor} from './models/composition-descriptor.model';
 import {HsShareUrlService} from '../permalink/share-url.service';
@@ -47,6 +48,7 @@ export class HsCompositionsService {
     private hsCompositionsMapService: HsCompositionsMapService,
     private hsEventBusService: HsEventBusService,
     private hsToastService: HsToastService,
+    private hsLayerManagerService: HsLayerManagerService,
   ) {
     this.hsEventBusService.compositionEdits.subscribe(() => {
       this.hsCompositionsParserService.composition_edited = true;
@@ -374,6 +376,7 @@ export class HsCompositionsService {
         this.hsMapService.addLayer(layers[i], DuplicateHandling.RemoveOriginal);
       }
       this.hsMapService.fitExtent(response.data.nativeExtent);
+      this.hsLayerManagerService.updateLayerListPositions();
     } else {
       this.$log.log('Error loading permalink layers');
     }
@@ -411,6 +414,7 @@ export class HsCompositionsService {
         this.hsMapService.addLayer(layers[i], DuplicateHandling.IgnoreNew);
       }
       localStorage.removeItem('hs_layers');
+      this.hsLayerManagerService.updateLayerListPositions();
     }
   }
 

--- a/projects/hslayers/src/components/compositions/compositions.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions.service.ts
@@ -360,8 +360,7 @@ export class HsCompositionsService {
    */
   async parsePermalinkLayers(permalink: string): Promise<void> {
     await this.hsMapService.loaded();
-    const layersUrl = this.hsUtilsService.proxify(permalink);
-    const response: any = await lastValueFrom(this.http.get(layersUrl));
+    const response: any = await lastValueFrom(this.http.get(permalink));
     if (response.success == true) {
       const data: any = {};
       data.data = {};

--- a/projects/hslayers/src/components/compositions/compositions.service.ts
+++ b/projects/hslayers/src/components/compositions/compositions.service.ts
@@ -13,7 +13,6 @@ import {HsCompositionsMapService} from './compositions-map.service';
 import {HsCompositionsMickaService} from './endpoints/compositions-micka.service';
 import {HsCompositionsParserService} from './compositions-parser.service';
 import {HsConfig} from '../../config.service';
-import {HsCoreService} from '../core/core.service';
 import {HsEndpoint} from '../../common/endpoints/endpoint.interface';
 import {HsEventBusService} from '../core/event-bus.service';
 import {HsLanguageService} from '../language/language.service';
@@ -36,7 +35,6 @@ export class HsCompositionsService {
   constructor(
     private http: HttpClient,
     private hsMapService: HsMapService,
-    private hsCore: HsCoreService,
     private hsCompositionsParserService: HsCompositionsParserService,
     private hsConfig: HsConfig,
     private hsUtilsService: HsUtilsService,

--- a/projects/hslayers/src/components/layermanager/layermanager.component.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.component.ts
@@ -32,6 +32,7 @@ import {
   getActive,
   getAttribution,
   getFromBaseComposition,
+  getIgnorePathZIndex,
   getShowInLayerManager,
   getThumbnail,
   getTitle,
@@ -182,7 +183,9 @@ export class HsLayerManagerComponent
         .on('add', (e) => {
           this.hsLayerManagerService.applyZIndex(
             e.element as Layer<Source>,
-            true,
+            //z-index of composition layers should be the same as order of layers in composition.
+            //ignoring fodler structure
+            !getIgnorePathZIndex(e.element as Layer<Source>),
           );
           if (getShowInLayerManager(e.element) == false) {
             return;

--- a/projects/hslayers/src/components/layermanager/layermanager.service.ts
+++ b/projects/hslayers/src/components/layermanager/layermanager.service.ts
@@ -507,24 +507,20 @@ export class HsLayerManagerService {
     let curfolder = this.data.folders;
     const zIndex = lyr.getZIndex();
     for (let i = 0; i < parts.length; i++) {
-      let found = null;
-      for (const folder of curfolder.sub_folders) {
-        if (folder.name == parts[i]) {
-          found = folder;
-        }
-      }
-      if (found === null) {
+      const found = curfolder.sub_folders.find(
+        (folder) => folder.name === parts[i],
+      );
+      if (!found) {
         //TODO: Need to describe how hsl_path works here
+        const hsl_path = `${curfolder.hsl_path}${curfolder.hsl_path !== '' ? '/' : ''}${parts[i]}`;
+        const coded_path = `${curfolder.coded_path}${curfolder.sub_folders.length}-`;
         const new_folder = {
           sub_folders: [],
           indent: i,
           layers: [],
           name: parts[i],
-          hsl_path:
-            curfolder.hsl_path +
-            (curfolder.hsl_path != '' ? '/' : '') +
-            parts[i],
-          coded_path: curfolder.coded_path + curfolder.sub_folders.length + '-',
+          hsl_path,
+          coded_path,
           visible: true,
           zIndex: zIndex,
         };
@@ -543,7 +539,6 @@ export class HsLayerManagerService {
 
   /**
    * Remove layer from layer folder structure a clean empty folder
-   * @private
    * @param lyr - Layer to remove from layer folder
    */
   cleanFolders(lyr: Layer<Source>): void {


### PR DESCRIPTION
## Description

fix issue #4650 for version 13.x
- fix zindex assignment of composition layers -> should  match the composition layer order and not be influenced by path's max zindex
- sort layers in folder based on hsConfig.reverseLayerList

## Related issues or pull requests

#4650

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
