### PR TITLE
Align style of HSLayers/OpenLayers/Cesium buttons

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -637,7 +637,8 @@
             ],
             "styles": [
               "node_modules/cesium/Build/Cesium/Widgets/widgets.css",
-              "projects/hslayers/css/hslayers-bootstrap.scss"
+              "projects/hslayers/css/hslayers-bootstrap.scss",
+              "projects/hslayers-cesium/css/hslayers-cesium.scss"
             ],
             "scripts": [],
             "customWebpackConfig": {

--- a/projects/cesium-test-app/src/app/app.component.ts
+++ b/projects/cesium-test-app/src/app/app.component.ts
@@ -150,6 +150,9 @@ export class AppComponent implements OnInit {
       opacity: 1,
     });
     this.hsConfig.update({
+      componentsEnabled: {
+        basemapGallery: true,
+      },
       datasources: [
         {
           title: 'Layman',

--- a/projects/hslayers-cesium/css/hslayers-cesium.scss
+++ b/projects/hslayers-cesium/css/hslayers-cesium.scss
@@ -5,7 +5,9 @@ $bs-btn-border-color: transparent;
 
 .hs-cesium-container .cesium-viewer-toolbar {
     position: absolute;
-    display: block;
+    display: flex;
+    gap: 0.25rem;
+    margin-right: 0.25em;
     top: 0.7em;
     right: calc(15px + 1rem + 1rem + 2px);
 }

--- a/projects/hslayers-cesium/css/hslayers-cesium.scss
+++ b/projects/hslayers-cesium/css/hslayers-cesium.scss
@@ -1,0 +1,27 @@
+$bs-btn-bg: white;
+$bs-btn-color: #6c757d;
+$bs-border-radius: 0.375rem;
+$bs-btn-border-color: transparent;
+
+.hs-cesium-container .cesium-viewer-toolbar {
+    position: absolute;
+    display: block;
+    top: 0.7em;
+    right: calc(15px + 1rem + 1rem + 2px);
+}
+
+.hs-cesium-container .cesium-button {
+    opacity: 0.9;
+    color: $bs-btn-color;
+    fill: $bs-btn-color;
+    background-color: $bs-btn-bg;
+    border-radius: $bs-border-radius;
+    border-color: $bs-btn-border-color;
+    box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+}
+
+.hs-cesium-container .cesium-button:hover {
+    background-color: $bs-btn-color;
+    color: $bs-btn-bg;
+    fill: $bs-btn-bg;
+}

--- a/projects/hslayers-cesium/src/hscesium.component.scss
+++ b/projects/hslayers-cesium/src/hscesium.component.scss
@@ -1,0 +1,14 @@
+.hs-cesium-container {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    margin-right: 0;
+}
+
+
+

--- a/projects/hslayers-cesium/src/hscesium.component.ts
+++ b/projects/hslayers-cesium/src/hscesium.component.ts
@@ -15,19 +15,7 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 @Component({
   selector: 'hs-cesium',
   templateUrl: './hscesium.component.html',
-  styles: `
-    .hs-cesium-container {
-      height: 100%;
-      margin: 0;
-      padding: 0;
-      overflow: hidden;
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 100%;
-      margin-right: 0;
-    }
-  `,
+  styleUrl: './hscesium.component.scss',
 })
 export class HslayersCesiumComponent implements AfterViewInit {
   app = 'default';

--- a/projects/hslayers/components/layer-manager/gallery/layer-manager-gallery.component.scss
+++ b/projects/hslayers/components/layer-manager/gallery/layer-manager-gallery.component.scss
@@ -108,10 +108,15 @@
   background-color: var(--ol-background-color);
   color: var(--ol-subtle-foreground-color);
   box-shadow: rgb(0 0 0 / 24%) 0px 3px 8px;
+  height: 32px;
 
   &:hover {
     background-color: $secondary !important;
     color: var(--ol-background-color) !important;
+  }
+
+  i {
+    vertical-align: bottom;
   }
 }
 


### PR DESCRIPTION
## Description
Prevent clash of basemapGallery and Cesium buttons. Unify styling of Cesium buttons and HSL/OL buttons.
![image](https://github.com/hslayers/hslayers-ng/assets/5598693/78193f8c-0e4d-45f6-b7ae-dd3207ae34d9)

Solution is not perfect, yet better than now.
![image](https://github.com/hslayers/hslayers-ng/assets/5598693/991af440-eee5-4824-bd9b-3e6164fccfa6)


## Related issues or pull requests

none

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
