### PR TITLE
String based attributes for style comparison filter & configurable number of color map categories

### DIFF
--- a/projects/hslayers/assets/locales/cs.json
+++ b/projects/hslayers/assets/locales/cs.json
@@ -621,7 +621,8 @@
       "selectOption": "Vyberte možnost",
       "typeFolderName": "Zadejte název nové složky",
       "pickOrCreate": "Vyberte nebo vytvořte novou složku",
-      "moveToNewFolder": "Přesunout vrstvu do složky"
+      "moveToNewFolder": "Přesunout vrstvu do složky",
+      "nrOfCategories": "Počet kategorií"
     },
     "layerList": {
       "layerIsQueryable": "Tato vrstva je dotazovatelná",
@@ -1038,7 +1039,8 @@
     "reallyResetStyleToDefault": "Opravdu chcete použít výchozí styl?",
     "sldParsingError": "Chyba při zpracování stylu",
     "sldParsingErrorMessage": "Při zpracování poskytnutého stylu SLD došlo k chybě. Byl použit výchozí styl.",
-    "uploadStyleFile": "Nahrajte styl jako soubor SLD/QML"
+    "uploadStyleFile": "Nahrajte styl jako soubor SLD/QML",
+    "tooFewCategories": "Pro správnou funkci vybrané barevné mapy je potřeba více kategorií"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Měřit linie a polygony",

--- a/projects/hslayers/assets/locales/en.json
+++ b/projects/hslayers/assets/locales/en.json
@@ -1040,7 +1040,7 @@
     "sldParsingError": "Style parsing error",
     "sldParsingErrorMessage": "There was an error parsing provided SLD style. Default style used.",
     "uploadStyleFile": "Upload style as SLD/QML file",
-    "tooFewCategories": "Selected color map requires more categories to function"
+    "tooFewCategories": "Selected color map requires more categories to function properly"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Measure lines and polygon",

--- a/projects/hslayers/assets/locales/en.json
+++ b/projects/hslayers/assets/locales/en.json
@@ -621,7 +621,8 @@
       "selectOption": "Select an option",
       "typeFolderName": "Type new folder name",
       "pickOrCreate": "Pick or create new folder",
-      "moveToNewFolder": "Move layer to folder"
+      "moveToNewFolder": "Move layer to folder",
+      "nrOfCategories": "Number of categories"
     },
     "layerList": {
       "layerIsQueryable": "This layer is queryable",
@@ -1038,7 +1039,8 @@
     "reallyResetStyleToDefault": "Do you really want to apply default style?",
     "sldParsingError": "Style parsing error",
     "sldParsingErrorMessage": "There was an error parsing provided SLD style. Default style used.",
-    "uploadStyleFile": "Upload style as SLD/QML file"
+    "uploadStyleFile": "Upload style as SLD/QML file",
+    "tooFewCategories": "Selected color map requires more categories to function"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Measure lines and polygon",

--- a/projects/hslayers/assets/locales/lv.json
+++ b/projects/hslayers/assets/locales/lv.json
@@ -586,7 +586,8 @@
       "colorMap": "Toņu karte",
       "max": "Maks.",
       "min": "Min.",
-      "interpolatedAttribute": "Interpolējamais atribūts"
+      "interpolatedAttribute": "Interpolējamais atribūts",
+      "nrOfCategories": "Kategoriju skaits"
     },
     "layerList": {
       "layerIsQueryable": "Šis slānis ir vaicājams",

--- a/projects/hslayers/assets/locales/sk.json
+++ b/projects/hslayers/assets/locales/sk.json
@@ -621,7 +621,8 @@
       "selectOption": "Vyberte možnosť",
       "typeFolderName": "Zadajte názov novej zložky",
       "pickOrCreate": "Vyberte alebo vytvorte novú zložku",
-      "moveToNewFolder": "Presuňte vrstvu do zložky"
+      "moveToNewFolder": "Presuňte vrstvu do zložky",
+      "nrOfCategories": "Počet kategórií"
     },
     "layerList": {
       "layerIsQueryable": "Táto vrstva je dotazovateľná",
@@ -1007,7 +1008,8 @@
     "reallyResetStyleToDefault": "Naozaj chcete aplikovať predvolený štýl?",
     "sldParsingError": "Chyba pri spracovaní štýlu",
     "sldParsingErrorMessage": "Pri spracovaní poskytnutého štýlu SLD došlo k chybe. Bol použitý predvolený štýl.",
-    "uploadStyleFile": "Nahrajte štýl ako súbor SLD/QML"
+    "uploadStyleFile": "Nahrajte štýl ako súbor SLD/QML",
+    "tooFewCategories": "Pre správnu funkciu vybranej farebnej mapy je potrebné viac kategórií"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Merať línie a polygóny",

--- a/projects/hslayers/components/layer-manager/widgets/idw-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/idw-widget.component.ts
@@ -81,7 +81,7 @@ export class HsIdwWidgetComponent
   }
 
   listNumericAttributes(features: Feature[]): string[] {
-    return this.hsLayerUtilsService.listAttributes(features, true);
+    return this.hsLayerUtilsService.listNumericAttributes(features);
   }
 
   getIdwSource(): InterpolatedSource {

--- a/projects/hslayers/components/layer-manager/widgets/idw-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/idw-widget.component.ts
@@ -81,7 +81,7 @@ export class HsIdwWidgetComponent
   }
 
   listNumericAttributes(features: Feature[]): string[] {
-    return this.hsLayerUtilsService.listNumericAttributes(features);
+    return this.hsLayerUtilsService.listAttributes(features, true);
   }
 
   getIdwSource(): InterpolatedSource {

--- a/projects/hslayers/components/styler/add-colormap.component.html
+++ b/projects/hslayers/components/styler/add-colormap.component.html
@@ -1,30 +1,37 @@
-<div class="form-group">
+<div class="form-group ps-2">
   <div class="form-inline">
     <label class="control-label" style="width: 100%; justify-content: left">{{
-    "LAYERMANAGER.layerEditor.interpolatedAttribute" | translateHs }}:</label>
+      "LAYERMANAGER.layerEditor.interpolatedAttribute" | translateHs }}:</label>
 
     <select class="form-control form-select" style="width: 100%" [(ngModel)]="weightAttribute"
       [ngModelOptions]="{standalone: true}" (change)="changeAttrib()">
       @for (attr of attributes; track attr) {
-        <option [ngValue]="attr">
-          {{attr}}
-        </option>
+      <option [ngValue]="attr">
+        {{attr}}
+      </option>
       }
     </select>
   </div>
 
   <hs-colormap-picker [(ngModel)]="colorMap"></hs-colormap-picker>
 
+  <div class="pb-3 pt-2 d-flex flex-column">
+    <label class="form-label">{{
+      "LAYERMANAGER.layerEditor.nrOfCategories" | translateHs }}: {{categories}}</label>
+    <input type="range" min="4" max="16" step="1" class="inline mt-0" [(ngModel)]="categories"
+      name="hs-colormap-categories" />
+  </div>
+
   <div class="row g-3">
     <div class="col-md-6">
       <label class="form-label">{{
-      "LAYERMANAGER.layerEditor.min" | translateHs }}:</label>
+        "LAYERMANAGER.layerEditor.min" | translateHs }}:</label>
       <input class="form-control inline" [(ngModel)]="min" name="hsIdwMin" />
 
     </div>
     <div class="col-md-6">
       <label class="form-label">{{
-      "LAYERMANAGER.layerEditor.max" | translateHs }}:</label>
+        "LAYERMANAGER.layerEditor.max" | translateHs }}:</label>
       <input class="form-control" [(ngModel)]="max" name="hsIdwMax" />
     </div>
   </div>

--- a/projects/hslayers/components/styler/add-colormap.component.ts
+++ b/projects/hslayers/components/styler/add-colormap.component.ts
@@ -31,7 +31,7 @@ export class HsAddColormapComponent implements OnInit {
   ngOnInit(): void {
     const src = this.layer.getSource();
     const features = src.getFeatures();
-    this.attributes = this.hsLayerUtilsService.listNumericAttributes(features);
+    this.attributes = this.hsLayerUtilsService.listAttributes(features, true);
   }
 
   changeAttrib() {

--- a/projects/hslayers/components/styler/add-colormap.component.ts
+++ b/projects/hslayers/components/styler/add-colormap.component.ts
@@ -20,6 +20,7 @@ export class HsAddColormapComponent implements OnInit {
   colorMap: string;
   min: number | string = '';
   max: number | string = '';
+  categories: number = 10;
   @Output() canceled = new EventEmitter<void>();
 
   constructor(
@@ -52,6 +53,7 @@ export class HsAddColormapComponent implements OnInit {
   save(): void {
     this.hsStylerService.addRule('ColorMap', {
       colorMapName: this.colorMap,
+      categories: this.categories,
       min: this.min ? parseFloat(this.min.toString()) : undefined,
       max: this.max ? parseFloat(this.max.toString()) : undefined,
       attribute: this.weightAttribute,

--- a/projects/hslayers/components/styler/add-colormap.component.ts
+++ b/projects/hslayers/components/styler/add-colormap.component.ts
@@ -31,7 +31,7 @@ export class HsAddColormapComponent implements OnInit {
   ngOnInit(): void {
     const src = this.layer.getSource();
     const features = src.getFeatures();
-    this.attributes = this.hsLayerUtilsService.listAttributes(features, true);
+    this.attributes = this.hsLayerUtilsService.listNumericAttributes(features);
   }
 
   changeAttrib() {

--- a/projects/hslayers/components/styler/filters/comparison-filter.component.html
+++ b/projects/hslayers/components/styler/filters/comparison-filter.component.html
@@ -1,18 +1,21 @@
 <div class="d-flex flex-row form-group p-1">
-  <select class="form-control form-select" style="width: 100%" [(ngModel)]="filter[1]" name="hs-sld-filter-attribute">
-    <option [ngValue]="undefined" [disabled]="true" selected hidden>Pick an attribute</option>
-    @for (attr of attributes; track attr) {
-      <option [ngValue]="attr">
-        {{attr}}
-      </option>
+  <select class="form-control form-select" style="width: 100%" [formControl]="attributeControl"
+    name="hs-sld-filter-attribute">
+    <option [ngValue]="null" [disabled]="true" selected hidden>Pick an attribute</option>
+    @for(attr of attributes; track attr){
+    <option [ngValue]="attr">
+      {{ attr }}
+    </option>
     }
+
   </select>
+
   <select (change)="emitChange()" class="form-control form-select hs-sld-filter-comparison-sign"
     style="width: min-content" [(ngModel)]="filter[0]" name="hs-sld-filter-comparison-sign">
-    @for (op of operators; track op) {
-      <option [ngValue]="op">
-        {{op}}
-      </option>
+    @for (op of operators | async ; track op) {
+    <option [ngValue]="op">
+      {{op}}
+    </option>
     }
   </select>
   <div style="min-width: 33%;">

--- a/projects/hslayers/components/styler/filters/comparison-filter.component.ts
+++ b/projects/hslayers/components/styler/filters/comparison-filter.component.ts
@@ -34,7 +34,7 @@ export class HsComparisonFilterComponent
     numeric: ['<', '<=', '>', '>='],
   };
 
-  private features: Feature<Geometry>[] = [];
+  features: Feature<Geometry>[] = [];
 
   attributeControl: FormControl;
   attributes: string[];

--- a/projects/hslayers/components/styler/filters/comparison-filter.component.ts
+++ b/projects/hslayers/components/styler/filters/comparison-filter.component.ts
@@ -1,30 +1,73 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
+import {Feature} from 'ol';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {Geometry} from 'ol/geom';
+import {Observable, map, startWith, tap} from 'rxjs';
 import {Vector as VectorSource} from 'ol/source';
 
+import {AsyncPipe, NgForOf} from '@angular/common';
 import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 import {HsLayerUtilsService} from 'hslayers-ng/services/utils';
 import {HsStylerPartBaseComponent} from '../style-part-base.component';
+import {TranslateCustomPipe} from 'hslayers-ng/services/language';
 
 @Component({
+  standalone: true,
+  imports: [
+    NgForOf,
+    ReactiveFormsModule,
+    FormsModule,
+    TranslateCustomPipe,
+    AsyncPipe,
+  ],
   selector: 'hs-comparison-filter',
   templateUrl: './comparison-filter.component.html',
 })
-export class HsComparisonFilterComponent extends HsStylerPartBaseComponent {
+export class HsComparisonFilterComponent
+  extends HsStylerPartBaseComponent
+  implements OnInit {
   @Input() filter;
   @Input() parent;
 
+  private readonly OPERATORS = {
+    default: ['==', '*=', '!='],
+    numeric: ['<', '<=', '>', '>='],
+  };
+
+  private features: Feature<Geometry>[] = [];
+
+  attributeControl: FormControl;
   attributes: string[];
-  operators = ['==', '*=', '!=', '<', '<=', '>', '>='];
+  operators: Observable<string[]>;
 
   constructor(
     private hsLayerSelectorService: HsLayerSelectorService,
     private hsLayerUtilsService: HsLayerUtilsService,
   ) {
     super();
+
     const layer = this.hsLayerSelectorService.currentLayer.layer;
     const src = layer.getSource();
-    const features = (src as VectorSource).getFeatures();
-    this.attributes = this.hsLayerUtilsService.listNumericAttributes(features);
+    this.features = (src as VectorSource).getFeatures();
+    this.attributes = this.hsLayerUtilsService.listAttributes(this.features);
+  }
+
+  ngOnInit(): void {
+    this.attributeControl = new FormControl(this.filter[1] ?? null);
+    this.operators = this.attributeControl.valueChanges.pipe(
+      tap((attr) => {
+        // Update the filter when attribute changes
+        this.filter[1] = attr;
+        this.emitChange();
+      }),
+      map((attr: string) => {
+        if (!isNaN(Number(this.features[0].get(attr)))) {
+          return [...this.OPERATORS.default, ...this.OPERATORS.numeric];
+        }
+        return this.OPERATORS.default;
+      }),
+      startWith([...this.OPERATORS.default, ...this.OPERATORS.numeric]),
+    );
   }
 
   remove(): void {

--- a/projects/hslayers/components/styler/filters/filters.component.ts
+++ b/projects/hslayers/components/styler/filters/filters.component.ts
@@ -24,8 +24,6 @@ export class HsFiltersComponent extends HsStylerPartBaseComponent {
 
   remove(): void {
     delete this.rule.filter;
-    //Trigger change detection
-    this.rule = {...this.rule};
     this.emitChange();
   }
 }

--- a/projects/hslayers/components/styler/styles.module.ts
+++ b/projects/hslayers/components/styler/styles.module.ts
@@ -49,7 +49,6 @@ import {TranslateCustomPipe} from 'hslayers-ng/services/language';
     HsSliderComponent,
     HsFiltersComponent,
     HsFilterComponent,
-    HsComparisonFilterComponent,
     HsAddFilterButtonComponent,
     HsScaleDenominatorComponent,
     HsSelectIconDialogComponent,
@@ -71,6 +70,7 @@ import {TranslateCustomPipe} from 'hslayers-ng/services/language';
     DragDropModule,
     HsColormapPickerModule,
     HsPanelHeaderComponent,
+    HsComparisonFilterComponent,
   ],
   exports: [
     HsStylerComponent,

--- a/projects/hslayers/services/utils/layer-utils.service.ts
+++ b/projects/hslayers/services/utils/layer-utils.service.ts
@@ -487,18 +487,29 @@ export class HsLayerUtilsService {
     return denominator / (mpu * 39.37 * dpi);
   }
 
+  /**
+   * List numeric attributes of the feature
+   */
+  listNumericAttributes(features: Feature[]) {
+    return this.listAttributes(features, true);
+  }
+
+  private readonly ATTRIBUTES_EXCLUDED_FROM_LIST = [
+    'geometry',
+    'hs_normalized_IDW_value',
+  ];
+
+  /**
+   * List all attributes of the feature apart from the geometry
+   */
   listAttributes(features: Feature[], numericOnly = false): string[] {
     return features.length > 0
-      ? Object.keys(features[0].getProperties()).filter(
-          (attr) => {
-            return (
-              (attr != 'geometry' &&
-                attr != 'hs_normalized_IDW_value' &&
-                !numericOnly) ??
-              !isNaN(Number(features[0].get(attr)))
-            );
-          }, //Check if number
-        )
+      ? Object.keys(features[0].getProperties()).filter((attr) => {
+          return (
+            !this.ATTRIBUTES_EXCLUDED_FROM_LIST.includes(attr) &&
+            (!numericOnly || !isNaN(Number(features[0].get(attr))))
+          );
+        })
       : [];
   }
 

--- a/projects/hslayers/services/utils/layer-utils.service.ts
+++ b/projects/hslayers/services/utils/layer-utils.service.ts
@@ -487,13 +487,14 @@ export class HsLayerUtilsService {
     return denominator / (mpu * 39.37 * dpi);
   }
 
-  listNumericAttributes(features: Feature[]): string[] {
+  listAttributes(features: Feature[], numericOnly = false): string[] {
     return features.length > 0
       ? Object.keys(features[0].getProperties()).filter(
           (attr) => {
             return (
-              attr != 'geometry' &&
-              attr != 'hs_normalized_IDW_value' &&
+              (attr != 'geometry' &&
+                attr != 'hs_normalized_IDW_value' &&
+                !numericOnly) ??
               !isNaN(Number(features[0].get(attr)))
             );
           }, //Check if number

--- a/projects/hslayers/test/layer-manager/layer-selector.service.mock.ts
+++ b/projects/hslayers/test/layer-manager/layer-selector.service.mock.ts
@@ -1,0 +1,32 @@
+import Feature from 'ol/Feature';
+import VectorSource from 'ol/source/Vector';
+import {Point} from 'ol/geom';
+import {Vector as VectorLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+
+export class MockHsLayerSelectorService {
+  currentLayer: {layer: VectorLayer<VectorSource>} = {layer: undefined};
+
+  constructor() {
+    // Create a feature with two attributes
+    const feature = new Feature({
+      geometry: new Point(fromLonLat([0, 0])), // Example coordinates
+      stringBased: 'value1',
+      numeric: 123,
+    });
+
+    // Create a vector source and add the feature to it
+    const source = new VectorSource({
+      features: [feature],
+    });
+
+    // Create a vector layer and set its source
+    this.currentLayer.layer = new VectorLayer({
+      source: source,
+    });
+  }
+
+  getCurrentLayer() {
+    return this.currentLayer;
+  }
+}

--- a/projects/hslayers/test/layer-utils.service.mock.ts
+++ b/projects/hslayers/test/layer-utils.service.mock.ts
@@ -29,5 +29,6 @@ export function mockLayerUtilsService() {
     'hasNestedLayers',
     'isLayerArcgis',
     'highlightFeatures',
+    'listAttributes',
   ]);
 }

--- a/projects/hslayers/test/layer-utils.service.mock.ts
+++ b/projects/hslayers/test/layer-utils.service.mock.ts
@@ -30,5 +30,6 @@ export function mockLayerUtilsService() {
     'isLayerArcgis',
     'highlightFeatures',
     'listAttributes',
+    'listNumericAttributes',
   ]);
 }

--- a/projects/hslayers/test/styler/filters/comparison-filter.spec.ts
+++ b/projects/hslayers/test/styler/filters/comparison-filter.spec.ts
@@ -1,0 +1,88 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+
+import {HsComparisonFilterComponent} from 'hslayers-ng/components/styler';
+import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
+import {HsLayerUtilsService} from 'hslayers-ng/services/utils';
+import {MockHsLayerSelectorService} from 'hslayers-ng/test/layer-manager/layer-selector.service.mock';
+import {mockLayerUtilsService} from 'hslayers-ng/test/layer-utils.service.mock';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {skip, take} from 'rxjs';
+
+describe('ComparisonFilterComponent', () => {
+  let component: HsComparisonFilterComponent;
+  let fixture: ComponentFixture<HsComparisonFilterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, FormsModule, HsComparisonFilterComponent],
+      providers: [
+        // ... other test providers
+        provideHttpClientTesting(),
+        provideHttpClientTesting(),
+        {provide: HsLayerUtilsService, useValue: mockLayerUtilsService()},
+        {
+          provide: HsLayerSelectorService,
+          useClass: MockHsLayerSelectorService,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HsComparisonFilterComponent);
+    component = fixture.componentInstance;
+    component.filter = ['>', 'attr1', 'value'];
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should trigger side effects when attribute changes', fakeAsync(() => {
+    spyOn(component, 'emitChange');
+
+    component.attributeControl.setValue('attribute1');
+    tick(500);
+    fixture.detectChanges();
+
+    expect(component.emitChange).toHaveBeenCalled();
+  }));
+
+  it('should initialize with default operators or empty', fakeAsync(() => {
+    component.operators.pipe(take(1)).subscribe((operators) => {
+      expect(operators).toEqual(['==', '*=', '!=', '<', '<=', '>', '>=']); // Assuming it should be empty on init
+    });
+
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it('should update operators correctly based on selected attribute - string based', fakeAsync(() => {
+    component.operators.pipe(skip(1), take(1)).subscribe((operators) => {
+      expect(operators).toEqual(['==', '*=', '!=']);
+    });
+
+    // Simulate selecting a stringBased attribute
+    component.attributeControl.setValue('stringBased');
+    tick(500); // Advance the virtual time
+    fixture.detectChanges();
+  }));
+
+  it('should update operators correctly based on selected attribute - numeric', fakeAsync(() => {
+    component.operators.pipe(skip(1), take(1)).subscribe((operators) => {
+      expect(operators).toEqual(['==', '*=', '!=', '<', '<=', '>', '>=']);
+    });
+
+    // Simulate selecting a numeric attribute
+    component.attributeControl.setValue('numeric');
+    tick(500); // Advance the virtual time
+    fixture.detectChanges();
+  }));
+});

--- a/projects/hslayers/test/styler/filters/filters.component.spec.ts
+++ b/projects/hslayers/test/styler/filters/filters.component.spec.ts
@@ -1,0 +1,70 @@
+import {By} from '@angular/platform-browser';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DebugElement} from '@angular/core';
+import {
+  HsAddFilterButtonComponent,
+  HsFiltersComponent,
+  HsFiltersService,
+} from 'hslayers-ng/components/styler';
+import {TranslateCustomPipe} from 'hslayers-ng/services/language';
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+
+describe('StylerFiltersComponent', () => {
+  let component: HsFiltersComponent;
+  let fixture: ComponentFixture<HsFiltersComponent>;
+  let filtersService: HsFiltersService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HsFiltersComponent, HsAddFilterButtonComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        HsFiltersService,
+      ],
+      imports: [TranslateCustomPipe],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HsFiltersComponent);
+    component = fixture.componentInstance;
+    component.rule = {
+      name: 'Untitled rule',
+      symbolizers: [],
+    };
+    filtersService = TestBed.inject(HsFiltersService);
+    fixture.detectChanges(); // Ensure Angular processes all bindings
+    await fixture.whenStable(); // Wait for async tasks to complete
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should update the rule filter correctly when a filter is added', () => {
+    spyOn(component, 'add').and.callThrough(); // Spy on the add method in the component
+    spyOn(filtersService, 'add').and.callThrough(); // Spy on the add method in the service
+
+    // Create a mock event object with the required properties
+    const mockEvent = {type: 'COMPARE'};
+
+    // Simulate button click to add filter
+    const button: DebugElement = fixture.debugElement.query(
+      By.css('hs-add-filter-button'),
+    );
+    expect(button).toBeTruthy(); // Ensure the button exists in the DOM
+
+    button.triggerEventHandler('clicks', mockEvent);
+
+    expect(filtersService.add).toHaveBeenCalled();
+    expect(component.rule.filter).toEqual(['==', undefined, '<value>']);
+  });
+
+  it('should emit change when filter is updated', () => {
+    spyOn(component.changes, 'emit');
+
+    component.emitChange();
+
+    expect(component.changes.emit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
- String based attributes for style comaprison filter along with some unit tests
- Configurable number of color map categories
-  Fixes bug where styler rule removal created new instance of rule thus disconnecting stylerService.styleObject used to produce SLD from styler UI

## Related issues or pull requests

closes #5152 
closes #4886 


## Pull request type
<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
