### PR TITLE
Set default panel via HsConfig, language updates

### DIFF
--- a/projects/hslayers/assets/locales/sk.json
+++ b/projects/hslayers/assets/locales/sk.json
@@ -1012,7 +1012,7 @@
     "sldParsingError": "Chyba pri spracovaní štýlu",
     "sldParsingErrorMessage": "Pri spracovaní poskytnutého štýlu SLD došlo k chybe. Bol použitý predvolený štýl.",
     "uploadStyleFile": "Nahrajte štýl ako súbor SLD/QML",
-    "tooFewCategories": "Pre správnu funkciu vybranej farebnej mapy je potrebné viac kategórií",
+    "tooFewCategories": "Pre správnu funkciu vybranej farebnej mapy je potrebné viac kategórií"
   },
   "TOOLBAR": {
     "measureLinesAndPolygon": "Merať línie a polygóny",

--- a/projects/hslayers/common/panels/panel-header/panel-header.component.ts
+++ b/projects/hslayers/common/panels/panel-header/panel-header.component.ts
@@ -87,8 +87,4 @@ export class HsPanelHeaderComponent implements OnInit {
   tabClicked(tab: string): void {
     this.selectedTab$.next(tab);
   }
-
-  closePanel(): void {
-    this.HsLayoutService.closePanel(this.name);
-  }
 }

--- a/projects/hslayers/config/config.service.ts
+++ b/projects/hslayers/config/config.service.ts
@@ -36,7 +36,6 @@ export type PanelsEnabled = {
   draw?: boolean;
   layerManager?: boolean;
   featureTable?: boolean;
-  feature_crossfilter?: boolean;
   print?: boolean;
   saveMap?: boolean;
   language?: boolean;

--- a/projects/hslayers/config/config.service.ts
+++ b/projects/hslayers/config/config.service.ts
@@ -28,6 +28,31 @@ export interface KeyNumberDict {
   [key: string]: number;
 }
 
+export type PanelsEnabled = {
+  legend?: boolean;
+  measure?: boolean;
+  query?: boolean;
+  compositions?: boolean;
+  draw?: boolean;
+  layerManager?: boolean;
+  featureTable?: boolean;
+  feature_crossfilter?: boolean;
+  print?: boolean;
+  saveMap?: boolean;
+  language?: boolean;
+  share?: boolean;
+  sensors?: boolean;
+  search?: boolean;
+  tripPlanner?: boolean;
+  addData?: boolean;
+  mapSwipe?: boolean;
+  wfsFilter?: boolean;
+};
+//Provides PanelsEnabled suggestions while keeping type open for custom panels
+export type DefaultPanel =
+  | keyof PanelsEnabled
+  | (string & Record<never, never>);
+
 export class HsConfigObject {
   componentsEnabled?: {
     guiOverlay?: boolean;
@@ -94,26 +119,8 @@ export class HsConfigObject {
   defaultDrawLayerPath?: string;
   defaultComposition?: string;
   default_view?: View;
-  panelsEnabled?: {
-    legend?: boolean;
-    measure?: boolean;
-    query?: boolean;
-    compositions?: boolean;
-    draw?: boolean;
-    layerManager?: boolean;
-    featureTable?: boolean;
-    feature_crossfilter?: boolean;
-    print?: boolean;
-    saveMap?: boolean;
-    language?: boolean;
-    share?: boolean;
-    sensors?: boolean;
-    search?: boolean;
-    tripPlanner?: boolean;
-    addData?: boolean;
-    mapSwipe?: boolean;
-    wfsFilter?: boolean;
-  };
+  panelsEnabled?: PanelsEnabled;
+  defaultPanel?: DefaultPanel;
   errorToastDuration?: number;
   advancedForm?: boolean;
   project_name?: string;

--- a/projects/hslayers/services/language/language.service.ts
+++ b/projects/hslayers/services/language/language.service.ts
@@ -45,7 +45,11 @@ export class HsLanguageService {
       if (this.hsConfig.language) {
         this.setLanguage(this.hsConfig.language);
       }
-      if (this.hsConfig.translationOverrides != undefined) {
+      const currentLoader = translator.currentLoader as WebpackTranslateLoader;
+      if (
+        this.hsConfig.translationOverrides != undefined &&
+        !currentLoader.loadedViaInitializator.includes(translator.currentLang)
+      ) {
         if (translator?.currentLang) {
           translator.reloadLang(translator.currentLang);
         }
@@ -59,7 +63,7 @@ export class HsLanguageService {
   initLanguages() {
     const languages = this.hsConfig.enabledLanguages
       ? this.hsConfig.enabledLanguages.split(',').map((lang) => lang.trim())
-      : ['cs', 'sk'];
+      : ['en,', 'cs', 'sk'];
     this.translationService.addLangs(languages);
     this.translationService.setDefaultLang('en');
     const langToUse = this.getLangToUse();
@@ -154,7 +158,9 @@ export class HsLanguageService {
     const MAX_CONFIG_POLLS = 10;
     let counter = 0;
     while (
-      !(translator.currentLoader as WebpackTranslateLoader).loaded[lang] &&
+      !(translator.currentLoader as WebpackTranslateLoader).loadedLanguages()[
+        lang
+      ] &&
       counter++ < MAX_CONFIG_POLLS
     ) {
       await new Promise((resolve2) => setTimeout(resolve2, 500));

--- a/projects/hslayers/services/language/language.service.ts
+++ b/projects/hslayers/services/language/language.service.ts
@@ -63,7 +63,7 @@ export class HsLanguageService {
   initLanguages() {
     const languages = this.hsConfig.enabledLanguages
       ? this.hsConfig.enabledLanguages.split(',').map((lang) => lang.trim())
-      : ['en,', 'cs', 'sk'];
+      : ['en', 'cs', 'sk'];
     this.translationService.addLangs(languages);
     this.translationService.setDefaultLang('en');
     const langToUse = this.getLangToUse();

--- a/projects/hslayers/services/layout/layout.service.ts
+++ b/projects/hslayers/services/layout/layout.service.ts
@@ -194,6 +194,9 @@ export class HsLayoutService extends HsLayoutParams {
       this.sidebarToggleable = this.hsConfig.hasOwnProperty('sidebarToggleable')
         ? this.hsConfig.sidebarToggleable
         : true;
+      if (this.hsConfig.defaultPanel) {
+        this.setMainPanel(this.hsConfig.defaultPanel);
+      }
     }
 
     this.sidebarPosition$.next(this.hsConfig?.sidebarPosition ?? 'left');
@@ -314,16 +317,6 @@ export class HsLayoutService extends HsLayoutParams {
       this.sidebarLabels = false;
     }
     this.mainpanel$.next(which);
-  }
-
-  /**
-   * Sets new default panel (Panel which is opened first and which displayed if previous active panel is closed)
-   * @public
-   * @param which - New panel to be default (specify panel name)
-   */
-  setDefaultPanel(which: string): void {
-    this.defaultPanel = which;
-    this.setMainPanel(which);
   }
 
   getPanelSpaceWidth(): number {

--- a/projects/hslayers/services/layout/layout.service.ts
+++ b/projects/hslayers/services/layout/layout.service.ts
@@ -219,46 +219,11 @@ export class HsLayoutService extends HsLayoutParams {
   /**
    * Close opened panel programmatically.
    * If sidebar toolbar is used in the app, sidebar stays expanded with sidebar labels.
-   * Cannot resolve unpinned panels.
    * @public
    */
   hidePanels() {
     this.sidebarLabels = true;
     this.mainpanel$.next(undefined);
-  }
-
-  /**
-   * Close selected panel (either unpinned panels or actual mainpanel). If default panel is defined, it is opened instead.
-   * @public
-   * @param which - Panel to close (panel scope)
-   */
-  closePanel(which) {
-    if (which.unpinned) {
-      this.contentWrapper
-        .querySelector(which.original_container)
-        .appendChild(which.drag_panel);
-      which.drag_panel.css({
-        top: 'auto',
-        left: 'auto',
-        position: 'relative',
-      });
-    }
-    which.unpinned = false;
-    if (which.panelName == this.mainpanel) {
-      if (this.defaultPanel != '') {
-        if (which.panelName == this.defaultPanel) {
-          this.sidebarExpanded = false;
-        } else {
-          this.setMainPanel(this.defaultPanel);
-        }
-      } else {
-        this.mainpanel$.next(undefined);
-        this.sidebarLabels = true;
-      }
-      this.sidebarExpanded = false;
-    }
-
-    this.mainpanel$.next(which);
   }
 
   /**

--- a/projects/hslayers/test/config.service.mock.ts
+++ b/projects/hslayers/test/config.service.mock.ts
@@ -10,7 +10,6 @@ export class HsConfigMock {
     toolbar: false,
     draw: false,
     layermanager: false,
-    feature_crossfilter: false,
     print: false,
     saveMap: false,
     language: false,

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -56,10 +56,6 @@ export class HslayersAppComponent {
       },
       {},
     );
-    /* Switch to it */
-    this.hsLayoutService.layoutLoads.subscribe(() => {
-      this.hsLayoutService.setDefaultPanel('custom');
-    });
 
     /* Proper WMS-t layer */
     const imageWmsTSource = new TileWMS({
@@ -719,6 +715,7 @@ export class HslayersAppComponent {
           'My Cool Panel': 'Mea tabula magna',
         },
       },
+      defaultPanel: 'custom',
     });
 
     const dimensions = opticalMap.get('dimensions');


### PR DESCRIPTION
## Description

- Set default panel via HsConfig.
- Refactor WebpackTranslateLoader of CustomTranslationService to use observables instead of promises
- create `loadedViaInitializator` array which can be populated by consumer appliacation to prevent translations loaded via APP_INITIALIZER handler to get reloaded (normaly we use this reload to load translationOverrides)

## Related issues or pull requests

closes #5215 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
