### PR TITLE
Filters update

### DIFF
--- a/projects/hslayers/assets/locales/cs.json
+++ b/projects/hslayers/assets/locales/cs.json
@@ -321,7 +321,8 @@
     "copyToClipboardFailure": "Nelze zkopírovat. Váš prohlížeč nepodporuje potřebné funkce.",
     "base": "Podkladová mapa",
     "thematic": "Tematická mapa",
-    "contains": "obsahuje"
+    "contains": "obsahuje",
+    "property": "Atribut"
   },
   "COMPOSITIONS": {
     "addByAddress": "Přidat kompozici z adresy",

--- a/projects/hslayers/assets/locales/en.json
+++ b/projects/hslayers/assets/locales/en.json
@@ -321,7 +321,8 @@
     "copyToClipboardFailure": "Could not copy. Clipboard API not supported in your browser.",
     "base": "Basemap",
     "thematic": "Thematic map",
-    "contains": "contains"
+    "contains": "contains",
+    "property": "Property"
   },
   "COMPOSITIONS": {
     "addByAddress": "Add composition by address",

--- a/projects/hslayers/assets/locales/lv.json
+++ b/projects/hslayers/assets/locales/lv.json
@@ -298,7 +298,8 @@
     "copyToClipboardFailure": "Nevar kopēt. Jūsu pārlūkprogramma neatbalsta nepieciešamās funkcijas.",
     "base": "Pamatkarte",
     "thematic": "Tematiskā karte",
-    "contains": "satur"
+    "contains": "satur",
+    "property": "Īpašība"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pievienot kompozīciju pēc adreses",

--- a/projects/hslayers/assets/locales/sk.json
+++ b/projects/hslayers/assets/locales/sk.json
@@ -321,7 +321,8 @@
     "copyToClipboardFailure": "Nie je možné kopírovať. \nVáš prehliadač nepodporuje potrebné funkcie.",
     "base": "Podkladová mapa",
     "thematic": "Tematická mapa",
-    "contains": "obsahuje"
+    "contains": "obsahuje",
+    "property": "Atribút"
   },
   "COMPOSITIONS": {
     "addByAddress": "Pridať kompozíciu z adresy",

--- a/projects/hslayers/common/filters/comparison-filter/attribute-selector/attribute-selector.component.ts
+++ b/projects/hslayers/common/filters/comparison-filter/attribute-selector/attribute-selector.component.ts
@@ -1,0 +1,63 @@
+import {Component, forwardRef, input} from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormsModule,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import {TranslateCustomPipe} from 'hslayers-ng/services/language';
+
+@Component({
+  selector: 'hs-attribute-selector',
+  standalone: true,
+  imports: [FormsModule, ReactiveFormsModule, TranslateCustomPipe],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      // eslint-disable-next-line no-use-before-define
+      useExisting: forwardRef(() => HsAttributeSelectorComponent),
+      multi: true,
+    },
+  ],
+  template: `
+    <select
+      class="form-control form-select hs-comparison-filter-attribute h-100 border-end-0"
+      [(ngModel)]="value"
+      (ngModelChange)="onChange($event)"
+      (blur)="onTouched()"
+      [disabled]="disabled"
+    >
+      <option [ngValue]="null" [disabled]="true" hidden>
+        {{ 'FILTERS.pickAnAttribute' | translateHs }}
+      </option>
+      @for (attr of attributes(); track attr) {
+        <option [ngValue]="attr">{{ attr }}</option>
+      }
+    </select>
+  `,
+})
+export class HsAttributeSelectorComponent implements ControlValueAccessor {
+  attributes = input.required<string[]>();
+
+  value: string = null;
+  disabled = false;
+
+  onChange: (value: string) => void = () => {};
+  onTouched: () => void = () => {};
+
+  writeValue(value: string): void {
+    this.value = value;
+  }
+
+  registerOnChange(fn: (value: string) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+}

--- a/projects/hslayers/common/filters/comparison-filter/attribute-selector/attribute-selector.component.ts
+++ b/projects/hslayers/common/filters/comparison-filter/attribute-selector/attribute-selector.component.ts
@@ -8,7 +8,7 @@ import {
 import {TranslateCustomPipe} from 'hslayers-ng/services/language';
 
 @Component({
-  selector: 'hs-attribute-selector',
+  selector: 'hs-filters-attribute-selector',
   standalone: true,
   imports: [FormsModule, ReactiveFormsModule, TranslateCustomPipe],
   providers: [

--- a/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
+++ b/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
@@ -67,11 +67,11 @@
 <div class="comparison-filter-value-source btn-group w-100 p-1 d-flex justify-content-end">
   <button type="button" class="btn btn-sm btn-outline-secondary p-1 border-0 rounded-0 w-25 flex-grow-0"
     [class.active]="valueSource() === 'value'" (click)="toggleValueSource('value')">
-    Value
+    {{'COMMON.value' | translateHs}}
   </button>
   <button type="button" class="btn btn-sm btn-outline-secondary p-1 border-0 rounded-0 w-25 flex-grow-0"
     [class.active]="valueSource() === 'property'" (click)="toggleValueSource('property')">
-    Property
+    {{'COMMON.property' | translateHs}}
   </button>
 </div>
 }

--- a/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
+++ b/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
@@ -1,7 +1,8 @@
 <div class="comparison-filter-container d-flex flex-row form-group p-1 position-relative mb-0"
   [ngClass]="{'expanded': expanded()}">
-  <hs-attribute-selector [attributes]="attributes" [formControl]="attributeControl" (ngModelChange)="emitChange()">
-  </hs-attribute-selector>
+  <hs-filters-attribute-selector [attributes]="attributes" [formControl]="attributeControl"
+    (ngModelChange)="emitChange()">
+  </hs-filters-attribute-selector>
 
   <select class=" form-control form-select hs-comparison-filter-operator" style="width: min-content"
     [ngModel]="selectedOperator()" (change)="onOperatorChange($event)" name="hs-sld-filter-comparison-sign"
@@ -23,8 +24,8 @@
       [(value)]="_filter[2]" (change)="emitChange()">
     </hs-filter-range-input>
     } @else if(valueSource() === 'property') {
-    <hs-attribute-selector [attributes]="attributes" [ngModel]="_filter[2]" (ngModelChange)="emitChange()">
-    </hs-attribute-selector>
+    <hs-filters-attribute-selector [attributes]="attributes" [ngModel]="_filter[2]" (ngModelChange)="emitChange()">
+    </hs-filters-attribute-selector>
     }
     }
     @else {

--- a/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
+++ b/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
@@ -1,4 +1,5 @@
-<div class="comparison-filter-container d-flex flex-row form-group p-1 position-relative" [ngClass]="{'expanded': expanded()}">
+<div class="comparison-filter-container d-flex flex-row form-group p-1 position-relative"
+  [ngClass]="{'expanded': expanded()}">
   <select class="form-control form-select hs-comparison-filter-attribute" [formControl]="attributeControl"
     name="hs-sld-filter-attribute">
     <option [ngValue]="null" [disabled]="true" selected hidden>{{'FILTERS.pickAnAttribute' | translateHs}}</option>
@@ -10,43 +11,42 @@
 
   </select>
 
-  <select (change)="emitChange()" class="form-control form-select hs-comparison-filter-operator"
-    style="width: min-content" [(ngModel)]="filter[0]" name="hs-sld-filter-comparison-sign"
+  <select class="form-control form-select hs-comparison-filter-operator" style="width: min-content"
+    [ngModel]="selectedOperator()" (change)="onOperatorChange($event)" name="hs-sld-filter-comparison-sign"
     [disabled]="!attributeControl.value">
-    @for (op of operators | async ; track op.value) {
-    <option [ngValue]="op.value">
+    @for (op of operators | async; track op.alias) {
+    <option [value]="op.alias">
       {{op.alias | translateHs : 'COMMON'}}
     </option>
     }
   </select>
-  <div class="comparison-filter-value" >
-      @if(currentAttribute()?.range){
-        <hs-filter-range-input
-          [min]="currentAttribute()?.range.min"
-          [max]="currentAttribute()?.range.max"
-          [(value)]="filter[2]"
-          (change)="emitChange()"
-          >
-        </hs-filter-range-input>
-      }
-      @else {
-        @if(filter[0] === '*=') {
-          <input class="form-select h-100" [(ngModel)]="filter[2]" (change)="emitChange()"
-            [disabled]="!attributeControl.value" [attr.list]="'customValues'" />
-          <datalist id="customValues">
-            @for (value of currentAttribute()?.values; track value) {
-            <option [value]="value">
-            }
-          </datalist>
-        } @else {
-          <select class="form-control form-select h-100" [(ngModel)]="filter[2]" (change)="emitChange()"
-            [disabled]="!attributeControl.value">
-            @for (value of currentAttribute()?.values; track value) {
-            <option [ngValue]="value">{{value}}</option>
-            }
-          </select>
+  <div class="comparison-filter-value">
+    @if(customOperatorSelected()){
+    <input class="form-select h-100 rounded-0" disabled value='NULL' />
+    }
+    @else if(currentAttribute()?.range){
+    <hs-filter-range-input [min]="currentAttribute()?.range.min" [max]="currentAttribute()?.range.max"
+      [(value)]="filter[2]" (change)="emitChange()">
+    </hs-filter-range-input>
+    }
+    @else {
+    @if(filter[0] === '*=') {
+    <input class="form-select h-100" [(ngModel)]="filter[2]" (change)="emitChange()"
+      [disabled]="!attributeControl.value" [attr.list]="'customValues'" />
+    <datalist id="customValues">
+      @for (value of currentAttribute()?.values; track value) {
+      <option [value]="value">
         }
+    </datalist>
+    } @else {
+    <select class="form-control form-select h-100" [(ngModel)]="filter[2]" (change)="emitChange()"
+      [disabled]="!attributeControl.value">
+      @for (value of currentAttribute()?.values; track value) {
+      <option [ngValue]="value">{{value}}</option>
       }
+    </select>
+    }
+    }
   </div>
 
   <div>

--- a/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
+++ b/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.html
@@ -1,17 +1,9 @@
-<div class="comparison-filter-container d-flex flex-row form-group p-1 position-relative"
+<div class="comparison-filter-container d-flex flex-row form-group p-1 position-relative mb-0"
   [ngClass]="{'expanded': expanded()}">
-  <select class="form-control form-select hs-comparison-filter-attribute" [formControl]="attributeControl"
-    name="hs-sld-filter-attribute">
-    <option [ngValue]="null" [disabled]="true" selected hidden>{{'FILTERS.pickAnAttribute' | translateHs}}</option>
-    @for(attr of attributes; track attr){
-    <option [ngValue]="attr">
-      {{ attr }}
-    </option>
-    }
+  <hs-attribute-selector [attributes]="attributes" [formControl]="attributeControl" (ngModelChange)="emitChange()">
+  </hs-attribute-selector>
 
-  </select>
-
-  <select class="form-control form-select hs-comparison-filter-operator" style="width: min-content"
+  <select class=" form-control form-select hs-comparison-filter-operator" style="width: min-content"
     [ngModel]="selectedOperator()" (change)="onOperatorChange($event)" name="hs-sld-filter-comparison-sign"
     [disabled]="!attributeControl.value">
     @for (op of operators | async; track op.alias) {
@@ -25,13 +17,19 @@
     <input class="form-select h-100 rounded-0" disabled value='NULL' />
     }
     @else if(currentAttribute()?.range){
+    @if(valueSource() === 'value'){
+
     <hs-filter-range-input [min]="currentAttribute()?.range.min" [max]="currentAttribute()?.range.max"
-      [(value)]="filter[2]" (change)="emitChange()">
+      [(value)]="_filter[2]" (change)="emitChange()">
     </hs-filter-range-input>
+    } @else if(valueSource() === 'property') {
+    <hs-attribute-selector [attributes]="attributes" [ngModel]="_filter[2]" (ngModelChange)="emitChange()">
+    </hs-attribute-selector>
+    }
     }
     @else {
-    @if(filter[0] === '*=') {
-    <input class="form-select h-100" [(ngModel)]="filter[2]" (change)="emitChange()"
+    @if(_filter[0] === '*=') {
+    <input class=" form-select h-100" [(ngModel)]="_filter[2]" (change)="emitChange()"
       [disabled]="!attributeControl.value" [attr.list]="'customValues'" />
     <datalist id="customValues">
       @for (value of currentAttribute()?.values; track value) {
@@ -39,7 +37,7 @@
         }
     </datalist>
     } @else {
-    <select class="form-control form-select h-100" [(ngModel)]="filter[2]" (change)="emitChange()"
+    <select class="form-control form-select h-100" [(ngModel)]="_filter[2]" (change)="emitChange()"
       [disabled]="!attributeControl.value">
       @for (value of currentAttribute()?.values; track value) {
       <option [ngValue]="value">{{value}}</option>
@@ -48,7 +46,6 @@
     }
     }
   </div>
-
   <div>
     <button class="btn btn-outline-danger btn-sm rounded-0" style="height: 100%" (click)="remove()">
       <span class="icon-trash"></span>
@@ -65,3 +62,15 @@
   </div>
   }
 </div>
+@if(currentAttribute()?.range && !isWfsFilter()){
+<div class="comparison-filter-value-source btn-group w-100 p-1 d-flex justify-content-end">
+  <button type="button" class="btn btn-sm btn-outline-secondary p-1 border-0 rounded-0 w-25 flex-grow-0"
+    [class.active]="valueSource() === 'value'" (click)="toggleValueSource('value')">
+    Value
+  </button>
+  <button type="button" class="btn btn-sm btn-outline-secondary p-1 border-0 rounded-0 w-25 flex-grow-0"
+    [class.active]="valueSource() === 'property'" (click)="toggleValueSource('property')">
+    Property
+  </button>
+</div>
+}

--- a/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.scss
+++ b/projects/hslayers/common/filters/comparison-filter/comparison-filter.component.scss
@@ -1,3 +1,8 @@
+:host {
+    display: block;
+    padding-bottom: 0.75rem;
+}
+
 .comparison-filter-container {
     position: relative;
     min-height: 50px;
@@ -30,4 +35,10 @@
     justify-content: center;
     align-items: center;
     z-index: 1000;
+}
+
+.comparison-filter-value-source {
+    button {
+        font-size: 0.7rem;
+    }
 }

--- a/projects/hslayers/common/filters/filters.component.ts
+++ b/projects/hslayers/common/filters/filters.component.ts
@@ -3,6 +3,7 @@ import {Component, Input, inject, viewChild} from '@angular/core';
 import {FilterType} from 'hslayers-ng/types';
 import {HsAddFilterButtonComponent} from './add-filter-button/add-filter-button.component';
 import {HsComparisonFilterComponent} from './comparison-filter/comparison-filter.component';
+import {HsEventBusService} from 'hslayers-ng/services/event-bus';
 import {HsFilterComponent} from './filter.component';
 import {HsFiltersService} from './filters.service';
 import {HsLayerDescriptor} from 'hslayers-ng/types';
@@ -28,6 +29,8 @@ export class HsFiltersComponent extends HsStylerPartBaseComponent {
   addFilterButton = viewChild<HsAddFilterButtonComponent>('addFilterButton');
 
   hsFiltersService = inject(HsFiltersService);
+  hsEventBusService = inject(HsEventBusService);
+
   constructor() {
     super();
   }
@@ -42,6 +45,7 @@ export class HsFiltersComponent extends HsStylerPartBaseComponent {
   remove(): void {
     delete this.rule.filter;
     this.addFilterButton().setActiveTab(undefined);
+    this.hsEventBusService.resetWfsFilter.next();
     this.emitChange();
   }
 }

--- a/projects/hslayers/common/filters/filters.service.ts
+++ b/projects/hslayers/common/filters/filters.service.ts
@@ -110,6 +110,9 @@ export class HsFiltersService {
    * Checks if a filter can be deleted
    */
   private canDeleteFilter(parent: Filter): boolean {
+    if (!Array.isArray(parent)) {
+      return false;
+    }
     return (
       (['||', '&&'].includes(parent[0]) && parent.length > 3) ||
       (parent[0] === '!' && parent.length > 2)
@@ -146,7 +149,7 @@ export class HsFiltersService {
    * @returns True if the filter was successfully removed, false otherwise
    */
   removeFilter(parent: Filter, filter: Filter): boolean {
-    if (this.canDeleteFilter(parent)) {
+    if (Array.isArray(parent) && this.canDeleteFilter(parent)) {
       const index = parent.findIndex((item) => item === filter);
       if (index !== -1) {
         parent.splice(index, 1);

--- a/projects/hslayers/components/wfs-filter/wfs-filter.component.ts
+++ b/projects/hslayers/components/wfs-filter/wfs-filter.component.ts
@@ -117,6 +117,12 @@ export class HsWfsFilterComponent extends HsPanelBaseComponent {
         'boundedBy',
       ];
     });
+
+    this.hsEventBusService.resetWfsFilter
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => {
+        this.updateLayer(this.selectedLayer(), undefined, undefined);
+      });
   }
 
   /**
@@ -352,20 +358,30 @@ export class HsWfsFilterComponent extends HsPanelBaseComponent {
         );
         return;
       }
-
       const parsedFilter = this.parseFilter(currentFilter);
-      selectedLayer.layer.set('wfsFilter', this.rule());
-      const source = selectedLayer.layer.getSource();
-      source.set('filter', parsedFilter);
-      source.refresh();
-      /**
-       * Manually pull features from WFS if layer is from Layman
-       */
-      if (getWorkspace(selectedLayer.layer)) {
-        this.hsEventBusService.refreshLaymanLayer.next(
-          selectedLayer.layer as VectorLayer<VectorSource>,
-        );
-      }
+      this.updateLayer(selectedLayer, parsedFilter, this.rule());
+    }
+  }
+
+  /**
+   * Updates the layer with the parsed filter
+   */
+  updateLayer(
+    selectedLayer: HsLayerDescriptor,
+    parsedFilter: any,
+    wfsFilter: any[],
+  ) {
+    selectedLayer.layer.set('wfsFilter', wfsFilter);
+    const source = selectedLayer.layer.getSource();
+    source.set('filter', parsedFilter);
+    source.refresh();
+    /**
+     * Manually pull features from WFS if layer is from Layman
+     */
+    if (getWorkspace(selectedLayer.layer)) {
+      this.hsEventBusService.refreshLaymanLayer.next(
+        selectedLayer.layer as VectorLayer<VectorSource>,
+      );
     }
   }
 

--- a/projects/hslayers/components/wfs-filter/wfs-filter.component.ts
+++ b/projects/hslayers/components/wfs-filter/wfs-filter.component.ts
@@ -119,7 +119,10 @@ export class HsWfsFilterComponent extends HsPanelBaseComponent {
     });
 
     this.hsEventBusService.resetWfsFilter
-      .pipe(takeUntilDestroyed())
+      .pipe(
+        takeUntilDestroyed(),
+        filter(() => this.hsLayoutService.mainpanel === 'wfsFilter'),
+      )
       .subscribe(() => {
         this.updateLayer(this.selectedLayer(), undefined, undefined);
       });

--- a/projects/hslayers/services/event-bus/event-bus.service.ts
+++ b/projects/hslayers/services/event-bus/event-bus.service.ts
@@ -176,5 +176,9 @@ export class HsEventBusService {
    */
   refreshLaymanLayer: Subject<VectorLayer<VectorSource<Feature>>> =
     new Subject();
+  /**
+   * Fires when WFS filter should be reset - used  when last filter is removed
+   */
+  resetWfsFilter: Subject<void> = new Subject();
   constructor() {}
 }

--- a/projects/hslayers/test/common/filters/comparison-filter.spec.ts
+++ b/projects/hslayers/test/common/filters/comparison-filter.spec.ts
@@ -133,6 +133,8 @@ describe('HsComparisonFilterComponent', () => {
       expect(ops.map((op) => op.value)).toEqual([
         '==',
         '!=',
+        '==',
+        '!=',
         '<',
         '<=',
         '>',

--- a/projects/hslayers/test/event-bus.service.mock.ts
+++ b/projects/hslayers/test/event-bus.service.mock.ts
@@ -13,5 +13,6 @@ export class HsEventBusServiceMock {
   layerManagerUpdates: Subject<any> = new Subject();
   mapResets: Subject<any> = new Subject();
   mapEventHandlersSet: Subject<any> = new Subject();
+  resetWfsFilter: Subject<any> = new Subject();
   constructor() {}
 }


### PR DESCRIPTION
## Description

- listAttributes  from local data (styler) is now calcualted from subset of features not just the first one
- added two new operators `!= NULL`  and `== NULL` 
  adjustForUndefinedValues and replaceNullValues are related to this change as OL needs `undefined` to be filter value while SLD is expecting 'NULL' so we need to switch between the two on read/write
 it was also necessary to manually alter the fitler value eg. this.filter[2] 

- Allow attribute comparison in filter 
Geostyler parsers expect 'function' notation when trying to compare attributes (not attribute and literal value) eg for SLD such as :
```
<ogc:PropertyIsGreaterThan>
   <ogc:PropertyName>posledni_hodnota</ogc:PropertyName>
   <ogc:PropertyName>spa2h</ogc:PropertyName>
</ogc:PropertyIsGreaterThan>
```
we need goestyler filter to look something like this:
```
[
      '>',
      {
        name: 'property',
        args: ['posledni_hodnota'],
      },
      {
        name: 'property',
        args: ['spa2h'],
      };
 ]
```

Teoretically the first argument (posledni_hodnota) could be kept 'in simple form' (string) but geostyler pareres doesnt account for that see [this snippet](https://github.com/geostyler/geostyler-sld-parser/blob/e5164c4782d0cbeae78f053a65d9b33a602c54fb/src/SldStyleParser.ts#L1496-L1504) where 'literal' is hardcoded.

Another reason why we need both arguments in 'geostlyer function' form is that provided SLD snippet will get written by geostyler (SLD -> geostlyer -> SLD) into `SLD function` . Reading such SLD  would produce plain value for key (even for first argument eg. key) ... which is in a bit of a contradiction with the [style rendering](https://github.com/geostyler/geostyler-openlayers-parser/blob/0621db2d04064b2fa974e24af0a64ec20fbb8222/src/OlStyleParser.ts#L899-L903) (key is always treated as propertyName)
```
  <Function name="greaterThan">
      <PropertyName>posledni_hodnota</PropertyName>
      <PropertyName>spa2h</PropertyName>
 </Function>
``` 

To keep comaprison-fitler.component somewhat simple (to not swich between different types of filter[1] and filter[2] values) Ive added 'local state' which is always in simple string form and is parsed into obj. in case its necessary.


## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [ ] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
