### PR TITLE
Fixes v15 - swipe layer render, map layers order, catalogue remove

### DIFF
--- a/projects/hslayers/components/add-data/common/url/details/details.component.html
+++ b/projects/hslayers/components/add-data/common/url/details/details.component.html
@@ -88,14 +88,14 @@
     <div class="capabilities_input d-flex flex-column">
       @if (type === 'wms') {
       <label class="capabilities_label control-label"> <input type="checkbox" class="me-1 checkbox-lg" name="useTiles"
-          [(ngModel)]="data.use_tiles" />
+          [(ngModel)]="data.useTiles" />
         {{'ADDLAYERS.useTiles' | translateHs }}
       </label>
       }
     </div>
   </div>
   @if (type === 'wms' || type === 'arcgis') {
-  <p class="col-sm-12 alert alert-warning" [hidden]="data.use_tiles">
+  <p class="col-sm-12 alert alert-warning" [hidden]="data.useTiles">
     {{'ADDLAYERS.considerUsingTiles' | translateHs }}
   </p>
   }

--- a/projects/hslayers/components/layer-manager/layer-manager.component.html
+++ b/projects/hslayers/components/layer-manager/layer-manager.component.html
@@ -2,8 +2,8 @@
 <div class="card panel-default hs-main-panel hs-layermanager-card" [ngClass]="panelWidthClass">
     <hs-panel-header name="layerManager" [panelTabs]="'LM'">
         <button mainButton class="btn btn-sm btn-outline-primary border-0 align-items-center d-flex gap-2"
-            [class.text-bg-primary]="physicalLayerListEnabled"
-            (click)="physicalLayerListEnabled = !physicalLayerListEnabled" [title]="'LAYERMANAGER.enablePhysicalLayerList' |
+            [class.text-bg-primary]="physicalLayerListEnabled()"
+            (click)="togglePhysicalLayerList()" [title]="'LAYERMANAGER.enablePhysicalLayerList' |
         translateHs"> {{'COMMON.reorder' | translateHs}}
             <i class="glyphicon icon-layerorder"></i>
         </button>
@@ -21,7 +21,7 @@
                 <i class="glyphicon icon-fatredo"></i>&nbsp;{{'LAYERMANAGER.resetMap' |
                 translateHs }}
             </a>
-            @if(hsLayerManagerService.data.layers?.length > 0 && !physicalLayerListEnabled){
+            @if(hsLayerManagerService.data.layers?.length > 0 && !physicalLayerListEnabled()){
             <a class="dropdown-item" (click)="toggleVisibilityForAll()">
                 <i class="glyphicon me-0" [ngClass]="allLayersVisible ? 'hs-checkmark' : 'hs-uncheckmark'"></i>
                 {{'LAYERMANAGER.toggleAllLayerVisibility'|translateHs}}
@@ -132,7 +132,7 @@
                 <span class="align-middle" style="line-height: 2em;">{{ 'LAYERMANAGER.mapContent' | translateHs}}</span>
             </li>
             }
-            @if(!physicalLayerListEnabled){
+            @if(!physicalLayerListEnabled()){
             @for(entry of hsLayerManagerService.data.folders() | keyvalue :keepOrder; track entry.key){
             <ul class="list-group hs-lm-layerlist mb-1">
                 @if(hsLayerManagerService.data.folders().size > 1){

--- a/projects/hslayers/components/layer-manager/layer-manager.component.ts
+++ b/projects/hslayers/components/layer-manager/layer-manager.component.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   OnInit,
   ViewChild,
+  signal,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -66,7 +67,7 @@ export class HsLayerManagerComponent
   composition_id: string;
   layerlistVisible: boolean;
   hovering: boolean;
-  physicalLayerListEnabled = false;
+  physicalLayerListEnabled = signal(false);
   cesiumActive$: Observable<boolean>;
   icons = [
     'bag1.svg',
@@ -122,7 +123,6 @@ export class HsLayerManagerComponent
   getThumbnail = getThumbnail;
   name = 'layerManager';
   layerTooltipDelay = 0;
-
   constructor(
     public hsCore: HslayersService,
     public hsUtilsService: HsUtilsService,
@@ -277,6 +277,10 @@ export class HsLayerManagerComponent
     this.layerTooltipDelay = this.hsConfig.layerTooltipDelay;
     this.layerlistVisible = true;
     super.ngOnInit();
+  }
+
+  togglePhysicalLayerList() {
+    this.physicalLayerListEnabled.update((enabled) => !enabled);
   }
 
   changeBaseLayerVisibility(e?, layer?: HsLayerDescriptor) {

--- a/projects/hslayers/components/layer-manager/widgets/layer-folder-widget/layer-folder-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/layer-folder-widget/layer-folder-widget.component.ts
@@ -65,6 +65,8 @@ export class HsLayerFolderWidgetComponent extends HsLayerEditorWidgetBaseCompone
     this.folderService.folderAction$.next(
       this.folderService.addLayer(this.hsLayerSelectorService.currentLayer),
     );
-    this.folderService.folderAction$.next(this.folderService.sortByZ(false));
+    this.folderService.folderAction$.next(
+      this.folderService.sortByZ({debounce: false}),
+    );
   }
 }

--- a/projects/hslayers/components/layer-manager/widgets/layer-folder-widget/layer-folder-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/layer-folder-widget/layer-folder-widget.component.ts
@@ -65,6 +65,6 @@ export class HsLayerFolderWidgetComponent extends HsLayerEditorWidgetBaseCompone
     this.folderService.folderAction$.next(
       this.folderService.addLayer(this.hsLayerSelectorService.currentLayer),
     );
-    this.folderService.folderAction$.next(this.folderService.sortByZ());
+    this.folderService.folderAction$.next(this.folderService.sortByZ(false));
   }
 }

--- a/projects/hslayers/services/add-data/common-file.service.ts
+++ b/projects/hslayers/services/add-data/common-file.service.ts
@@ -515,7 +515,7 @@ export class HsAddDataCommonFileService extends HsAddDataCommonFileServiceParams
    */
   handleLaymanError(response: PostPatchLayerResponse): void {
     const errorMessage =
-      response?.error?.message ?? response?.message == 'Wrong parameter value'
+      (response?.error?.message ?? response?.message == 'Wrong parameter value')
         ? `${response?.message} : ${response?.detail.parameter}`
         : response?.message;
     const errorDetails = response?.detail?.missing_extensions
@@ -577,6 +577,7 @@ export class HsAddDataCommonFileService extends HsAddDataCommonFileServiceParams
               descriptor.style.url,
             )
           : undefined,
+        group: false, //Make sure WMS layer is not set as group, no effect on others
       },
     });
   }

--- a/projects/hslayers/services/add-data/url/add-data-ows.service.ts
+++ b/projects/hslayers/services/add-data/url/add-data-ows.service.ts
@@ -20,7 +20,7 @@ import {
 } from 'hslayers-ng/services/get-capabilities';
 import {HsLogService} from 'hslayers-ng/services/log';
 
-import {AddDataUrlType} from 'hslayers-ng/types';
+import {AddDataUrlType, LayerOptions} from 'hslayers-ng/types';
 import {HsHistoryListService} from 'hslayers-ng/common/history-list';
 import {HsUrlTypeServiceModel} from 'hslayers-ng/types';
 import {LayerConnection, OwsConnection} from 'hslayers-ng/types';
@@ -90,6 +90,7 @@ export class HsAddDataOwsService {
       this.hsAddDataCommonService.throwParsingError(wrapper.response);
       return [];
     } else {
+      this.overwriteServiceDefaults(options?.layerOptions);
       const response = await this.typeService.listLayerFromCapabilities(
         wrapper,
         options?.layerOptions,
@@ -118,6 +119,18 @@ export class HsAddDataOwsService {
       }
 
       return response;
+    }
+  }
+
+  /**
+   * Overwrites service defaults with layerOptions
+   * @param layerOptions - Layer options to overwrite
+   */
+  overwriteServiceDefaults(layerOptions: LayerOptions): void {
+    for (const key in layerOptions) {
+      if (Object.hasOwn(this.typeService.data, key)) {
+        this.typeService.data[key] = layerOptions[key];
+      }
     }
   }
 

--- a/projects/hslayers/services/add-data/url/arcgis.service.ts
+++ b/projects/hslayers/services/add-data/url/arcgis.service.ts
@@ -55,7 +55,7 @@ export class HsUrlArcGisService implements HsUrlTypeServiceModel {
       map_projection: '',
       tile_size: 512,
       use_resampling: false,
-      use_tiles: true,
+      useTiles: true,
       table: {
         trackBy: 'id',
         nameProperty: 'name',

--- a/projects/hslayers/services/add-data/url/wms.service.ts
+++ b/projects/hslayers/services/add-data/url/wms.service.ts
@@ -64,7 +64,7 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
       map_projection: '',
       tile_size: 512,
       use_resampling: false,
-      use_tiles: true,
+      useTiles: true,
       visible: true,
       table: {
         trackBy: 'Name',
@@ -475,10 +475,9 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
       },
       crossOrigin: 'anonymous',
     };
-    const USE_TILES = options.useTiles ?? this.data.use_tiles;
-    const source: ImageWMS | TileWMS = !USE_TILES
-      ? new ImageWMS(sourceOptions)
-      : new TileWMS(sourceOptions);
+    const source: ImageWMS | TileWMS = this.data.useTiles
+      ? new TileWMS(sourceOptions)
+      : new ImageWMS(sourceOptions);
     const metadata =
       this.hsWmsGetCapabilitiesService.getMetadataObjectWithUrls(layer);
     const view = this.hsMapService.getMap().getView();
@@ -518,10 +517,10 @@ export class HsUrlWmsService implements HsUrlTypeServiceModel {
      */
     layerOptions['capsExtentSet'] = !!layerOptions.extent;
 
-    const new_layer = USE_TILES
+    const new_layer = this.data.useTiles
       ? new Tile(layerOptions as TileOptions<TileSource>)
       : new ImageLayer(layerOptions as ImageOptions<ImageSource>);
-    this.hsMapService.proxifyLayerLoader(new_layer, USE_TILES);
+    this.hsMapService.proxifyLayerLoader(new_layer, this.data.useTiles);
     return new_layer;
   }
 

--- a/projects/hslayers/services/layer-manager/layer-manager-folder.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager-folder.service.ts
@@ -60,7 +60,7 @@ export class HsLayerManagerFolderService {
     private hsConfig: HsConfig,
   ) {
     this.sortSubject.pipe(debounceTime(this.sortDebounceTime)).subscribe(() => {
-      this.folderAction$.next(this.sortByZ(false));
+      this.folderAction$.next(this.sortByZ({debounce: false}));
     });
   }
 
@@ -104,11 +104,11 @@ export class HsLayerManagerFolderService {
     };
   }
 
-  sortByZ(debounce = true): SortFoldersByZAction {
+  sortByZ(options = {debounce: true}): SortFoldersByZAction {
     return {
       type: FolderActionTypes.SORT_BY_Z,
       lyr: undefined,
-      debounce: debounce,
+      debounce: options.debounce,
     };
   }
 

--- a/projects/hslayers/services/layer-manager/layer-manager.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager.service.ts
@@ -182,7 +182,7 @@ export class HsLayerManagerService {
       }
 
       this.folderService.folderAction$.next(this.folderService.sortByZ());
-      this.sortLayersByZ(this.data.layers);
+      this.folderService.sortLayersByZ(this.data.layers);
       this.hsEventBusService.layerManagerUpdates.next(null);
       this.toggleEditLayerByUrlParam();
 
@@ -388,16 +388,11 @@ export class HsLayerManagerService {
    */
   updateLayerListPositions(): void {
     //TODO: We could also sort by title or other property. Not supported right now though, just zIndex
-    this.data.layers = this.sortLayersByZ(this.data.layers);
+    this.folderService.folderAction$.next(this.folderService.sortByZ());
   }
 
   sortLayersByZ(arr: any[]): any[] {
-    const minus = this.hsConfig.reverseLayerList ?? true;
-    return arr.sort((a, b) => {
-      a = a.layer.getZIndex();
-      b = b.layer.getZIndex();
-      return (a < b ? -1 : a > b ? 1 : 0) * (minus ? -1 : 1);
-    });
+    return this.folderService.sortLayersByZ(arr);
   }
 
   /**

--- a/projects/hslayers/services/layer-shifting/layer-shifting.service.ts
+++ b/projects/hslayers/services/layer-shifting/layer-shifting.service.ts
@@ -58,7 +58,7 @@ export class HsLayerShiftingService {
     if (!this.layerFilter()) {
       return;
     }
-    this.layersCopy = this.hsLayerManagerService.sortLayersByZ(
+    this.layersCopy = this.hsFolderService.sortLayersByZ(
       this.layerFilter().map((l) => {
         return {title: l.title, layer: l.layer};
       }),

--- a/projects/hslayers/test/layer-manager/layer-manager.folder.service.spec.ts
+++ b/projects/hslayers/test/layer-manager/layer-manager.folder.service.spec.ts
@@ -101,7 +101,7 @@ describe('HsLayerManagerFolderService', () => {
   });
 
   it('should reorder folders by zIndex', () => {
-    service.folderAction$.next(service.sortByZ());
+    service.folderAction$.next(service.sortByZ({debounce: false}));
     expect(Array.from(service.data.folders().keys())[0]).toEqual(
       'Path with higher zIndex',
     );
@@ -109,7 +109,7 @@ describe('HsLayerManagerFolderService', () => {
 
   it('should remain in the original order after reorder', () => {
     hsConfig.reverseLayerList = false;
-    service.folderAction$.next(service.sortByZ());
+    service.folderAction$.next(service.sortByZ({debounce: false}));
     expect(Array.from(service.data.folders().keys())[0]).toEqual('other');
   });
 

--- a/projects/hslayers/types/add-data/data-object.type.ts
+++ b/projects/hslayers/types/add-data/data-object.type.ts
@@ -36,7 +36,7 @@ export type UrlDataObject = {
   tile_size?: number;
   title?: string;
   use_resampling?: boolean;
-  use_tiles?: boolean;
+  useTiles?: boolean;
   version?: string;
   visible?: boolean;
   table: {

--- a/projects/hslayers/types/compositions/composition-layer-options.type.ts
+++ b/projects/hslayers/types/compositions/composition-layer-options.type.ts
@@ -17,7 +17,13 @@ export type LayerOptions = {
   crs?: string;
   opacity?: number;
 
-  //WMS
+  //****WMS****//
+
+  /**
+   * Normally used to determine if layer is a group of sublayers or single layers.
+   * Set to false when loading layer after an upload to parse correct layer name
+   */
+  group?: boolean;
   useTiles?: boolean;
   base?: boolean;
   imageFormat?: string;


### PR DESCRIPTION
## Description

Fixes for few bugs:
-  messy rendering of map-swipe layers caused by swipe position not set correctly
-  Sort layers inside folders. Currently only folders were sorted, layers themselves where displayed in inital order
-  Layers not being removed from map when executed from catalgoue as a result of incorrectly set layer name. 

Along that :
- give priority to the property values in layerOptions over those in service defults
- Unify use_tiles and useTiles properties used in add-data

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
