### PR TITLE
refactor(map): Add axis orientation info to EPSG:3035 definition

### DIFF
--- a/projects/hslayers-cesium/src/hscesium-layers.service.ts
+++ b/projects/hslayers-cesium/src/hscesium-layers.service.ts
@@ -41,7 +41,6 @@ import {
   Vector as VectorSource,
   XYZ,
 } from 'ol/source';
-import {default as proj4} from 'proj4';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
@@ -62,6 +61,7 @@ import {
 import {HsCesiumConfig} from './hscesium-config.service';
 import {OlCesiumObjectMapItem} from './ol-cesium-object-map-item.class';
 import {ParamCacheMapItem} from './param-cache-map-item.class';
+import {transform} from 'ol/proj';
 
 function MyProxy({proxy, maxResolution, HsUtilsService, projection}) {
   this.proxy = proxy;
@@ -376,7 +376,11 @@ export class HsCesiumLayersService {
       const ya = coordinates[1];
       const za = coordinates[2];
 
-      const newCoordinates = proj4(firstProjection, secondProjection, [xa, ya]);
+      const newCoordinates = transform(
+        [xa, ya],
+        firstProjection,
+        secondProjection,
+      );
       return Cartesian3.fromDegrees(
         newCoordinates[0],
         newCoordinates[1],

--- a/projects/hslayers/services/map/map.service.ts
+++ b/projects/hslayers/services/map/map.service.ts
@@ -510,7 +510,7 @@ export class HsMapService {
 
     proj4.defs(
       'EPSG:3035',
-      '+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs',
+      '+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs +axis=neu',
     );
     proj4.defs(
       'http://www.opengis.net/gml/srs/epsg.xml#3035',


### PR DESCRIPTION
## Description

- Add axis orientation info to EPSG:3035 definition to allow its usage with WMS 1.3.0

## Related issues or pull requests

#5093 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
