### PR TITLE
Add GitHub Workflow to Detect Focused Tests (fdescribe and fit) in Test Directory

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+# Pre-commit hook to check for focused tests (fdescribe and fit)
+
+if grep -rn 'fdescribe(' ./projects/hslayers/test || grep -rn 'fit(' ./projects/hslayers/test; then
+  echo "Error: Found focused tests (fdescribe or fit). Please remove them before committing."
+  echo "Pre-commit hook failed. Commit aborted."
+  exit 1
+else
+  echo "No focused tests found."
+fi
+
+echo "Pre-commit hook completed."

--- a/.github/workflows/check-focused-tests.yml
+++ b/.github/workflows/check-focused-tests.yml
@@ -1,0 +1,26 @@
+name: Check for Focused Tests
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - "projects/hslayers/test/**"
+jobs:
+  check-focused-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check for fdescribe and fit in projects/hslayers/test
+        run: |
+          # Search for fdescribe or fit in the test directory and print matches with filename and line number
+          if grep -rn 'fdescribe(' ./projects/hslayers/test || grep -rn 'fit(' ./projects/hslayers/test; then
+            echo "Error: Found focused tests (fdescribe or fit) in the following files:"
+            # Show where focused tests were found, including line numbers
+            grep -rn 'fdescribe(' ./projects/hslayers/test
+            grep -rn 'fit(' ./projects/hslayers/test
+            exit 1
+          fi


### PR DESCRIPTION
## Description

- Add new GitHub Actions workflow that checks for the presence of focused tests (fdescribe and fit) within the projects/hslayers/test directory. Ensures that focused tests do not make it into the main codebase.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
