### PR TITLE
Composition layer order (issue 4679)

### DIFF
--- a/projects/hslayers/common/extensions/layer-extensions.ts
+++ b/projects/hslayers/common/extensions/layer-extensions.ts
@@ -625,7 +625,7 @@ export function setSwipeSide(
 
 /**
  * When set to true, prevents z-index to be set based on highest value of layer in
- * the same layer (which is default). Used for layers from compositions (basic, permalik)
+ * the same layer (which is default). Used for layers from compositions (basic, permalink)
  */
 export function setIgnorePathZIndex(
   layer: Layer<Source>,

--- a/projects/hslayers/common/extensions/layer-extensions.ts
+++ b/projects/hslayers/common/extensions/layer-extensions.ts
@@ -40,6 +40,7 @@ const GREYSCALE = 'greyscale';
 const HS_LAYMAN_SYNCHRONIZING = 'hsLaymanSynchronizing';
 const HS_QML = 'qml';
 const HS_SLD = 'sld';
+const IGNORE_PATH_ZINDEX = 'ignorePathZIndex';
 const INFO_FORMAT = 'info_format';
 const INLINE_LEGEND = 'inlineLegend';
 const LAYMAN_LAYER_DESCRIPTOR = 'laymanLayerDescriptor';
@@ -620,6 +621,21 @@ export function setSwipeSide(
   side: 'left' | 'right',
 ): void {
   layer.set(SWIPE_SIDE, side);
+}
+
+/**
+ * When set to true, prevents z-index to be set based on highest value of layer in
+ * the same layer (which is default). Used for layers from compositions (basic, permalik)
+ */
+export function setIgnorePathZIndex(
+  layer: Layer<Source>,
+  ignorePathZIndex: boolean,
+) {
+  layer.set(IGNORE_PATH_ZINDEX, ignorePathZIndex);
+}
+
+export function getIgnorePathZIndex(layer: Layer<Source>) {
+  return layer.get(IGNORE_PATH_ZINDEX);
 }
 
 export const HsLayerExt = {

--- a/projects/hslayers/components/compositions/compositions.service.ts
+++ b/projects/hslayers/components/compositions/compositions.service.ts
@@ -13,10 +13,10 @@ import {HsCompositionsMapService} from './compositions-map.service';
 import {HsCompositionsMickaService} from './endpoints/compositions-micka.service';
 import {HsCompositionsParserService} from 'hslayers-ng/shared/compositions';
 import {HsConfig} from 'hslayers-ng/config';
-import {HsCoreService} from 'hslayers-ng/shared/core';
 import {HsEndpoint} from 'hslayers-ng/types';
 import {HsEventBusService} from 'hslayers-ng/shared/event-bus';
 import {HsLanguageService} from 'hslayers-ng/shared/language';
+import {HsLayerManagerService} from 'hslayers-ng/shared/layer-manager';
 import {HsLogService} from 'hslayers-ng/shared/log';
 import {HsMapCompositionDescriptor} from 'hslayers-ng/types';
 import {HsShareUrlService} from 'hslayers-ng/components/share';
@@ -36,7 +36,6 @@ export class HsCompositionsService {
   constructor(
     private http: HttpClient,
     private hsMapService: HsMapService,
-    private hsCore: HsCoreService,
     private hsCompositionsParserService: HsCompositionsParserService,
     private hsConfig: HsConfig,
     private hsUtilsService: HsUtilsService,
@@ -49,6 +48,7 @@ export class HsCompositionsService {
     private hsCompositionsMapService: HsCompositionsMapService,
     private hsEventBusService: HsEventBusService,
     private hsToastService: HsToastService,
+    private hsLayerManagerService: HsLayerManagerService,
   ) {
     this.hsEventBusService.compositionEdits.subscribe(() => {
       this.hsCompositionsParserService.composition_edited = true;
@@ -377,6 +377,7 @@ export class HsCompositionsService {
         this.hsMapService.addLayer(layers[i], DuplicateHandling.RemoveOriginal);
       }
       this.hsMapService.fitExtent(response.data.nativeExtent);
+      this.hsLayerManagerService.updateLayerListPositions();
     } else {
       this.$log.log('Error loading permalink layers');
     }
@@ -414,6 +415,7 @@ export class HsCompositionsService {
         this.hsMapService.addLayer(layers[i], DuplicateHandling.IgnoreNew);
       }
       localStorage.removeItem('hs_layers');
+      this.hsLayerManagerService.updateLayerListPositions();
     }
   }
 

--- a/projects/hslayers/shared/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/shared/compositions/compositions-parser.service.ts
@@ -479,6 +479,7 @@ export class HsCompositionsParserService {
       this.hsLayoutService.setMainPanel('layerManager');
     }
     this.composition_edited = false;
+    this.hsLayerManagerService.updateLayerListPositions();
     this.hsEventBusService.compositionLoads.next(responseData);
   }
 

--- a/projects/hslayers/shared/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/shared/compositions/compositions-parser.service.ts
@@ -39,6 +39,7 @@ import {
 import {
   getTitle,
   setFromBaseComposition,
+  setIgnorePathZIndex,
   setMetadata,
   setSwipeSide,
 } from 'hslayers-ng/common/extensions';
@@ -767,6 +768,7 @@ export class HsCompositionsParserService {
       resultLayer = await resultLayer; //createWMTSLayer returns Promise which needs to be resolved first
       setMetadata(resultLayer, lyr_def.metadata);
       setSwipeSide(resultLayer, lyr_def.swipeSide);
+      setIgnorePathZIndex(resultLayer, true);
     }
     return resultLayer;
   }

--- a/projects/hslayers/shared/layer-manager/layer-manager.service.ts
+++ b/projects/hslayers/shared/layer-manager/layer-manager.service.ts
@@ -203,7 +203,7 @@ export class HsLayerManagerService {
       this.applyZIndex(
         e.element as Layer<Source>,
         //z-index of composition layers should be the same as order of layers in composition.
-        //ignoring fodler structure
+        //ignoring folder structure
         !getIgnorePathZIndex(e.element as Layer<Source>),
       );
       if (getShowInLayerManager(e.element) == false) {

--- a/projects/hslayers/shared/layer-manager/layer-manager.service.ts
+++ b/projects/hslayers/shared/layer-manager/layer-manager.service.ts
@@ -45,6 +45,7 @@ import {
   getFromBaseComposition,
   getFromComposition,
   getGreyscale,
+  getIgnorePathZIndex,
   getLegends,
   getName,
   getPath,
@@ -199,7 +200,12 @@ export class HsLayerManagerService {
    */
   private setupMapEventHandlers(map: Map) {
     const onLayerAddition = map.getLayers().on('add', (e) => {
-      this.applyZIndex(e.element as Layer<Source>, true);
+      this.applyZIndex(
+        e.element as Layer<Source>,
+        //z-index of composition layers should be the same as order of layers in composition.
+        //ignoring fodler structure
+        !getIgnorePathZIndex(e.element as Layer<Source>),
+      );
       if (getShowInLayerManager(e.element) == false) {
         return;
       }
@@ -271,7 +277,9 @@ export class HsLayerManagerService {
       abstract: getAbstract(layer),
       layer,
       grayed:
-        !this.hsLayerManagerVisibilityService.isLayerInResolutionInterval(layer),
+        !this.hsLayerManagerVisibilityService.isLayerInResolutionInterval(
+          layer,
+        ),
       visible: layer.getVisible(),
       showInLayerManager,
       uid: this.hsUtilsService.generateUuid(),
@@ -451,24 +459,20 @@ export class HsLayerManagerService {
     let curfolder = this.data.folders;
     const zIndex = lyr.getZIndex();
     for (let i = 0; i < parts.length; i++) {
-      let found = null;
-      for (const folder of curfolder.sub_folders) {
-        if (folder.name == parts[i]) {
-          found = folder;
-        }
-      }
-      if (found === null) {
+      const found = curfolder.sub_folders.find(
+        (folder) => folder.name === parts[i],
+      );
+      if (!found) {
+        const hsl_path = `${curfolder.hsl_path}${curfolder.hsl_path !== '' ? '/' : ''}${parts[i]}`;
+        const coded_path = `${curfolder.coded_path}${curfolder.sub_folders.length}-`;
         //TODO: Need to describe how hsl_path works here
         const new_folder = {
           sub_folders: [],
           indent: i,
           layers: [],
           name: parts[i],
-          hsl_path:
-            curfolder.hsl_path +
-            (curfolder.hsl_path != '' ? '/' : '') +
-            parts[i],
-          coded_path: curfolder.coded_path + curfolder.sub_folders.length + '-',
+          hsl_path,
+          coded_path,
           visible: true,
           zIndex: zIndex,
         };


### PR DESCRIPTION
## Description

- fix zindex assignment of composition layers -> should match the composition layer order and not be influenced by path's max zindex
- sort layers in folder based on hsConfig.reverseLayerList

## Related issues or pull requests

fixes #4679

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
