### PR TITLE
Sensor units and sensors filtering

### DIFF
--- a/projects/hslayers-sensors/src/components/sensors/partials/sensors.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/sensors.component.html
@@ -1,5 +1,6 @@
 <div class="card panel-default hs-main-panel" *ngIf="isVisible$ | async" [ngClass]="panelWidthClass">
-    <hs-panel-header *ngIf="!hsSensorsService.unitInUrl" name="sensors" [panelTabs]="'SENSORS'"></hs-panel-header>
+    <hs-panel-header *ngIf="!hsSensorsService.unitInUrl && !hsSensorsService.mapServiceDisabled" name="sensors"
+        [panelTabs]="'SENSORS'"></hs-panel-header>
     <div class="card-body">
         <p [hidden]="hsSensorsService.unitInUrl"> <input type="text" class="form-control"
                 [placeholder]="'COMMON.filter' | translateHs " [(ngModel)]="query.description"></p>

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
@@ -10,17 +10,17 @@
                 <button type="button" class="btn-close" (click)="close()" data-dismiss="modal"
                     [attr.aria-label]="'COMMON.close' | translateHs "></button>
             </div>
-            <div class="modal-body" style="max-height: 300px; overflow-y: auto">
+            <div class="modal-body py-0" style="max-height: 300px; overflow-y: auto">
                 <div class="container-fluid">
                     <div class="row">
                         <div class="col-12 position-relative">
                             @if(hsSensorsUnitDialogService.loading | async ){
-                            <div style="z-index: 10;background: white;font-size: 1.5rem;"
+                            <div style="z-index: 10;background: white;font-size: 1.5rem; width:calc(100% - 1rem)"
                                 class="fadein align-items-center d-flex flex-column-reverse h-100 justify-content-center position-absolute w-100">
                                 <span class="ms-2 hs-loader hs-loader-dark"></span>
                             </div>
                             }
-                            <div class="hs-chartplace" style="min-width: 400px; min-height: 50px; max-width: 65vw;">
+                            <div class="hs-chartplace" style="min-height: 50px; max-width: 65vw;">
                             </div>
                         </div>
                     </div>
@@ -50,7 +50,7 @@
                     <div class="m-1 d-flex align-items-center">
                         <div class="btn-group" role="group">
                             <!-- TODO: Remove function call from template -->
-                            <button type="button" class="btn btn-"
+                            <button type="button" class="btn btn-sm"
                                 [ngClass]="{'btn-primary': getCurrentInterval() === interval}"
                                 (click)="timeButtonClicked(interval)" *ngFor="let interval of getIntervals()"
                                 [attr.aria-label]="'SENSORS.oneHour' | translateHs ">
@@ -65,7 +65,7 @@
                                 <input type="text" style="width: 6em;" ngbDatepicker
                                     [placeholder]="'COMMON.from' | translateHs" #d="ngbDatepicker"
                                     [(ngModel)]="customInterval.fromTime" (dateSelect)="customIntervalChanged()" />
-                                <button class="btn btn-outline-secondary" (click)="d.toggle()" type="button"><i
+                                <button class="btn btn-sm  btn-outline-secondary" (click)="d.toggle()" type="button"><i
                                         class="icon-calendarthree"></i></button>
                             </div>
                         </div>
@@ -74,7 +74,7 @@
                                 <input type="text" style="width: 6em;" ngbDatepicker
                                     [placeholder]="'COMMON.until' | translateHs" #d2="ngbDatepicker"
                                     [(ngModel)]="customInterval.toTime" (dateSelect)="customIntervalChanged()" />
-                                <button class="btn btn-outline-secondary" (click)="d2.toggle()" type="button"><i
+                                <button class="btn btn-sm btn-outline-secondary" (click)="d2.toggle()" type="button"><i
                                         class="icon-calendarthree"></i></button>
                             </div>
                         </div>

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
@@ -13,7 +13,13 @@
             <div class="modal-body" style="max-height: 300px; overflow-y: auto">
                 <div class="container-fluid">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 position-relative">
+                            @if(hsSensorsUnitDialogService.loading | async ){
+                            <div style="z-index: 10;background: white;font-size: 1.5rem;"
+                                class="fadein align-items-center d-flex flex-column-reverse h-100 justify-content-center position-absolute w-100">
+                                <span class="ms-2 hs-loader hs-loader-dark"></span>
+                            </div>
+                            }
                             <div class="hs-chartplace" style="min-width: 400px; min-height: 50px; max-width: 65vw;">
                             </div>
                         </div>

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
@@ -48,7 +48,7 @@
                                 [ngClass]="{'btn-primary': getCurrentInterval() === interval}"
                                 (click)="timeButtonClicked(interval)" *ngFor="let interval of getIntervals()"
                                 [attr.aria-label]="'SENSORS.oneHour' | translateHs ">
-                                {{interval.name | translateHs : {module: 'SENSORS.SENSORNAMES'} }}
+                                {{interval.name | translateHs : {module: 'SENSORS'} }}
                                 &emsp;<span class="hs-loader" [hidden]="!interval.loading"></span></button>
                         </div>
                     </div>

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-dialog.component.html
@@ -47,8 +47,9 @@
                             <button type="button" class="btn btn-"
                                 [ngClass]="{'btn-primary': getCurrentInterval() === interval}"
                                 (click)="timeButtonClicked(interval)" *ngFor="let interval of getIntervals()"
-                                [attr.aria-label]="'SENSORS.oneHour' | translateHs ">{{getTranslation(interval.name)}}&emsp;<span
-                                    class="hs-loader" [hidden]="!interval.loading"></span></button>
+                                [attr.aria-label]="'SENSORS.oneHour' | translateHs ">
+                                {{interval.name | translateHs : {module: 'SENSORS.SENSORNAMES'} }}
+                                &emsp;<span class="hs-loader" [hidden]="!interval.loading"></span></button>
                         </div>
                     </div>
                     <div class="divider" style="border-left: 1px solid lightgray;"></div>

--- a/projects/hslayers-sensors/src/components/sensors/partials/unit-list-item.component.html
+++ b/projects/hslayers-sensors/src/components/sensors/partials/unit-list-item.component.html
@@ -3,8 +3,8 @@
     <ul class="list-group" [hidden]="!(expanded || unit.expanded)">
         <div *ngFor="let sensorType of unit.sensorTypes" class="list-group-item p-1">
             <a (click)="sensorType.expanded = !sensorType.expanded" class="hs-sensor-type"
-                style="line-height: 2em;">{{getTranslation(sensorType.name,
-                'SENSORNAMES')}}</a><!-- TODO: Remove function call from template -->
+                style="line-height: 2em;">{{sensorType.name | translateHs : {module: 'SENSORS.SENSORNAMES'} }}
+            </a>
             <ul class="list-group" [hidden]="!sensorType.expanded">
                 <li *ngFor="let sensor of sensorType.sensors" class="list-group-item p-1">
                     <div class="d-flex ">
@@ -14,10 +14,11 @@
                         </div>
                         <div class="align-items-center p-0 flex-grow-1 hs-lm-item-title">
                             <a *ngIf="viewMode === 'sensornames'" class="hs-sensor" (click)="sensorClicked(sensor)">
-                                <b>{{sensor.sensor_name_translated}}</b></a>
+                                <b>{{sensor.sensor_name | translateHs : {module: 'SENSORS.SENSORNAMES'} }}</b></a>
 
                             <a *ngIf="viewMode === 'sensors'" class="hs-sensor" (click)="sensorClicked(sensor)">
-                                <b>{{sensor.sensor_name_translated}}</b><span class="ms-1">{{'SENSORS.measure' |
+                                <b>{{sensor.sensor_name | translateHs : {module: 'SENSORS.SENSORNAMES'} }}</b><span
+                                    class="ms-1">{{'SENSORS.measure' |
                                     translateHs }}</span> {{sensor.phenomenon_name}}</a>
                             <a *ngIf="viewMode === 'phenomena'" class="hs-sensor" (click)="sensorClicked(sensor)">
                                 {{sensor.phenomenon_name_translated}}</a>

--- a/projects/hslayers-sensors/src/components/sensors/sensor-unit.class.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensor-unit.class.ts
@@ -1,10 +1,19 @@
-export class HsSensorUnit {
-  sensorTypes: any;
-  sensors: any;
-  description: string;
-  expanded: boolean;
-  unit_id: any;
-  unit_position: any;
-  feature: any;
-  constructor() {}
-}
+import {Feature} from 'ol';
+import {Geometry} from 'ol/geom';
+import {SenslogResponse} from './types/senslog-response.type';
+import {SenslogSensor} from './types/senslog-sensor.type';
+
+export type SensorTypes = {
+  name: string;
+  expanded?: boolean;
+  sensors?: SenslogSensor[];
+};
+
+/**
+ * expanded - Wether the list of sensors for this unit is visible or not
+ */
+export type HsSensorUnit = SenslogResponse & {
+  expanded?: boolean;
+  sensorTypes?: SensorTypes[];
+  feature?: Feature<Geometry>;
+};

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
@@ -22,6 +22,21 @@ import {LangChangeEvent} from '@ngx-translate/core';
 @Component({
   selector: 'hs-sensor-unit',
   templateUrl: './partials/unit-dialog.component.html',
+  styles: `
+    @keyframes fadein {
+      0% {
+        opacity: 0;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+    .fadein {
+      animation: fadein 1s ease-out;
+      animation-fill-mode: forwards;
+    }
+  `,
 })
 export class HsSensorsUnitDialogComponent
   implements HsDialogComponent, OnInit, OnDestroy {
@@ -38,11 +53,13 @@ export class HsSensorsUnitDialogComponent
   constructor(
     private hsLayoutService: HsLayoutService,
     private hsDialogContainerService: HsDialogContainerService,
-    private hsSensorsUnitDialogService: HsSensorsUnitDialogService,
+    public hsSensorsUnitDialogService: HsSensorsUnitDialogService,
     private hsLanguageService: HsLanguageService,
     private cdr: ChangeDetectorRef,
     public elementRef: ElementRef,
-  ) {}
+  ) {
+    this.hsSensorsUnitDialogService.dialogElement = this.elementRef;
+  }
 
   ngOnInit(): void {
     this.hsSensorsUnitDialogService.unitDialogVisible = true;
@@ -100,9 +117,10 @@ export class HsSensorsUnitDialogComponent
       );
     });
     Promise.all(promises).then((_) => {
-      this.hsSensorsUnitDialogService.createChart(
+      this.hsSensorsUnitDialogService.createChart$.next([
         this.hsSensorsUnitDialogService.unit,
-      );
+        false,
+      ]);
     });
   }
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
@@ -117,10 +117,9 @@ export class HsSensorsUnitDialogComponent
       );
     });
     Promise.all(promises).then((_) => {
-      this.hsSensorsUnitDialogService.createChart$.next([
+      this.hsSensorsUnitDialogService.createChart$.next(
         this.hsSensorsUnitDialogService.unit,
-        false,
-      ]);
+      );
     });
   }
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
@@ -1,14 +1,23 @@
-import {Component, ElementRef, OnDestroy, OnInit, ViewRef} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewRef,
+} from '@angular/core';
+import {Subject, combineLatest, takeUntil} from 'rxjs';
 
 import {
   HsDialogComponent,
   HsDialogContainerService,
 } from 'hslayers-ng/common/dialogs';
+import {HsLanguageService} from 'hslayers-ng/services/language';
 import {HsLayoutService} from 'hslayers-ng/services/layout';
 
 import {Aggregates, HsSensorsUnitDialogService} from './unit-dialog.service';
 import {CustomInterval, Interval} from './types/interval.type';
-import {Subject, combineLatest, takeUntil} from 'rxjs';
+import {LangChangeEvent} from '@ngx-translate/core';
 
 @Component({
   selector: 'hs-sensor-unit',
@@ -30,6 +39,8 @@ export class HsSensorsUnitDialogComponent
     private hsLayoutService: HsLayoutService,
     private hsDialogContainerService: HsDialogContainerService,
     private hsSensorsUnitDialogService: HsSensorsUnitDialogService,
+    private hsLanguageService: HsLanguageService,
+    private cdr: ChangeDetectorRef,
     public elementRef: ElementRef,
   ) {}
 
@@ -47,6 +58,11 @@ export class HsSensorsUnitDialogComponent
       .subscribe(([panelSpace, sidebar]) => {
         this.calculateDialogStyle(panelSpace, sidebar == 'bottom');
       });
+
+    const translator = this.hsLanguageService.getTranslator();
+    translator.onLangChange.subscribe((event: LangChangeEvent) => {
+      this.cdr.detectChanges();
+    });
   }
 
   /**
@@ -68,14 +84,6 @@ export class HsSensorsUnitDialogComponent
    */
   getCurrentInterval() {
     return this.hsSensorsUnitDialogService.currentInterval;
-  }
-
-  /**
-   * Get translations to local
-   * @param text - Text to translate
-   */
-  getTranslation(text: string): string {
-    return this.hsSensorsUnitDialogService.translate(text, 'SENSORNAMES');
   }
 
   /**

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
@@ -6,6 +6,7 @@ import {HsSensorUnit} from './sensor-unit.class';
 import {HsSensorsService} from './sensors.service';
 import {HsSensorsUnitDialogComponent} from './sensors-unit-dialog.component';
 import {HsSensorsUnitDialogService} from './unit-dialog.service';
+import {SenslogSensor} from './types/senslog-sensor.type';
 
 @Component({
   selector: 'hs-sensor-unit-list-item',
@@ -35,27 +36,17 @@ export class HsSensorsUnitListItemComponent {
    * When sensor is clicked, create a dialog window for
    * displaying charts or reopen already existing one.
    */
-  sensorClicked(sensor): void {
+  sensorClicked(sensor: SenslogSensor): void {
     this.hsSensorsUnitDialogService.resetAggregations();
     this.hsSensorsUnitDialogService.unit = [this.unit];
     this.generateDialog();
   }
-
-  /**
-   * Get data translation to local
-   * @param text - Text to translate
-   * @param module - Locales json object where to look for the translation
-   */
-  getTranslation(text: string, module?: string): string {
-    return this.hsSensorsUnitDialogService.translate(text, module);
-  }
-
   /**
    * @param sensor - Clicked to be toggled
    * When sensor is toggled, create a dialog window for
    * displaying charts or reopen already existing one.
    */
-  sensorToggleSelected(sensor): void {
+  sensorToggleSelected(sensor: SenslogSensor): void {
     sensor.checked = !sensor.checked;
     if (this.hsSensorsUnitDialogService.comparisonAllowed) {
       //If the opened sensor belongs to unit that's not included add it

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
@@ -41,6 +41,7 @@ export class HsSensorsUnitListItemComponent {
     this.hsSensorsUnitDialogService.unit = [this.unit];
     this.generateDialog();
   }
+
   /**
    * @param sensor - Clicked to be toggled
    * When sensor is toggled, create a dialog window for
@@ -74,11 +75,12 @@ export class HsSensorsUnitListItemComponent {
     if (!this.hsSensorsUnitDialogService.unitDialogVisible) {
       this.hsDialogContainerService.create(HsSensorsUnitDialogComponent, {});
     } else {
-      this.hsSensorsUnitDialogService.createChart(
+      this.hsSensorsUnitDialogService.createChart$.next([
         single
           ? this.hsSensorsUnitDialogService.unit[0]
           : this.hsSensorsUnitDialogService.unit,
-      );
+        this.hsSensorsUnitDialogService.sensorsSelected.size === 0,
+      ]);
     }
   }
 }

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
@@ -75,12 +75,11 @@ export class HsSensorsUnitListItemComponent {
     if (!this.hsSensorsUnitDialogService.unitDialogVisible) {
       this.hsDialogContainerService.create(HsSensorsUnitDialogComponent, {});
     } else {
-      this.hsSensorsUnitDialogService.createChart$.next([
+      this.hsSensorsUnitDialogService.createChart$.next(
         single
           ? this.hsSensorsUnitDialogService.unit[0]
           : this.hsSensorsUnitDialogService.unit,
-        this.hsSensorsUnitDialogService.sensorsSelected.size === 0,
-      ]);
+      );
     }
   }
 }

--- a/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
@@ -41,9 +41,10 @@ export class HsSensorsComponent extends HsPanelBaseComponent implements OnInit {
           (u) => u.unit_id != this.hsSensorsUnitDialogService.unit[0].unit_id,
         )
         .forEach((u) => this.hsSensorsService.deselectUnit(u));
-      this.hsSensorsUnitDialogService.createChart(
+      this.hsSensorsUnitDialogService.createChart$.next([
         this.hsSensorsUnitDialogService.unit,
-      );
+        false,
+      ]);
     }
   }
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
@@ -41,10 +41,9 @@ export class HsSensorsComponent extends HsPanelBaseComponent implements OnInit {
           (u) => u.unit_id != this.hsSensorsUnitDialogService.unit[0].unit_id,
         )
         .forEach((u) => this.hsSensorsService.deselectUnit(u));
-      this.hsSensorsUnitDialogService.createChart$.next([
+      this.hsSensorsUnitDialogService.createChart$.next(
         this.hsSensorsUnitDialogService.unit,
-        false,
-      ]);
+      );
     }
   }
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
@@ -50,7 +50,7 @@ export class HsSensorsComponent extends HsPanelBaseComponent implements OnInit {
   /**
    * Set data view mode
    */
-  setViewMode(viewMode): void {
+  setViewMode(viewMode: string): void {
     this.viewMode = viewMode;
   }
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -182,9 +182,10 @@ export class HsSensorsService {
       ) {
         this.deselectUnit(unit);
         if (this.hsSensorsUnitDialogService.unit.length > 0) {
-          this.hsSensorsUnitDialogService.createChart(
+          this.hsSensorsUnitDialogService.createChart$.next([
             this.hsSensorsUnitDialogService.unit,
-          );
+            false,
+          ]);
         } else {
           this.closeSensorDialog();
         }
@@ -235,18 +236,19 @@ export class HsSensorsService {
       };
     }
     //Get observations for selected unit
-    this.hsSensorsUnitDialogService
-      .getObservationHistory(
-        unit,
-        this.hsSensorsUnitDialogService.currentInterval,
-      )
-      .then((_) =>
-        this.hsSensorsUnitDialogService.createChart(
-          this.hsSensorsUnitDialogService.comparisonAllowed
-            ? this.hsSensorsUnitDialogService.unit
-            : unit,
-        ),
-      );
+    this.hsSensorsUnitDialogService.getObservationHistory(
+      unit,
+      this.hsSensorsUnitDialogService.currentInterval,
+    );
+    /**
+     * Create EMPTY chart placeholder. No sensors are selected
+     */
+    this.hsSensorsUnitDialogService.createChart$.next([
+      this.hsSensorsUnitDialogService.comparisonAllowed
+        ? this.hsSensorsUnitDialogService.unit
+        : unit,
+      true,
+    ]);
 
     unit.feature?.set('selected', true);
     this.hsMapService

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -1,13 +1,11 @@
 import dayjs from 'dayjs';
 import {HttpClient} from '@angular/common/http';
 import {Inject, Injectable, Optional, inject} from '@angular/core';
-import {LangChangeEvent} from '@ngx-translate/core';
 import {Subject, concatMap, map, take} from 'rxjs';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {HsDialogContainerService} from 'hslayers-ng/common/dialogs';
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
-import {HsLanguageService} from 'hslayers-ng/services/language';
 import {HsLayoutService} from 'hslayers-ng/services/layout';
 import {HsLogService} from 'hslayers-ng/services/log';
 import {HsUtilsService} from 'hslayers-ng/services/utils';
@@ -53,7 +51,6 @@ export class HsSensorsService {
     private http: HttpClient,
     private hsEventBusService: HsEventBusService,
     private hsSensorsUnitDialogService: HsSensorsUnitDialogService,
-    private hsLanguageService: HsLanguageService,
     private hsLog: HsLogService,
     @Optional() @Inject('MAPSERVICE_DISABLED') mapServiceDisabled: boolean,
     @Optional() @Inject('HsQueryVectorService') hsQueryVectorService,
@@ -108,32 +105,6 @@ export class HsSensorsService {
         );
       },
     );
-
-    const translator = this.hsLanguageService.getTranslator();
-    translator.onLangChange.subscribe((event: LangChangeEvent) => {
-      this.units.forEach((unit) => {
-        this.setSensorTranslations(unit);
-      });
-    });
-  }
-
-  /**
-   * Update senor name and phenomenon translations
-   * @param unit - Sensor unit
-   */
-  private setSensorTranslations(unit) {
-    for (const sensor of unit.sensors) {
-      sensor.sensor_name_translated =
-        this.hsLanguageService.getTranslationIgnoreNonExisting(
-          'SENSORS.SENSORNAMES',
-          sensor.sensor_name,
-        );
-      sensor.phenomenon_name_translated =
-        this.hsLanguageService.getTranslationIgnoreNonExisting(
-          'SENSORS.PHENOMENON',
-          sensor.phenomenon_name,
-        );
-    }
   }
 
   /**
@@ -391,7 +362,6 @@ export class HsSensorsService {
               return {name: s.sensor_type};
             });
 
-            this.setSensorTranslations(unit);
             unit.sensorTypes = this.hsUtilsService.removeDuplicates(
               unit.sensorTypes,
               'name',
@@ -474,11 +444,8 @@ export class HsSensorsService {
                   .getFeatures()
                   .find((f) => getUnitId(f) == unit.unit_id);
                 if (feature) {
-                  feature.set(sensor.sensor_name_translated, reading.value);
-                  feature.set(
-                    sensor.sensor_name_translated + ' at ',
-                    reading.timestamp,
-                  );
+                  feature.set(sensor.sensor_name, reading.value);
+                  feature.set(sensor.sensor_name + ' at ', reading.timestamp);
                 } else {
                   this.hsLog.log(`No feature exists for unit ${unit.unit_id}`);
                 }

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -400,7 +400,8 @@ export class HsSensorsService {
               sensorType.sensors = unit.sensors.filter(
                 (s) => s.sensor_type == sensorType.name,
               );
-              sensorType.expanded = !!this.unitInUrl;
+              sensorType.expanded =
+                unit.sensorTypes.length > 7 ? !this.unitInUrl : false;
             });
           });
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -24,6 +24,8 @@ import {HsSensorUnit} from './sensor-unit.class';
 import {HsSensorsUnitDialogComponent} from './sensors-unit-dialog.component';
 import {HsSensorsUnitDialogService} from './unit-dialog.service';
 import {SensLogEndpoint} from './types/senslog-endpoint.type';
+import {SenslogResponse} from './types/senslog-response.type';
+import {SenslogSensor} from './types/senslog-sensor.type';
 import {sensorUnitStyle} from './partials/sensor-unit';
 
 const VISUALIZED_ATTR = 'Visualized attribute';
@@ -31,7 +33,7 @@ const VISUALIZED_ATTR = 'Visualized attribute';
   providedIn: 'root',
 })
 export class HsSensorsService {
-  units: any = [];
+  units: HsSensorUnit[] = [];
   layer = null;
   endpoint: SensLogEndpoint;
   visualizedAttribute = new Subject<{attribute: string}>();
@@ -110,7 +112,7 @@ export class HsSensorsService {
   /**
    * Deselect sensor unit and refresh sensors state
    */
-  deselectUnit(unit) {
+  deselectUnit(unit: HsSensorUnit) {
     this.hsSensorsUnitDialogService.unit =
       this.hsSensorsUnitDialogService.unit.filter(
         (u) => u.unit_id !== unit.unit_id,
@@ -151,7 +153,7 @@ export class HsSensorsService {
    * Select sensor from available sensors
    * @param sensor - Sensor selected
    */
-  selectSensor(sensor): void {
+  selectSensor(sensor: SenslogSensor): void {
     this.hsSensorsUnitDialogService.selectSensor(sensor);
     for (const feature of this.layer.getSource().getFeatures()) {
       feature.set(VISUALIZED_ATTR, sensor.sensor_name);
@@ -308,10 +310,30 @@ export class HsSensorsService {
         },
       })
       .pipe(
-        map((response: []) => {
-          return this.unitInUrl
-            ? response.filter((s) => s['unit_id'] == this.unitInUrl)
-            : response;
+        map((response: SenslogResponse[]) => {
+          const filter = this.hsConfig.senslog.filter;
+
+          return this.unitInUrl || filter
+            ? response.filter((s) => {
+                // If there is an unit_id GET param, give it a priority and get only the selected unit
+                if (this.unitInUrl) {
+                  return s['unit_id'] == this.unitInUrl;
+                }
+
+                // If config filter exists, take only whitelisted units
+                if (filter) {
+                  const unitFilter = filter[s['unit_id']];
+                  const defaultFilter = filter.default;
+
+                  // Include unit if specific unit filter is defined or if default filter includes sensors for all units
+                  return (
+                    unitFilter !== undefined || defaultFilter !== undefined
+                  );
+                }
+
+                return false;
+              })
+            : response; // Return the whole response otherwise
         }),
         // Wait for the mapEventHandlersSet to make sure this.layer exists
         concatMap((filteredResponse) =>
@@ -348,16 +370,17 @@ export class HsSensorsService {
           }
           this.units.forEach((unit: HsSensorUnit) => {
             unit.sensors = unit.sensors
-              .filter((s) => !(s['phenomenon_name'] as string).includes('TODO'))
+              .filter((s) => this.sensorAllowed(s, unit))
               .sort((a, b) => {
-                return b.sensor_id - a.sensor_id;
+                return (b.sensor_id as number) - (a.sensor_id as number);
               });
 
             unit.sensorTypes = unit.sensors.map((s) => {
+              // Changing the type of sensor_id from number to string, not ideal
               s.sensor_id = `${unit.unit_id}_${s.sensor_id}`;
-              this.hsSensorsUnitDialogService.sensorById[s.sensor_id] = s;
               s.unit_id = unit.unit_id;
               s.unit_description = unit.description;
+              this.hsSensorsUnitDialogService.sensorById[s.sensor_id] = s;
 
               return {name: s.sensor_type};
             });
@@ -370,8 +393,9 @@ export class HsSensorsService {
               sensorType.sensors = unit.sensors.filter(
                 (s) => s.sensor_type == sensorType.name,
               );
-              sensorType.expanded =
-                unit.sensorTypes.length > 7 ? !this.unitInUrl : false;
+              sensorType.expanded = this.unitInUrl
+                ? unit.sensorTypes.length <= 7
+                : false;
             });
           });
 
@@ -388,15 +412,33 @@ export class HsSensorsService {
   }
 
   /**
+   * Determine wether the sensor should be visible or not based on filter
+   */
+  private sensorAllowed(s: SenslogSensor, u: HsSensorUnit): boolean {
+    const filter = this.hsConfig.senslog.filter;
+
+    if (filter) {
+      const sensor_filter = filter[u.unit_id] || filter.default;
+      return (
+        sensor_filter === 'all' ||
+        (Array.isArray(sensor_filter) &&
+          sensor_filter.includes(s.sensor_id as number))
+      );
+    }
+
+    return !(s.phenomenon_name as string).includes('TODO');
+  }
+
+  /**
    * Filter sensors based on the query value
    * @param sensors -
    * @param query -
    */
-  filterquery(sensors, query) {
-    return sensors.filter(
-      (s) =>
+  filterquery(units: HsSensorUnit[], query) {
+    return units.filter(
+      (u) =>
         query.description == '' ||
-        s.description.toLowerCase().indexOf(query.description.toLowerCase()) >
+        u.description.toLowerCase().indexOf(query.description.toLowerCase()) >
           -1,
     );
   }

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -182,10 +182,9 @@ export class HsSensorsService {
       ) {
         this.deselectUnit(unit);
         if (this.hsSensorsUnitDialogService.unit.length > 0) {
-          this.hsSensorsUnitDialogService.createChart$.next([
+          this.hsSensorsUnitDialogService.createChart$.next(
             this.hsSensorsUnitDialogService.unit,
-            false,
-          ]);
+          );
         } else {
           this.closeSensorDialog();
         }
@@ -243,12 +242,11 @@ export class HsSensorsService {
     /**
      * Create EMPTY chart placeholder. No sensors are selected
      */
-    this.hsSensorsUnitDialogService.createChart$.next([
+    this.hsSensorsUnitDialogService.createChart$.next(
       this.hsSensorsUnitDialogService.comparisonAllowed
         ? this.hsSensorsUnitDialogService.unit
         : unit,
-      true,
-    ]);
+    );
 
     unit.feature?.set('selected', true);
     this.hsMapService

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -54,7 +54,9 @@ export class HsSensorsService {
     private hsEventBusService: HsEventBusService,
     private hsSensorsUnitDialogService: HsSensorsUnitDialogService,
     private hsLog: HsLogService,
-    @Optional() @Inject('MAPSERVICE_DISABLED') mapServiceDisabled: boolean,
+    @Optional()
+    @Inject('MAPSERVICE_DISABLED')
+    public mapServiceDisabled: boolean,
     @Optional() @Inject('HsQueryVectorService') hsQueryVectorService,
   ) {
     const urlParams = new URLSearchParams(location.search);

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -210,7 +210,7 @@ export class HsSensorsService {
         u.expanded = false;
         u.sensors.forEach((s) => (s.checked = false));
       });
-      this.hsSensorsUnitDialogService.sensorsSelected.clear();
+      this.hsSensorsUnitDialogService.sensorsSelected.set(new Map());
 
       this.hsSensorsUnitDialogService.unit = [unit];
     }

--- a/projects/hslayers-sensors/src/components/sensors/types/senslog-response.type.ts
+++ b/projects/hslayers-sensors/src/components/sensors/types/senslog-response.type.ts
@@ -1,0 +1,20 @@
+import {SenslogSensor} from './senslog-sensor.type';
+
+/**
+ * @example
+ * asWKT :  "POINT(16.7336889 48.8248517)"
+ * time_stamp: "2024-04-19 13:00:00+02"
+ */
+export type UnitPosition = {
+  asWKT: string;
+  time_stamp: string;
+};
+
+export type SenslogResponse = {
+  description: string;
+  is_mobile: boolean;
+  sensors: SenslogSensor[];
+  unit_id: number;
+  unit_position: UnitPosition;
+  unit_type: string;
+};

--- a/projects/hslayers-sensors/src/components/sensors/types/senslog-sensor.type.ts
+++ b/projects/hslayers-sensors/src/components/sensors/types/senslog-sensor.type.ts
@@ -1,0 +1,12 @@
+export class SenslogSensor {
+  phenomenon_name: string;
+  sensor_id: string | number;
+  sensor_name: string;
+  sensor_type: string;
+  uom: string;
+  unit_id: number;
+  unit_description: string;
+  lastObservationTimestamp?: string;
+  lastObservationValue?: string;
+  checked: boolean;
+}

--- a/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
@@ -56,7 +56,7 @@ export class HsSensorsUnitDialogService {
   timeFormat: 'HH:mm:ss' | 'HH:mm:ssZ';
   useTimeZone = new BehaviorSubject<boolean>(false);
 
-  createChart$ = new Subject<[HsSensorUnit | HsSensorUnit[], boolean]>();
+  createChart$ = new Subject<HsSensorUnit | HsSensorUnit[]>();
   loading = new BehaviorSubject(false);
 
   /**
@@ -82,8 +82,10 @@ export class HsSensorsUnitDialogService {
         tap(() => {
           this.loading.next(true);
         }),
-        switchMap(([unit, empty]) =>
-          empty ? this.createEmtpyChart() : this.createChart(unit),
+        switchMap((unit) =>
+          this.sensorsSelected.size === 0
+            ? this.createEmtpyChart()
+            : this.createChart(unit),
         ),
         debounce((chartData) => {
           return timer(chartData.encoding.text ? 0 : 300);

--- a/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
@@ -252,10 +252,7 @@ export class HsSensorsUnitDialogService {
           .filter((s) => this.sensorsSelected.has(s.sensor_id))
           .map((s) => {
             const time = dayjs(val.time_stamp);
-            s.sensor_name = `${this.translate(
-              this.sensorById[s.sensor_id].sensor_name_translated,
-              'SENSORNAMES',
-            )}_${val.unit_id}`;
+            s.sensor_name = `${this.sensorById[s.sensor_id].sensor_name}_${val.unit_id}`;
             s.time = time.format('DD.MM.YYYY HH:mm');
             s.unit_id = val.unit_id;
             s.time_stamp = time.toDate();
@@ -500,7 +497,7 @@ export class HsSensorsUnitDialogService {
           max: 0,
           avg: 0,
           sensor_id: sensor.sensor_id,
-          sensor_name: sensor.sensor_name_translated,
+          sensor_name: sensor.sensor_name,
         };
         if (observationsForSensor.length === 0) {
           return tmp;

--- a/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
@@ -20,6 +20,7 @@ import {HsUtilsService} from 'hslayers-ng/services/utils';
 
 import {Aggregate} from './types/aggregate.type';
 import {CustomInterval, Interval} from './types/interval.type';
+import {HsLayoutService} from 'hslayers-ng/services/layout';
 import {HsSensorUnit} from './sensor-unit.class';
 import {SensLogEndpoint} from './types/senslog-endpoint.type';
 import {SenslogSensor} from './types/senslog-sensor.type';
@@ -70,6 +71,7 @@ export class HsSensorsUnitDialogService {
     private hsUtilsService: HsUtilsService,
     private hsLogService: HsLogService,
     private hsLanguageService: HsLanguageService,
+    private hsLayoutService: HsLayoutService,
   ) {
     this.currentInterval = this.intervals[2];
     this.useTimeZone.subscribe((value) => {
@@ -351,6 +353,12 @@ export class HsSensorsUnitDialogService {
               ? sensorDesc[0]?.unit_description
               : this.hsLanguageService.getTranslation('SENSORS.sensors'),
             'labelExpr': "split(datum.value, '_')[0]",
+            'orient': this.hsLayoutService.layoutElement.classList.contains(
+              'hs-mobile-view',
+            )
+              ? 'bottom'
+              : 'right',
+            'direction': 'vertical',
           },
           'type': 'nominal',
           'sort': 'sensor_id',

--- a/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
@@ -594,7 +594,6 @@ export class HsSensorsUnitDialogService {
     observations: any,
   ): Aggregate[] {
     // Create a map of sensor IDs to their observations
-    // Create a map of sensor IDs to their observations
     const observationMap = new Map<string, number[]>();
     observations.forEach((obs: {sensor_id: string; value: number}) => {
       if (!observationMap.has(obs.sensor_id)) {
@@ -609,7 +608,7 @@ export class HsSensorsUnitDialogService {
         const observationsForSensor =
           observationMap.get(sensor.sensor_id as string) || [];
         const tmp: Aggregate = {
-          min: 0,
+          min: undefined,
           max: 0,
           avg: 0,
           sensor_id: sensor.sensor_id,
@@ -621,7 +620,7 @@ export class HsSensorsUnitDialogService {
         let sum = 0;
 
         observationsForSensor.forEach((value) => {
-          if (value < tmp.min) {
+          if (value < tmp.min || !tmp.min) {
             tmp.min = value;
           }
           if (value > tmp.max) {

--- a/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
@@ -299,8 +299,6 @@ export class HsSensorsUnitDialogService {
           .map((s) => {
             const time = dayjs(val.time_stamp);
             s.sensor_name = `${this.sensorById[s.sensor_id].sensor_name}_${val.unit_id}`;
-            s.time = time.format('DD.MM.YYYY HH:mm');
-            s.unit_id = val.unit_id;
             s.time_stamp = time.toDate();
             return s;
           }),

--- a/projects/hslayers-sensors/src/public-api.ts
+++ b/projects/hslayers-sensors/src/public-api.ts
@@ -12,3 +12,5 @@ export * from './components/sensors/unit-dialog.service';
 export * from './components/sensors/types/aggregate.type';
 export * from './components/sensors/types/interval.type';
 export * from './components/sensors/types/senslog-endpoint.type';
+export * from './components/sensors/types/senslog-response.type';
+export * from './components/sensors/types/senslog-sensor.type';

--- a/projects/hslayers/config/config.service.ts
+++ b/projects/hslayers/config/config.service.ts
@@ -60,6 +60,27 @@ export class HsConfigObject {
     user_id: number;
     group: string;
     user: string;
+    /**
+     * Whitelist object defining which units and which unit sensors
+     * should be listed. Each key is a `unit_id`, and the value is an array
+     * of `sensor_id`s to be included for that unit.
+     * If the value is `all`, all sensors for that unit will be included.
+     *
+     * Example:
+     * ```
+     * {
+     *   default: [1,2,3],
+     *   1305167: [530040, 560030],
+     *   1405167: 'all'
+     * }
+     *```
+     * The `default` property defines a common set of sensor IDs that should be included for all units,
+     * unless overridden by a specific unit's configuration.
+     */
+    filter?: {
+      default?: number[];
+      [unit_id: number]: number[] | 'all';
+    };
     liteApiPath?: string;
     mapLogApiPath?: string;
     senslog1Path?: string;


### PR DESCRIPTION
## Description

Add possiblity to fitler units and sensors via HsConfig `senslog.filter` object .
You can now either:
- set `default` property with a value of list of `sensor_id`s which would filter all units and show only the sensors listed
-  whitelist each sensor idividually by setting up key - value pair on the config object. Accepted values for this option are either `all` or `string[]` . 

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
