### PR TITLE
Toolbar updates

### DIFF
--- a/projects/hslayers/common/panels/panel-container.component.ts
+++ b/projects/hslayers/common/panels/panel-container.component.ts
@@ -54,13 +54,13 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
       this.service.panelObserver.complete();
       this.service.panelObserver = new ReplaySubject<HsPanelItem>();
     }
-    for (const p of this.service.panels) {
+    for (const p of this.service.panels()) {
       this.service.destroy(p);
     }
   }
 
   ngOnInit(): void {
-    this.service.panels = [];
+    this.service.panels.set([]);
     (this.panelObserver ?? this.service.panelObserver)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((item: HsPanelItem) => {
@@ -96,7 +96,7 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
       Object.assign(panelItem.data, this.data);
       componentRefInstance.data = panelItem.data;
     }
-    this.service.panels.push(componentRefInstance);
+    this.service.panels.update((panels) => [...panels, componentRefInstance]);
     if (!componentRefInstance.isVisible$) {
       this.hsLog.warn(
         componentRefInstance,

--- a/projects/hslayers/common/panels/panel-container.service.interface.ts
+++ b/projects/hslayers/common/panels/panel-container.service.interface.ts
@@ -1,12 +1,12 @@
 import {ReplaySubject, Subject} from 'rxjs';
-import {Type} from '@angular/core';
+import {Type, WritableSignal} from '@angular/core';
 
 import {HsPanelComponent} from './panel-component.interface';
 import {HsPanelItem} from './panel-item';
 import {KeyNumberDict} from 'hslayers-ng/config';
 
 export interface HsPanelContainerServiceInterface {
-  panels: HsPanelComponent[];
+  panels: WritableSignal<HsPanelComponent[]>;
   panelObserver: ReplaySubject<HsPanelItem>;
   panelDestroyObserver: Subject<any>;
   setPanelWidth?(

--- a/projects/hslayers/components/draw/draw-toolbar/draw-toolbar.component.html
+++ b/projects/hslayers/components/draw/draw-toolbar/draw-toolbar.component.html
@@ -1,60 +1,37 @@
 @if ({ position: hsLayoutService.sidebarPosition | async }; as sidebar) {
-  <button
-    class="btn btn-light hs-toolbar-button text-secondary"
-    [ngClass]="{
-      'btn-outline-danger': HsDrawService.highlightDrawButton,
+<button class="btn btn-light hs-toolbar-button text-secondary" [ngClass]="{
+      'btn-outline-danger': hsDrawService.highlightDrawButton,
       'btn-light text-secondary': !drawToolbarExpanded,
       'btn-secondary': drawToolbarExpanded,
-    }"
-    (click)="toggleDrawToolbar()"
-  >
-    <i
-      [ngClass]="{
+    }" (click)="toggleDrawToolbar()">
+  <i [ngClass]="{
         'icon-pencil': !drawToolbarExpanded,
         'icon-remove': drawToolbarExpanded,
-      }"
-      data-toggle="tooltip"
-      [title]="'PANEL_HEADER.draw' | translateHs"
-    ></i>
-  </button>
+      }" data-toggle="tooltip" [title]="'PANEL_HEADER.draw' | translateHs"></i>
+</button>
 
-  @if (drawToolbarExpanded) {
-    @defer (when drawToolbarExpanded) {
-      <hs-draw-panel
-        [inToolbar]="true"
-        class="draw-panel-popup d-block w-100 rounded-3 d-flex flex-column w-auto bg-white p-3"
-      ></hs-draw-panel>
-    }
-  }
+@if (drawToolbarExpanded) {
+@defer (when drawToolbarExpanded) {
+<hs-draw-panel [inToolbar]="true"
+  class="draw-panel-popup d-block w-100 rounded-3 d-flex flex-column w-auto bg-white p-3"></hs-draw-panel>
+}
+}
 
-  @if (HsDrawService.drawActive) {
-  <div
-    style="top: 35vh"
-    role="group"
-    class="btn-group-vertical position-fixed d-flex flex-column"
-    [ngStyle]="
+@if (hsDrawService.drawActive) {
+<div style="top: 35vh" role="group" class="btn-group-vertical position-fixed d-flex flex-column" [ngStyle]="
       sidebar.position === 'right' || sidebar.position === 'bottom'
         ? { left: 0 }
         : { right: 0 }
-    "
-  >
-      <button
-        class="btn btn-secondary"
-        (click)="HsDrawService.removeLastPoint()"
-        data-toggle="tooltip"
-        [title]="'DRAW.drawToolbar.removeLastPoint' | translateHs"
-      >
-        <i class="icon-remove-circle"></i>
-      </button>
+    ">
+  <button class="btn btn-secondary" (click)="hsDrawService.removeLastPoint()" data-toggle="tooltip"
+    [title]="'DRAW.drawToolbar.removeLastPoint' | translateHs">
+    <i class="icon-remove-circle"></i>
+  </button>
 
-      <button
-        class="btn btn-secondary"
-        (click)="finishDrawing()"
-        data-toggle="tooltip"
-        [title]="'DRAW.drawToolbar.finishFeature' | translateHs"
-      >
-        <i class="icon-check"></i>
-      </button>
-    </div>
-  }
+  <button class="btn btn-secondary" (click)="finishDrawing()" data-toggle="tooltip"
+    [title]="'DRAW.drawToolbar.finishFeature' | translateHs">
+    <i class="icon-check"></i>
+  </button>
+</div>
+}
 }

--- a/projects/hslayers/config/config.service.ts
+++ b/projects/hslayers/config/config.service.ts
@@ -316,7 +316,7 @@ export class HsConfig extends HsConfigObject {
       val.url = (this.assetsPath ?? '') + val.url;
       return val;
     });
-    Object.assign(this.componentsEnabled, newConfig.componentsEnabled);
+    this.componentsEnabled = this.updateComponentsEnabled(newConfig);
     //Delete since we assign the whole object later and don't want it replaced, but merged
     delete newConfig.componentsEnabled;
     Object.assign(this.panelWidths, newConfig.panelWidths);
@@ -337,6 +337,29 @@ export class HsConfig extends HsConfigObject {
     this.assetsPath += this.assetsPath.endsWith('/') ? '' : '/';
 
     this.configChanges.next();
+  }
+
+  /**
+   * Merges componentsEnabled from newConfig with existing componentsEnabled
+   * Preserves the order of keys from newConfig.componentsEnabled
+   */
+  updateComponentsEnabled?(
+    newConfig: HsConfigObject,
+  ): HsConfigObject['componentsEnabled'] {
+    // Merging the keys into a Set to keep the order from newConfig.componentsEnabled first
+    const orderedKeys = new Set([
+      ...Object.keys(newConfig.componentsEnabled),
+      ...Object.keys(this.componentsEnabled),
+    ]);
+
+    // Creating a new object with the desired key order
+    const mergedComponentsEnabled = {};
+    orderedKeys.forEach((key) => {
+      mergedComponentsEnabled[key] =
+        newConfig.componentsEnabled[key] ?? this.componentsEnabled[key];
+    });
+
+    return mergedComponentsEnabled;
   }
 
   /**

--- a/projects/hslayers/services/draw/draw.service.ts
+++ b/projects/hslayers/services/draw/draw.service.ts
@@ -88,14 +88,6 @@ export class HsDrawService extends HsDrawServiceParams {
     this.keyUp = this.keyUp.bind(this);
     this.hsMapService.loaded().then((map) => {
       this.fillDrawableLayers();
-      this.hsMapService.getLayersArray().forEach((l) =>
-        l.on('change:visible', (e) => {
-          if (this.draw && l == this.selectedLayer) {
-            this.setType(this.type);
-          }
-          this.fillDrawableLayers();
-        }),
-      );
 
       this.modify = new Modify({
         features: this.selectedFeatures,

--- a/projects/hslayers/services/panel-constructor/overlay-constructor.service.ts
+++ b/projects/hslayers/services/panel-constructor/overlay-constructor.service.ts
@@ -1,10 +1,10 @@
+import {HsQueryPopupService} from 'hslayers-ng/common/query-popup';
 import {
-  EnvironmentInjector,
   Injectable,
+  Injector,
   inject,
   runInInjectionContext,
 } from '@angular/core';
-import {HsQueryPopupService} from 'hslayers-ng/common/query-popup';
 import {filter, firstValueFrom, map, take, tap} from 'rxjs';
 
 import {HsConfig} from 'hslayers-ng/config';
@@ -17,7 +17,7 @@ import {toObservable} from '@angular/core/rxjs-interop';
   providedIn: 'root',
 })
 export class HsOverlayConstructorService extends HsPanelContainerService {
-  private injector = inject(EnvironmentInjector);
+  private injector = inject(Injector);
 
   panels$ = toObservable(this.hsToolbarPanelContainerService.panels);
 

--- a/projects/hslayers/services/panel-constructor/panel-constructor.service.ts
+++ b/projects/hslayers/services/panel-constructor/panel-constructor.service.ts
@@ -25,7 +25,7 @@ export class HsPanelConstructorService {
         (acc, [panel, isEnabled]) => (isEnabled ? [...acc, panel] : acc),
         [],
       );
-      const created = this.HsPanelContainerService.panels.map((p) => p.name);
+      const created = this.HsPanelContainerService.panels().map((p) => p.name);
       const toBeCreated = activePanels.filter((p) => !created.includes(p));
       for (const panel of toBeCreated) {
         await this._createPanel(panel);

--- a/projects/hslayers/services/panels/panel-container.service.ts
+++ b/projects/hslayers/services/panels/panel-container.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, Type} from '@angular/core';
+import {Injectable, Type, signal} from '@angular/core';
 import {ReplaySubject, Subject} from 'rxjs';
 
 import {HsPanelComponent} from 'hslayers-ng/common/panels';
@@ -10,7 +10,7 @@ import {HsPanelItem} from 'hslayers-ng/common/panels';
 })
 export class HsPanelContainerService
   implements HsPanelContainerServiceInterface {
-  panels: HsPanelComponent[] = [];
+  panels = signal<HsPanelComponent[]>([]);
   panelObserver: ReplaySubject<HsPanelItem> = new ReplaySubject();
   panelDestroyObserver: Subject<any> = new Subject();
 
@@ -41,7 +41,7 @@ export class HsPanelContainerService
     if (component.cleanup) {
       component.cleanup();
     }
-    const panelCollection = this.panels;
+    const panelCollection = this.panels();
     const panelIx = panelCollection.findIndex((d) => d == component);
     if (panelIx > -1) {
       panelCollection.splice(panelIx, 1);

--- a/projects/hslayers/services/utils/layer-utils.service.ts
+++ b/projects/hslayers/services/utils/layer-utils.service.ts
@@ -433,10 +433,14 @@ export class HsLayerUtilsService {
    * @param layer - Layer to check
    * @returns True if layer is drawable vector layer
    */
-  isLayerDrawable(layer: Layer<Source>): boolean {
+  isLayerDrawable(
+    layer: Layer<Source>,
+    options: {checkVisible?: boolean} = {},
+  ): boolean {
+    const checkVisible = options.checkVisible ?? true;
     return (
       this.isLayerVectorLayer(layer, false) &&
-      layer.getVisible() &&
+      (checkVisible ? layer.getVisible() : true) &&
       this.isLayerInManager(layer) &&
       this.hasLayerTitle(layer) &&
       this.isLayerEditable(layer)


### PR DESCRIPTION
## Description

- fill drawable layers on when draw tooblar is opened. In sidebar layers are updated on mainPanel change
- predictable toolbar tools order defined by componentEnabled keys order. `search` -> `draw` -> `measure` by default

## Related issues or pull requests

closes #5355 
closes #5348

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
