### PR TITLE
Allow to specify custom legend categories

### DIFF
--- a/projects/hslayers/common/layers/hs.source.SparqlJson.ts
+++ b/projects/hslayers/common/layers/hs.source.SparqlJson.ts
@@ -71,7 +71,6 @@ export type SparqlOptions = {
 export class SparqlJson extends Vector {
   category_map = {};
   category_id = 0;
-  legend_categories;
   loadCounter: number;
   occupied_xy: {[coord: string]: boolean} = {};
   //What is it good for?
@@ -224,7 +223,7 @@ export class SparqlJson extends Vector {
         },
     });
     this.loadCounter = 0;
-    this.legend_categories = this.category_map;
+    this.set('legendCategories', this.category_map);
   }
 
   /**
@@ -411,7 +410,7 @@ export class SparqlJson extends Vector {
         0.7,
       );
     }
-    src.legend_categories = categoryMap;
+    src.set('legendCategories', categoryMap);
     for (let i = 0; i < features.length; i++) {
       if (features[i].category_id) {
         features[i].color = this.rainbow(

--- a/projects/hslayers/components/layer-manager/widgets/legend-widget.component.html
+++ b/projects/hslayers/components/layer-manager/widgets/legend-widget.component.html
@@ -3,8 +3,8 @@
     <p style="text-align: center; font-weight: bold">
       {{ "COMMON.legend" | translateHs }}
     </p>
-    <hs-legend-layer-directive [layer]="HsLayerEditorService.legendDescriptor">
-    </hs-legend-layer-directive>
+    <hs-legend-layer [layer]="HsLayerEditorService.legendDescriptor">
+    </hs-legend-layer>
     <hr />
   </div>
 </div>

--- a/projects/hslayers/components/legend/legend-custom-category.type.ts
+++ b/projects/hslayers/components/legend/legend-custom-category.type.ts
@@ -1,0 +1,20 @@
+export type HsCustomLegendCategory = {
+  /**
+   * Unique category name
+   */
+  name: string;
+  /**
+   * rgb(a) or hex encoded color string
+   * (mutually exclusive with path)
+   */
+  color?: string;
+  /**
+   * Path to an icon
+   * (mutually exclusive with color)
+   */
+  path?: string;
+  /**
+   * Optional height of the icon in pixels
+   */
+  height?: number;
+};

--- a/projects/hslayers/components/legend/legend-layer-static/legend-layer-static.component.ts
+++ b/projects/hslayers/components/legend/legend-layer-static/legend-layer-static.component.ts
@@ -1,5 +1,6 @@
 import {Component, Input, OnInit} from '@angular/core';
 
+import {HsLegendDescriptor} from '../legend-descriptor.interface';
 import {HsLegendLayerStaticService} from './legend-layer-static.service';
 import {LayerLegend} from './types/layer-legend.type';
 import {getLegends} from 'hslayers-ng/common/extensions';
@@ -9,7 +10,7 @@ import {getLegends} from 'hslayers-ng/common/extensions';
   templateUrl: './legend-layer-static.component.html',
 })
 export class HsLegendLayerStaticComponent implements OnInit {
-  @Input() layer: any;
+  @Input() layer: HsLegendDescriptor;
   layerLegend: LayerLegend = {};
 
   constructor(private hsLegendLayerStaticService: HsLegendLayerStaticService) {}

--- a/projects/hslayers/components/legend/legend-layer/legend-layer.component.html
+++ b/projects/hslayers/components/legend/legend-layer/legend-layer.component.html
@@ -1,15 +1,41 @@
 <div>
-    <hs-legend-vector-layer *ngIf="layer.type === 'vector' && layer.autoLegend" [svg]="layer.svg">
-    </hs-legend-vector-layer>
-    <div *ngIf="layer.type === 'wms'">
-        <img *ngFor="let sublayer of layer.subLayerLegends" [src]="sublayer"
-            onerror=" this.parentNode.removeChild(this); "
-            onload="if(this.height<6) { this.parentNode.removeChild(this); }">
-    </div>
-    <div *ngIf="layer.type === 'vector'">
-        <p *ngFor="let category of legendCategories"><span
-                [ngStyle]="{'background-color': category.color}">&nbsp;&nbsp;&nbsp;</span>&nbsp;{{category.name}}
-        </p>
-    </div>
-    <hs-legend-layer-static *ngIf="layer.type === 'static'" [layer]="layer"></hs-legend-layer-static>
+  @switch (layer.type) {
+    @case ("static") {
+      <hs-legend-layer-static [layer]="layer"></hs-legend-layer-static>
+    }
+    @case ("wms") {
+      <div>
+        @for (sublayer of layer.subLayerLegends; track $index) {
+          <img
+            [src]="sublayer"
+            onerror="this.parentNode.removeChild(this);"
+            onload="if(this.height<6) {this.parentNode.removeChild(this);}"
+          />
+        }
+      </div>
+    }
+    @case ("vector") {
+      @if (layer.autoLegend) {
+        <hs-legend-vector-layer [svg]="layer.svg"> </hs-legend-vector-layer>
+      }
+      @if (hasLegendCategories()) {
+        <div>
+          @for (category of legendCategories; track category.name) {
+            <p>
+              @if (category.color) {
+                <span [ngStyle]="{ 'background-color': category.color }"
+                  >&nbsp;&nbsp;&nbsp;</span>
+              } @else if (category.path) {
+                <img
+                  [src]="category.path"
+                  [height]="category.height || defaultIconHeight"
+                />
+              }
+              &emsp;{{ category.name }}
+            </p>
+          }
+        </div>
+      }
+    }
+  }
 </div>

--- a/projects/hslayers/components/legend/legend-layer/legend-layer.component.html
+++ b/projects/hslayers/components/legend/legend-layer/legend-layer.component.html
@@ -7,7 +7,7 @@
             onload="if(this.height<6) { this.parentNode.removeChild(this); }">
     </div>
     <div *ngIf="layer.type === 'vector'">
-        <p *ngFor="let category of layer.lyr.getSource()?.legend_categories"><!-- TODO: Remove function call from template --><span
+        <p *ngFor="let category of legendCategories"><span
                 [ngStyle]="{'background-color': category.color}">&nbsp;&nbsp;&nbsp;</span>&nbsp;{{category.name}}
         </p>
     </div>

--- a/projects/hslayers/components/legend/legend-layer/legend-layer.component.ts
+++ b/projects/hslayers/components/legend/legend-layer/legend-layer.component.ts
@@ -1,7 +1,6 @@
-import {Component, Input, OnDestroy} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {SafeHtml} from '@angular/platform-browser';
-
-import {Subject, takeUntil} from 'rxjs';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {HsLegendService} from '../legend.service';
 import {HsStylerService} from 'hslayers-ng/services/styler';
@@ -11,27 +10,23 @@ import {HsUtilsService} from 'hslayers-ng/services/utils';
   selector: 'hs-legend-layer-directive',
   templateUrl: './legend-layer.component.html',
 })
-export class HsLegendLayerComponent implements OnDestroy {
+export class HsLegendLayerComponent {
   @Input() layer: any;
 
-  svg: SafeHtml;
-  private end = new Subject<void>();
+  //svg: SafeHtml;
+  legendCategories;
   constructor(
     public hsUtilsService: HsUtilsService,
     public hsLegendService: HsLegendService,
     public hsStylerService: HsStylerService,
   ) {
     this.hsStylerService.onSet
-      .pipe(takeUntil(this.end))
+      .pipe(takeUntilDestroyed())
       .subscribe(async (layer) => {
         if (this.layer.lyr == layer) {
           this.layer.svg = await this.hsLegendService.setSvg(layer);
         }
       });
-  }
-
-  ngOnDestroy(): void {
-    this.end.next();
-    this.end.complete();
+    this.legendCategories = this.layer.lyr.getSource()?.get('legendCategories');
   }
 }

--- a/projects/hslayers/components/legend/legend-layer/legend-layer.component.ts
+++ b/projects/hslayers/components/legend/legend-layer/legend-layer.component.ts
@@ -1,20 +1,27 @@
-import {Component, Input} from '@angular/core';
-import {SafeHtml} from '@angular/platform-browser';
+import {Component, Input, OnInit, signal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
+import {HsCustomLegendCategory} from '../legend-custom-category.type';
+import {HsLegendDescriptor} from '../legend-descriptor.interface';
 import {HsLegendService} from '../legend.service';
 import {HsStylerService} from 'hslayers-ng/services/styler';
 import {HsUtilsService} from 'hslayers-ng/services/utils';
 
 @Component({
-  selector: 'hs-legend-layer-directive',
+  selector: 'hs-legend-layer',
   templateUrl: './legend-layer.component.html',
 })
-export class HsLegendLayerComponent {
-  @Input() layer: any;
+export class HsLegendLayerComponent implements OnInit {
+  @Input() layer: HsLegendDescriptor;
 
-  //svg: SafeHtml;
-  legendCategories;
+  legendCategories: HsCustomLegendCategory[];
+  hasLegendCategories = signal(false);
+  /**
+   * default icon height in pixels
+   * @default 32
+   */
+  defaultIconHeight = 32;
+
   constructor(
     public hsUtilsService: HsUtilsService,
     public hsLegendService: HsLegendService,
@@ -27,6 +34,9 @@ export class HsLegendLayerComponent {
           this.layer.svg = await this.hsLegendService.setSvg(layer);
         }
       });
+  }
+  ngOnInit(): void {
     this.legendCategories = this.layer.lyr.getSource()?.get('legendCategories');
+    this.hasLegendCategories.set(this.legendCategories?.length > 0);
   }
 }

--- a/projects/hslayers/components/legend/legend.component.html
+++ b/projects/hslayers/components/legend/legend.component.html
@@ -8,13 +8,12 @@
             <p style="text-align: center">{{'LEGEND.noLegendExists' | translateHs }}</p>
         </span>
         <ul class="list-group">
-            <li *ngFor="let layer of filterDescriptors() | filter:legendFilter" class="list-group-item"
+            <li *ngFor="let layer of this.layerDescriptors | filter:legendFilter" class="list-group-item"
                 [hidden]="!hsLegendService.legendValid(layer)"><!-- TODO: Remove function call from template -->
                 <div>
                     {{layer.title | translateHs : {module: 'LAYERS'} }}
-                    <hs-legend-layer-directive [layer]="layer"></hs-legend-layer-directive>
+                    <hs-legend-layer [layer]="layer"></hs-legend-layer>
                 </div>
-
             </li>
         </ul>
         <div class="row justify-content-center">

--- a/projects/hslayers/components/legend/legend.component.ts
+++ b/projects/hslayers/components/legend/legend.component.ts
@@ -92,10 +92,6 @@ export class HsLegendComponent
     this.buildLegendsForLayers(this.hsMapService.getMap());
   }
 
-  filterDescriptors(): any[] {
-    return this.layerDescriptors;
-  }
-
   legendFilter = (item): boolean => {
     const r = new RegExp(this.titleSearch, 'i');
     return r.test(item.title);

--- a/projects/hslayers/components/legend/public-api.ts
+++ b/projects/hslayers/components/legend/public-api.ts
@@ -1,3 +1,4 @@
+export * from './legend-custom-category.type';
 export * from './legend-descriptor.interface';
 export * from './legend-layer-static/legend-layer-static.component';
 export * from './legend-layer-static/legend-layer-static.service';

--- a/projects/hslayers/components/print/print-legend.service.ts
+++ b/projects/hslayers/components/print/print-legend.service.ts
@@ -209,8 +209,7 @@ export class HsPrintLegendService extends PrintLegendParams {
         ),
       );
     } else {
-      for (const category of (desc.lyr.getSource() as SparqlJson)
-        .legend_categories) {
+      for (const category of desc.lyr.getSource().get('legendCategories')) {
         svgSource = this.sparqlJsonToSvg(category, desc.title);
       }
     }

--- a/projects/hslayers/test/legend-layer.spec.ts
+++ b/projects/hslayers/test/legend-layer.spec.ts
@@ -8,9 +8,9 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 
-import Feature from 'ol/Feature';
-import Point from 'ol/geom/Point';
 import {Circle, Fill, Stroke, Style} from 'ol/style';
+import {Feature} from 'ol';
+import {Point} from 'ol/geom';
 import {Vector as VectorLayer} from 'ol/layer';
 import {Vector as VectorSource} from 'ol/source';
 
@@ -210,7 +210,7 @@ describe('HsLegendLayerComponent', () => {
         radius: 5,
       }),
     });
-    component.layer.lyr.setStyle(customStyle);
+    (component.layer.lyr as VectorLayer<Feature>).setStyle(customStyle);
     fixture.detectChanges();
     const svg = await service.getVectorLayerLegendSvg(layer);
     expect(getCluster(component.layer.lyr)).toBeFalse();

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -219,6 +219,7 @@ export class HslayersAppComponent {
         swipeSide: 'left',
         cluster: false,
         inlineLegend: true,
+        autoLegend: false,
         editor: {
           editable: true,
           defaultAttributes: {
@@ -264,6 +265,20 @@ export class HslayersAppComponent {
       },
       source: new VectorSource({features}),
     });
+    /* A completely fake legend just for the sake of testing */
+    const pointLegend = [
+      {color: 'rgba(58, 168, 55, 0.85)', name: 'implemented status'},
+      {color: 'rgba(174, 203, 6, 0.85)', name: 'planned status'},
+      {color: 'rgba(6, 89, 155, 0.85)', name: 'idea status'},
+      {color: 'rgba(239, 135, 3, 0.85)', name: 'INTERREG status'},
+      {color: 'rgba(155, 155, 155, 0.85)', name: 'unknown status'},
+      {
+        path: 'https://pluschange.plan4all.eu/maps/nbs/assets/icons/wet_valley.svg',
+        name: 'wet valleys',
+        height: 32,
+      },
+    ];
+    points.getSource().set('legendCategories', pointLegend);
     const polygonSld = `<?xml version="1.0" encoding="ISO-8859-1"?>
               <StyledLayerDescriptor version="1.0.0" 
                   xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 


### PR DESCRIPTION
## Description

This change standardises de facto utilised way how to pass a custom legend via a Source (sub)class into the legend panel. It now uses custom property `legendCategories` and expected format is described in a type definition.
As an enhancement, the category can now also display custom icon (any image) instead of just colour rectangle.

![image](https://github.com/hslayers/hslayers-ng/assets/5598693/4b0c8ef8-a56b-4952-8f60-2a772b19ab62)

## Related issues or pull requests

Related to nature-based-solutions app.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
