### PR TITLE
refactor(IDW): Indicate no data state on canvas

### DIFF
--- a/projects/hslayers/common/layers/hs.source.interpolated.ts
+++ b/projects/hslayers/common/layers/hs.source.interpolated.ts
@@ -96,14 +96,14 @@ export class InterpolatedSource extends IDW {
     canvas.height = imageData.height;
     const ctx = canvas.getContext('2d');
 
-    ctx.putImageData(
-      new ImageData(imageData.data, imageData.width, imageData.height),
-      0,
-      0,
-    );
-
     if (this.isImageDataMostlyEmpty(imageData)) {
       this.drawNoData(ctx, canvas);
+    } else {
+      ctx.putImageData(
+        new ImageData(imageData.data, imageData.width, imageData.height),
+        0,
+        0,
+      );
     }
 
     // Draw full resolution canvas
@@ -342,21 +342,45 @@ export class InterpolatedSource extends IDW {
    * Draw 'NO DATA' label over layers canvas
    */
   drawNoData(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) {
-    // Set text properties
-    ctx.font = '30px Arial';
+    // Set the desired canvas size
+    const originalWidth = canvas.width;
+    const originalHeight = canvas.height;
+
+    // Get the device pixel ratio
+    const scale = window.devicePixelRatio || 1;
+
+    // Set the canvas width and height for high DPI
+    canvas.width = originalWidth * scale;
+    canvas.height = originalHeight * scale;
+
+    // Scale the context to match the canvas size
+    ctx.scale(scale, scale);
+
+    const text = 'NO DATA';
+    let fontSize = 30;
+    ctx.font = `${fontSize}px Arial`;
+
+    // Measure the text width with padding (10px on each side)
+    let textWidth = ctx.measureText(text).width + 20;
+
+    // Adjust font size to fit within the canvas
+    while (
+      textWidth > originalWidth * 0.9 * scale ||
+      fontSize > originalHeight * 0.9 * scale
+    ) {
+      fontSize -= 2;
+      ctx.font = `${fontSize}px Arial`;
+      textWidth = ctx.measureText(text).width + 20;
+    }
+
     ctx.fillStyle = 'white';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
 
-    // Calculate center position
-    const centerX = canvas.width / 2;
-    const centerY = canvas.height / 2;
-
     // Draw the text
-    ctx.fillText('NO DATA', centerX, centerY);
+    ctx.fillText(text, originalWidth / 2, originalHeight / 2);
   }
 }
-
 /**
  * Gets predefined colorMap array based on name and number of shades.
  * If you want to reverse defined color map add '-reverse' to the map name


### PR DESCRIPTION
## Description

Indicate no data state of IDW layers for the purposes of [info4agro](https://info4agro.com) app.

- overwriting `onImageData` method of IDW class
-  empty canvas/missing data is guesstimated from array of rgba values. Since this data tends to be quite large (easily 10 of thousands of array items) `isImageDataMostlyEmpty` method check only 4pixels for each of the 13 defined positions placed across the image.

![image](https://github.com/user-attachments/assets/52a3ce36-879c-405a-aae6-fe491be7db83)


## Related issues or pull requests

https://github.com/LESPROJEKT/info4agro/issues/46

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
