### PR TITLE
 Replace constructor-based dependency injection with inject() function

### DIFF
--- a/projects/cesium-test-app/src/app/app.component.ts
+++ b/projects/cesium-test-app/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {
   Cartesian3,
@@ -29,13 +29,13 @@ import {HslayersCesiumComponent} from 'hslayers-cesium/src/hscesium.component';
   standalone: false,
 })
 export class AppComponent implements OnInit {
-  constructor(
-    public hsConfig: HsConfig,
-    private hsCesiumConfig: HsCesiumConfig,
-    private hsLayoutService: HsLayoutService,
-    private hsOverlayConstructorService: HsOverlayConstructorService,
-    private hsPanelConstructorService: HsPanelConstructorService,
-  ) {
+  hsConfig = inject(HsConfig);
+  private hsCesiumConfig = inject(HsCesiumConfig);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsOverlayConstructorService = inject(HsOverlayConstructorService);
+  private hsPanelConstructorService = inject(HsPanelConstructorService);
+
+  constructor() {
     const polygon25d = new VectorLayer({
       properties: {
         title: '2.5D polygon surface',

--- a/projects/hslayers-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/hslayers-app/src/hslayers-app/hslayers-app.component.ts
@@ -1,4 +1,7 @@
 import * as proj from 'ol/proj';
+
+import {Component, ElementRef, inject} from '@angular/core';
+
 import {
   BingMaps,
   ImageArcGISRest,
@@ -11,7 +14,6 @@ import {
   XYZ,
 } from 'ol/source';
 import {Circle, Fill, Icon, Stroke, Style} from 'ol/style';
-import {Component, ElementRef} from '@angular/core';
 import {GeoJSON} from 'ol/format';
 import {
   Group,
@@ -35,13 +37,14 @@ import {SparqlJson} from 'hslayers-ng/common/layers';
   standalone: false,
 })
 export class HslayersAppComponent {
+  hsConfig = inject(HsConfig);
+  private elementRef = inject(ElementRef);
+  private hsOverlayConstructorService = inject(HsOverlayConstructorService);
+  private hsPanelConstructorService = inject(HsPanelConstructorService);
+
   id;
-  constructor(
-    public HsConfig: HsConfig,
-    private elementRef: ElementRef,
-    private HsOverlayConstructorService: HsOverlayConstructorService,
-    private HsPanelConstructorService: HsPanelConstructorService,
-  ) {
+
+  constructor() {
     const w: any = window;
     w.ol = {
       layer: {
@@ -83,19 +86,19 @@ export class HslayersAppComponent {
     }
     if (w['hslayersNgConfig' + this.id]) {
       const cfg = eval('w.hslayersNgConfig' + this.id + '(w.ol)');
-      this.HsConfig.update(cfg);
+      this.hsConfig.update(cfg);
     } else if (w.hslayersNgConfig) {
-      this.HsConfig.update(w.hslayersNgConfig(w.ol));
+      this.hsConfig.update(w.hslayersNgConfig(w.ol));
     }
     /**
      * Create panel components
      */
-    this.HsPanelConstructorService.createActivePanels();
+    this.hsPanelConstructorService.createActivePanels();
 
     /**
      * Create GUI overlay
      */
-    this.HsOverlayConstructorService.createGuiOverlay();
+    this.hsOverlayConstructorService.createGuiOverlay();
   }
   title = 'hslayers-workspace';
 }

--- a/projects/hslayers-cesium-app/src/app/app.component.ts
+++ b/projects/hslayers-cesium-app/src/app/app.component.ts
@@ -1,6 +1,7 @@
-import {Component, ElementRef, OnInit} from '@angular/core';
-
 import * as proj from 'ol/proj';
+
+import {Component, ElementRef, OnInit, inject} from '@angular/core';
+
 import {
   BingMaps,
   ImageArcGISRest,
@@ -40,15 +41,16 @@ import {SparqlJson} from 'hslayers-ng/common/layers';
   standalone: false,
 })
 export class AppComponent implements OnInit {
+  private elementRef = inject(ElementRef);
+  hsConfig = inject(HsConfig);
+  private hsCesiumConfig = inject(HsCesiumConfig);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsOverlayConstructorService = inject(HsOverlayConstructorService);
+  private hsPanelConstructorService = inject(HsPanelConstructorService);
+
   id = '';
-  constructor(
-    private elementRef: ElementRef,
-    public hsConfig: HsConfig,
-    private hsCesiumConfig: HsCesiumConfig,
-    private hsLayoutService: HsLayoutService,
-    private hsOverlayConstructorService: HsOverlayConstructorService,
-    private hsPanelConstructorService: HsPanelConstructorService,
-  ) {
+
+  constructor() {
     const w: any = window;
     w.ol = {
       layer: {

--- a/projects/hslayers-cesium/src/hscesium-camera.service.ts
+++ b/projects/hslayers-cesium/src/hscesium-camera.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {
   Cartesian2,
@@ -30,12 +30,12 @@ export class CesiumCameraServiceParams {
   providedIn: 'root',
 })
 export class HsCesiumCameraService extends CesiumCameraServiceParams {
-  constructor(
-    private hsLog: HsLogService,
-    public HsMapService: HsMapService,
-    public hsConfig: HsConfig,
-    private hsCesiumConfig: HsCesiumConfig,
-  ) {
+  private hsLog = inject(HsLogService);
+  hsMapService = inject(HsMapService);
+  hsConfig = inject(HsConfig);
+  private hsCesiumConfig = inject(HsCesiumConfig);
+
+  constructor() {
     super();
     this.hsCesiumConfig.viewerLoaded.subscribe((viewer) => {
       this.viewer = viewer;
@@ -259,7 +259,7 @@ export class HsCesiumCameraService extends CesiumCameraServiceParams {
 
   setExtentEqualToOlExtent(view) {
     try {
-      const ol_ext = view.calculateExtent(this.HsMapService.getMap().getSize());
+      const ol_ext = view.calculateExtent(this.hsMapService.getMap().getSize());
       const trans_ext = transformExtent(
         ol_ext,
         view.getProjection(),
@@ -328,7 +328,8 @@ export class HsCesiumCameraService extends CesiumCameraServiceParams {
   calcDistanceForResolution(resolution, latitude) {
     const canvas = this.viewer.scene.canvas;
     const fov = (<PerspectiveFrustum>this.viewer.camera.frustum).fov;
-    const metersPerUnit = this.HsMapService.getMap()
+    const metersPerUnit = this.hsMapService
+      .getMap()
       .getView()
       .getProjection()
       .getMetersPerUnit();
@@ -363,7 +364,7 @@ export class HsCesiumCameraService extends CesiumCameraServiceParams {
 
   fixMorphs(viewer) {
     viewer.camera.moveEnd.addEventListener((e) => {
-      if (!this.HsMapService.visible) {
+      if (!this.hsMapService.visible) {
         const center = this.getCameraCenterInLngLat();
         if (center === null || center[0] == 0 || center[1] == 0) {
           return;

--- a/projects/hslayers-cesium/src/hscesium-layers.service.ts
+++ b/projects/hslayers-cesium/src/hscesium-layers.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {lastValueFrom} from 'rxjs';
 
 import dayjs from 'dayjs';
@@ -74,18 +74,19 @@ function MyProxy({proxy, maxResolution, projection}) {
   providedIn: 'root',
 })
 export class HsCesiumLayersService {
+  hsMapService = inject(HsMapService);
+  private hsLog = inject(HsLogService);
+  hsConfig = inject(HsConfig);
+  hsEventBusService = inject(HsEventBusService);
+  hsCesiumConfig = inject(HsCesiumConfig);
+  private httpClient = inject(HttpClient);
+
   layersToBeDeleted = [];
   viewer: Viewer;
   ol2CsMappings: Array<OlCesiumObjectMapItem> = [];
   paramCaches: Array<ParamCacheMapItem> = [];
-  constructor(
-    public hsMapService: HsMapService,
-    private hsLog: HsLogService,
-    public hsConfig: HsConfig,
-    public HsEventBusService: HsEventBusService,
-    public hsCesiumConfig: HsCesiumConfig,
-    private httpClient: HttpClient,
-  ) {
+
+  constructor() {
     this.hsCesiumConfig.viewerLoaded.subscribe((viewer) => {
       this.viewer = viewer;
       this.ol2CsMappings = [];
@@ -149,7 +150,7 @@ export class HsCesiumLayersService {
   }
 
   async setupEvents() {
-    this.HsEventBusService.LayerManagerBaseLayerVisibilityChanges.subscribe(
+    this.hsEventBusService.LayerManagerBaseLayerVisibilityChanges.subscribe(
       async (data) => {
         if (this.viewer.isDestroyed() || data?.type != 'terrain') {
           return;

--- a/projects/hslayers-cesium/src/hscesium.component.html
+++ b/projects/hslayers-cesium/src/hscesium.component.html
@@ -1,1 +1,1 @@
-<div class="hs-cesium-container" [hidden]="!HsCesiumService.visible"></div>
+<div class="hs-cesium-container" [hidden]="!hsCesiumService.visible"></div>

--- a/projects/hslayers-cesium/src/hscesium.component.ts
+++ b/projects/hslayers-cesium/src/hscesium.component.ts
@@ -1,4 +1,6 @@
-import {AfterViewInit, Component, DestroyRef} from '@angular/core';
+import {AfterViewInit, Component, DestroyRef, inject} from '@angular/core';
+import {filter} from 'rxjs';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {HS_PRMS, HsShareUrlService} from 'hslayers-ng/services/share';
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
@@ -9,8 +11,6 @@ import {HsToolbarPanelContainerService} from 'hslayers-ng/services/panels';
 
 import {HsCesiumService} from './hscesium.service';
 import {HsToggleViewComponent} from './toggle-view/toggle-view.component';
-import {filter} from 'rxjs';
-import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'hs-cesium',
@@ -19,47 +19,48 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
   standalone: false,
 })
 export class HslayersCesiumComponent implements AfterViewInit {
+  hsCesiumService = inject(HsCesiumService);
+  hsShareUrlService = inject(HsShareUrlService);
+  hsMapService = inject(HsMapService);
+  hsSidebarService = inject(HsSidebarService);
+  private hsToolbarPanelContainerService = inject(
+    HsToolbarPanelContainerService,
+  );
+  hsEventBusService = inject(HsEventBusService);
+  hsLayoutService = inject(HsLayoutService);
+  private destroyRef = inject(DestroyRef);
+
   app = 'default';
-  constructor(
-    public HsCesiumService: HsCesiumService,
-    public HsShareUrlService: HsShareUrlService,
-    public HsMapService: HsMapService,
-    public HsSidebarService: HsSidebarService,
-    private hsToolbarPanelContainerService: HsToolbarPanelContainerService,
-    public HsEventBusService: HsEventBusService,
-    public HsLayoutService: HsLayoutService,
-    private DestroyRef: DestroyRef,
-  ) {}
 
   ngAfterViewInit(): void {
     //Timeout needed because view container might not
     //be resized yet and globe will be zoomed out in that case
     setTimeout(() => {
-      this.HsCesiumService.init();
+      this.hsCesiumService.init();
     }, 100);
 
-    const view = this.HsShareUrlService.getParamValue(HS_PRMS.view);
+    const view = this.hsShareUrlService.getParamValue(HS_PRMS.view);
     if (view != '2d') {
-      this.HsShareUrlService.updateCustomParams({view: '3d'});
-      this.HsMapService.visible = false;
+      this.hsShareUrlService.updateCustomParams({view: '3d'});
+      this.hsMapService.visible = false;
     } else {
-      this.HsShareUrlService.updateCustomParams({view: '2d'});
+      this.hsShareUrlService.updateCustomParams({view: '2d'});
     }
 
     this.hsToolbarPanelContainerService.create(HsToggleViewComponent, {});
 
-    this.HsEventBusService.layermanagerDimensionChanges.subscribe((data) =>
-      this.HsCesiumService.dimensionChanged(data.layer, data.dimension),
+    this.hsEventBusService.layermanagerDimensionChanges.subscribe((data) =>
+      this.hsCesiumService.dimensionChanged(data.layer, data.dimension),
     );
 
-    this.HsEventBusService.sizeChanges
+    this.hsEventBusService.sizeChanges
       .pipe(
-        takeUntilDestroyed(this.DestroyRef),
+        takeUntilDestroyed(this.destroyRef),
         /**
          * Resize immidiatelly only in case cesium is visible
          */
-        filter((size) => this.HsCesiumService.visible),
+        filter((size) => this.hsCesiumService.visible),
       )
-      .subscribe((size) => this.HsCesiumService.resize(size));
+      .subscribe((size) => this.hsCesiumService.resize(size));
   }
 }

--- a/projects/hslayers-cesium/src/picker.service.ts
+++ b/projects/hslayers-cesium/src/picker.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {
@@ -23,13 +23,12 @@ import {debounce} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsCesiumPickerService {
+  private hsCesiumQueryPopupService = inject(HsCesiumQueryPopupService);
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+
   viewer: Viewer;
   cesiumPositionClicked: Subject<any> = new Subject();
-  constructor(
-    private HsCesiumQueryPopupService: HsCesiumQueryPopupService,
-    private HsMapService: HsMapService,
-    private hsConfig: HsConfig,
-  ) {}
 
   init(viewer: Viewer) {
     const handler = new ScreenSpaceEventHandler(this.viewer.scene.canvas);
@@ -91,15 +90,15 @@ export class HsCesiumPickerService {
       if (button == 'left' && pickedObject?.id?.onclick) {
         pickedObject.id.onclick(pickedObject.id);
       }
-      const featureLike = this.HsMapService.getFeatureById(
+      const featureLike = this.hsMapService.getFeatureById(
         (pickedObject.id as Entity).properties.HsCesiumFeatureId.getValue(),
       );
-      this.HsCesiumQueryPopupService.fillFeatures([
+      this.hsCesiumQueryPopupService.fillFeatures([
         featureLike instanceof Feature ? featureLike : null,
       ]);
-      this.HsCesiumQueryPopupService.showPopup({pixel: movement.position});
+      this.hsCesiumQueryPopupService.showPopup({pixel: movement.position});
       return;
     }
-    this.HsCesiumQueryPopupService.fillFeatures([]);
+    this.hsCesiumQueryPopupService.fillFeatures([]);
   }
 }

--- a/projects/hslayers-cesium/src/query-popup.service.ts
+++ b/projects/hslayers-cesium/src/query-popup.service.ts
@@ -1,10 +1,8 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable} from '@angular/core';
 
-import {HsMapService} from 'hslayers-ng/services/map';
 import {
   HsQueryPopupBaseService,
   HsQueryPopupServiceModel,
-  HsQueryPopupWidgetContainerService,
 } from 'hslayers-ng/common/query-popup';
 
 @Injectable({
@@ -12,15 +10,8 @@ import {
 })
 export class HsCesiumQueryPopupService
   extends HsQueryPopupBaseService
-  implements HsQueryPopupServiceModel {
-  constructor(
-    HsMapService: HsMapService,
-    zone: NgZone,
-    hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
-  ) {
-    super(HsMapService, zone, hsQueryPopupWidgetContainerService);
-  }
-
+  implements HsQueryPopupServiceModel
+{
   registerPopup(nativeElement) {
     nativeElement.style.position = 'absolute';
     this.hoverPopup = nativeElement;

--- a/projects/hslayers-cesium/src/toggle-view/toggle-view.component.ts
+++ b/projects/hslayers-cesium/src/toggle-view/toggle-view.component.ts
@@ -1,5 +1,5 @@
 import {AsyncPipe, NgClass} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {HsGuiOverlayBaseComponent} from 'hslayers-ng/common/panels';
@@ -12,9 +12,8 @@ import {HsCesiumService} from '../hscesium.service';
   imports: [AsyncPipe, TranslatePipe, NgClass],
 })
 export class HsToggleViewComponent extends HsGuiOverlayBaseComponent {
-  constructor(public hsCesiumService: HsCesiumService) {
-    super();
-  }
+  hsCesiumService = inject(HsCesiumService);
+
   name = 'toggleViewToolbar';
 
   /**

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-dialog.component.ts
@@ -1,12 +1,17 @@
+import {AsyncPipe, KeyValuePipe, NgStyle} from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
   ElementRef,
   OnInit,
   ViewRef,
+  inject,
 } from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {LangChangeEvent, TranslatePipe} from '@ngx-translate/core';
+import {NgbDatepickerModule} from '@ng-bootstrap/ng-bootstrap';
 import {combineLatest, map, startWith} from 'rxjs';
-import {TranslatePipe} from '@ngx-translate/core';
+import {takeUntilDestroyed, toSignal} from '@angular/core/rxjs-interop';
 
 import {
   HsDialogComponent,
@@ -17,11 +22,6 @@ import {HsLayoutService} from 'hslayers-ng/services/layout';
 
 import {Aggregates, HsSensorsUnitDialogService} from './unit-dialog.service';
 import {CustomInterval, Interval} from './types/interval.type';
-import {LangChangeEvent} from '@ngx-translate/core';
-import {takeUntilDestroyed, toSignal} from '@angular/core/rxjs-interop';
-import {AsyncPipe, KeyValuePipe, NgStyle} from '@angular/common';
-import {NgbDatepickerModule} from '@ng-bootstrap/ng-bootstrap';
-import {FormsModule} from '@angular/forms';
 
 @Component({
   selector: 'hs-sensor-unit',
@@ -71,6 +71,13 @@ import {FormsModule} from '@angular/forms';
   ],
 })
 export class HsSensorsUnitDialogComponent implements HsDialogComponent, OnInit {
+  private hsLayoutService = inject(HsLayoutService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  hsSensorsUnitDialogService = inject(HsSensorsUnitDialogService);
+  private hsLanguageService = inject(HsLanguageService);
+  private cdr = inject(ChangeDetectorRef);
+  elementRef = inject(ElementRef);
+
   customInterval: CustomInterval = {
     name: 'Custom',
     fromTime: new Date(),
@@ -101,14 +108,7 @@ export class HsSensorsUnitDialogComponent implements HsDialogComponent, OnInit {
   viewRef: ViewRef;
   data: any;
 
-  constructor(
-    private hsLayoutService: HsLayoutService,
-    private hsDialogContainerService: HsDialogContainerService,
-    public hsSensorsUnitDialogService: HsSensorsUnitDialogService,
-    private hsLanguageService: HsLanguageService,
-    private cdr: ChangeDetectorRef,
-    public elementRef: ElementRef,
-  ) {
+  constructor() {
     this.hsSensorsUnitDialogService.dialogElement = this.elementRef;
   }
 

--- a/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors-unit-list-item.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 import {NgClass} from '@angular/common';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -15,15 +15,13 @@ import {SenslogSensor} from './types/senslog-sensor.type';
   imports: [TranslatePipe, NgClass],
 })
 export class HsSensorsUnitListItemComponent {
+  private hsSensorsService = inject(HsSensorsService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsSensorsUnitDialogService = inject(HsSensorsUnitDialogService);
+
   @Input() unit: HsSensorUnit;
   @Input() expanded: boolean;
   @Input('view-mode') viewMode: string;
-
-  constructor(
-    private hsSensorsService: HsSensorsService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsSensorsUnitDialogService: HsSensorsUnitDialogService,
-  ) {}
 
   /**
    * When unit is clicked, create a dialog window for

--- a/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewRef} from '@angular/core';
+import {Component, OnInit, ViewRef, inject} from '@angular/core';
 import {AsyncPipe, NgClass} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -26,18 +26,14 @@ import {HsSensorsUnitListItemComponent} from './sensors-unit-list-item.component
   ],
 })
 export class HsSensorsComponent extends HsPanelBaseComponent implements OnInit {
+  hsSensorsService = inject(HsSensorsService);
+  hsSensorsUnitDialogService = inject(HsSensorsUnitDialogService);
+
   viewMode = 'sensors';
   viewExpanded = false;
   query: any = {description: ''};
   viewRef: ViewRef;
   name = 'sensors';
-
-  constructor(
-    public hsSensorsService: HsSensorsService,
-    public hsSensorsUnitDialogService: HsSensorsUnitDialogService,
-  ) {
-    super();
-  }
 
   ngOnInit(): void {
     super.ngOnInit();

--- a/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/sensors.service.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import {HttpClient} from '@angular/common/http';
-import {Inject, Injectable, Optional, inject} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject, concatMap, debounceTime, map, take} from 'rxjs';
 
 import {HsConfig} from 'hslayers-ng/config';
@@ -34,6 +34,18 @@ const VISUALIZED_ATTR = 'Visualized attribute';
   providedIn: 'root',
 })
 export class HsSensorsService {
+  private hsProxyService = inject(HsProxyService);
+  private hsConfig = inject(HsConfig);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private http = inject(HttpClient);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsSensorsUnitDialogService = inject(HsSensorsUnitDialogService);
+  private hsLog = inject(HsLogService);
+  mapServiceDisabled = inject<boolean>('MAPSERVICE_DISABLED' as any, {
+    optional: true,
+  })!;
+
   units: HsSensorUnit[] = [];
   layer = null;
   endpoint: SensLogEndpoint;
@@ -46,20 +58,9 @@ export class HsSensorsService {
 
   hsMapService;
 
-  constructor(
-    private hsProxyService: HsProxyService,
-    private hsConfig: HsConfig,
-    private hsLayoutService: HsLayoutService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private http: HttpClient,
-    private hsEventBusService: HsEventBusService,
-    private hsSensorsUnitDialogService: HsSensorsUnitDialogService,
-    private hsLog: HsLogService,
-    @Optional()
-    @Inject('MAPSERVICE_DISABLED')
-    public mapServiceDisabled: boolean,
-    @Optional() @Inject('HsQueryVectorService') hsQueryVectorService,
-  ) {
+  constructor() {
+    const mapServiceDisabled = this.mapServiceDisabled;
+
     const urlParams = new URLSearchParams(location.search);
     this.unitInUrl = parseInt(urlParams.get('unit_id'));
 

--- a/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
+++ b/projects/hslayers-sensors/src/components/sensors/unit-dialog.service.ts
@@ -8,7 +8,7 @@ import {
   tap,
   timer,
 } from 'rxjs';
-import {ElementRef, Inject, Injectable, Optional, signal} from '@angular/core';
+import {ElementRef, Injectable, signal, inject} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -38,6 +38,16 @@ export class Aggregates {
   providedIn: 'root',
 })
 export class HsSensorsUnitDialogService {
+  private http = inject(HttpClient);
+  private hsConfig = inject(HsConfig);
+  private hsLogService = inject(HsLogService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsLayoutService = inject(HsLayoutService);
+  mapServiceDisabled = inject<boolean>('MAPSERVICE_DISABLED' as any, {
+    optional: true,
+  })!;
+  private hsProxyService = inject(HsProxyService);
+
   readonly COLOR_SCHEME = [
     '#4c78a8',
     '#9ecae9',
@@ -92,17 +102,7 @@ export class HsSensorsUnitDialogService {
    */
   comparisonAllowed = false;
 
-  constructor(
-    private http: HttpClient,
-    private hsConfig: HsConfig,
-    private hsLogService: HsLogService,
-    private hsLanguageService: HsLanguageService,
-    private hsLayoutService: HsLayoutService,
-    @Optional()
-    @Inject('MAPSERVICE_DISABLED')
-    public mapServiceDisabled: boolean,
-    private hsProxyService: HsProxyService,
-  ) {
+  constructor() {
     this.currentInterval = this.intervals[2];
     this.useTimeZone.subscribe((value) => {
       this.timeFormat = value ? 'HH:mm:ssZ' : 'HH:mm:ss';

--- a/projects/hslayers/common/color-map-picker/colormap-picker.component.ts
+++ b/projects/hslayers/common/color-map-picker/colormap-picker.component.ts
@@ -5,6 +5,7 @@ import {
   Input,
   Output,
   forwardRef,
+  inject,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
@@ -35,6 +36,8 @@ type hsStylerColorMapsKeyValue = {
   standalone: false,
 })
 export class ColormapPickerComponent implements ControlValueAccessor {
+  private hsStylerService = inject(HsStylerService);
+
   @Input() height?: string = '50vh';
   _colorMaps: hsStylerColorMaps;
   //Value propagated to ngModel
@@ -44,8 +47,6 @@ export class ColormapPickerComponent implements ControlValueAccessor {
   menuVisible = false;
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change = new EventEmitter<string>();
-
-  constructor(private hsStylerService: HsStylerService) {}
 
   get colorMaps(): hsStylerColorMaps {
     if (!this._colorMaps) {

--- a/projects/hslayers/common/confirm/confirm-dialog.component.ts
+++ b/projects/hslayers/common/confirm/confirm-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {
@@ -13,18 +13,19 @@ import {
   imports: [TranslatePipe],
 })
 export class HsConfirmDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   dialogItem: HsDialogItem;
-  constructor(public HsDialogContainerService: HsDialogContainerService) {}
   viewRef: ViewRef;
   data: any;
 
   yes(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve('yes');
   }
 
   no(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve('no');
   }
 }

--- a/projects/hslayers/common/dialog-csw-layers/csw-layers-dialog.component.ts
+++ b/projects/hslayers/common/dialog-csw-layers/csw-layers-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit, ViewRef} from '@angular/core';
+import {Component, Input, OnInit, ViewRef, inject} from '@angular/core';
 import {NgbAccordionModule} from '@ng-bootstrap/ng-bootstrap';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -28,20 +28,19 @@ import {isLayerWMS} from 'hslayers-ng/services/utils';
   imports: [TranslatePipe, NgbAccordionModule, HsLayerTableComponent],
 })
 export class CswLayersDialogComponent implements OnInit, HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  hsMapService = inject(HsMapService);
+
   dialogItem: HsDialogItem;
   viewRef: ViewRef;
   @Input() data: any;
   servicesLoaded = false;
   layersString: string;
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    public hsMapService: HsMapService,
-  ) {}
 
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve(false);
   }
 
@@ -119,7 +118,7 @@ export class CswLayersDialogComponent implements OnInit, HsDialogComponent {
       layers = this.setLayerParams(layers, service, checkedOnly);
       service.typeService.addLayers(layers);
     }
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve(true);
   }
 

--- a/projects/hslayers/common/dialog-set-permissions/set-permissions.component.ts
+++ b/projects/hslayers/common/dialog-set-permissions/set-permissions.component.ts
@@ -5,6 +5,7 @@ import {
   signal,
   ViewRef,
   WritableSignal,
+  inject,
 } from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -35,6 +36,10 @@ import {HsLaymanService} from 'hslayers-ng/services/save-map';
 export class HsSetPermissionsDialogComponent
   implements HsDialogComponent, OnInit
 {
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsLaymanService = inject(HsLaymanService);
+
   dialogItem: HsDialogItem;
   viewRef: ViewRef;
   access_rights: AccessRightsModel = {
@@ -57,12 +62,6 @@ export class HsSetPermissionsDialogComponent
   endpoint: HsEndpoint;
   state: WritableSignal<'idle' | 'loading' | 'success' | 'error'> =
     signal('idle');
-
-  constructor(
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsLaymanService: HsLaymanService,
-  ) {}
 
   ngOnInit(): void {
     // Can set permission for Layman endpoint only

--- a/projects/hslayers/common/dialogs/compositions-warning/warning-dialog.component.ts
+++ b/projects/hslayers/common/dialogs/compositions-warning/warning-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {HsDialogComponent} from '../dialog-component.interface';
@@ -9,12 +9,12 @@ import {HsDialogContainerService} from '../dialog-container.service';
   imports: [TranslatePipe],
 })
 export class HsCompositionsWarningDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   viewRef: ViewRef;
   data: any;
 
-  constructor(public HsDialogContainerService: HsDialogContainerService) {}
-
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/common/dialogs/dialog-container.component.ts
+++ b/projects/hslayers/common/dialogs/dialog-container.component.ts
@@ -19,24 +19,25 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
   imports: [HsDialogHostDirective],
 })
 export class HsDialogContainerComponent implements OnInit, OnDestroy {
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   @ViewChild(HsDialogHostDirective, {static: true})
   dialogHost: HsDialogHostDirective;
   interval: any;
   private destroyRef = inject(DestroyRef);
-  constructor(public HsDialogContainerService: HsDialogContainerService) {}
 
   ngOnDestroy(): void {
-    this.HsDialogContainerService.cleanup();
+    this.hsDialogContainerService.cleanup();
   }
 
   ngOnInit(): void {
-    this.HsDialogContainerService.dialogObserver
+    this.hsDialogContainerService.dialogObserver
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((item: HsDialogItem) => {
         this.loadDialog(item);
       });
 
-    this.HsDialogContainerService.dialogDestroyObserver
+    this.hsDialogContainerService.dialogDestroyObserver
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((item: HsDialogComponent) => {
         this.destroyDialog(item);
@@ -66,7 +67,7 @@ export class HsDialogContainerComponent implements OnInit, OnDestroy {
       (<HsDialogComponent>componentRef.instance).data = dialogItem.data;
     }
     (<HsDialogComponent>componentRef.instance).dialogItem = dialogItem;
-    this.HsDialogContainerService.dialogs.push(
+    this.hsDialogContainerService.dialogs.push(
       componentRef.instance as HsDialogComponent,
     );
   }

--- a/projects/hslayers/common/dialogs/dialog-host.directive.ts
+++ b/projects/hslayers/common/dialogs/dialog-host.directive.ts
@@ -1,9 +1,9 @@
-import {Directive, ViewContainerRef} from '@angular/core';
+import {Directive, ViewContainerRef, inject} from '@angular/core';
 
 @Directive({
   selector: '[hsDialogHost]',
   standalone: true,
 })
 export class HsDialogHostDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }

--- a/projects/hslayers/common/dialogs/overwrite-layer/overwrite-layer.component.ts
+++ b/projects/hslayers/common/dialogs/overwrite-layer/overwrite-layer.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {FileDataObject, VectorDataObject} from 'hslayers-ng/types';
@@ -13,14 +13,14 @@ import {HsRenameLayerDialogComponent} from '../rename-layer/rename-layer.compone
   imports: [TranslatePipe],
 })
 export class HsLayerOverwriteDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   dialogItem: HsDialogItem;
   viewRef: ViewRef;
   data: {
     dataObj: FileDataObject | VectorDataObject;
     repetive: boolean;
   };
-
-  constructor(public hsDialogContainerService: HsDialogContainerService) {}
 
   /**
    * Close the dialog

--- a/projects/hslayers/common/dialogs/rename-layer/rename-layer.component.ts
+++ b/projects/hslayers/common/dialogs/rename-layer/rename-layer.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewRef} from '@angular/core';
+import {Component, OnInit, ViewRef, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -12,6 +12,8 @@ import {HsDialogItem} from '../dialog-item';
   imports: [TranslatePipe, FormsModule],
 })
 export class HsRenameLayerDialogComponent implements HsDialogComponent, OnInit {
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   dialogItem: HsDialogItem;
   viewRef: ViewRef;
   newLayerName: string;
@@ -19,7 +21,6 @@ export class HsRenameLayerDialogComponent implements HsDialogComponent, OnInit {
     currentName: string;
   };
 
-  constructor(public hsDialogContainerService: HsDialogContainerService) {}
   ngOnInit(): void {
     this.newLayerName = this.data.currentName;
   }

--- a/projects/hslayers/common/download/download.directive.ts
+++ b/projects/hslayers/common/download/download.directive.ts
@@ -5,6 +5,7 @@ import {
   Input,
   OnDestroy,
   Output,
+  inject,
 } from '@angular/core';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 
@@ -13,14 +14,14 @@ import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
   standalone: true,
 })
 export class HsDownloadDirective implements OnDestroy {
+  private domSanitizer = inject(DomSanitizer);
+
   @Input() hsDownload = '';
   @Input() mimeType = '';
   @Output() downloadPrepared = new EventEmitter<SafeResourceUrl>();
 
   private exportedHref: SafeResourceUrl | null = null;
   private blobUrl: string | null = null;
-
-  constructor(private domSanitizer: DomSanitizer) {}
 
   /**
    * Clean up any created object URLs when the directive is destroyed

--- a/projects/hslayers/common/history-list/history-list.component.ts
+++ b/projects/hslayers/common/history-list/history-list.component.ts
@@ -5,6 +5,7 @@ import {
   OnChanges,
   Output,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import {HsHistoryListService} from './history-list.service';
 
@@ -14,13 +15,14 @@ import {HsHistoryListService} from './history-list.service';
   standalone: false,
 })
 export class HsHistoryListComponent implements OnChanges {
+  hsHistoryListService = inject(HsHistoryListService);
+
   @Input() what: string; //input
 
   @Output() historyUrlSelected = new EventEmitter<string>(); //output
   items: Array<string>;
-  constructor(public HsHistoryListService: HsHistoryListService) {}
   ngOnChanges(changes: SimpleChanges): void {
-    this.items = this.HsHistoryListService.readSourceHistory(
+    this.items = this.hsHistoryListService.readSourceHistory(
       changes.what.currentValue,
     );
   }

--- a/projects/hslayers/common/history-list/history-list.service.ts
+++ b/projects/hslayers/common/history-list/history-list.service.ts
@@ -1,16 +1,16 @@
 import {CookieService} from 'ngx-cookie-service';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class HsHistoryListService {
-  items: any = {};
+  private cookieService = inject(CookieService);
 
-  constructor(private CookieService: CookieService) {}
+  items: any = {};
   readSourceHistory(forWhat: string): Array<string> {
     if (forWhat !== undefined) {
-      let sourceString = this.CookieService.get(`last${forWhat}Sources`);
+      let sourceString = this.cookieService.get(`last${forWhat}Sources`);
       if (sourceString !== undefined) {
         this.items[forWhat] = {
           history: [],
@@ -45,7 +45,7 @@ export class HsHistoryListService {
     }
     if (!this.items[forWhat]?.history?.includes(url)) {
       this.items[forWhat].history.push(url);
-      this.CookieService.set(
+      this.cookieService.set(
         `last${forWhat}Sources`,
         JSON.stringify(this.items[forWhat].history),
       );

--- a/projects/hslayers/common/layer-table/layer-table.component.ts
+++ b/projects/hslayers/common/layer-table/layer-table.component.ts
@@ -1,4 +1,4 @@
-import {AfterContentInit, Component, Input} from '@angular/core';
+import {AfterContentInit, Component, Input, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgClass, SlicePipe} from '@angular/common';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -30,6 +30,12 @@ import {HsNestedLayersTableComponent} from './nested-layers-table/nested-layers-
   ],
 })
 export class HsLayerTableComponent implements AfterContentInit {
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsAddDataService = inject(HsAddDataService);
+  hsLanguageService = inject(HsLanguageService);
+  hsUrlWmsService = inject(HsUrlWmsService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+
   @Input() injectedService: HsUrlTypeServiceModel;
   @Input() type: AddDataUrlType;
 
@@ -37,13 +43,6 @@ export class HsLayerTableComponent implements AfterContentInit {
   checkedSubLayers = {};
   getDimensionValues: any;
   limitShown = 100;
-  constructor(
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsAddDataService: HsAddDataService,
-    public hsLanguageService: HsLanguageService,
-    public hsUrlWmsService: HsUrlWmsService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-  ) {}
 
   ngAfterContentInit(): void {
     this.data = this.injectedService.data;

--- a/projects/hslayers/common/layer-table/nested-layers-table/nested-layers-table.component.ts
+++ b/projects/hslayers/common/layer-table/nested-layers-table/nested-layers-table.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, Output, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -11,11 +11,11 @@ import {WmsLayerHighlightDirective} from '../wms-layer-highlight.directive';
   imports: [FormsModule, TranslatePipe, WmsLayerHighlightDirective],
 })
 export class HsNestedLayersTableComponent {
+  hsUrlWmsService = inject(HsUrlWmsService);
+
   @Input() layers;
 
-  @Output() layerChecked = new EventEmitter<string>(); //output
-
-  constructor(public hsUrlWmsService: HsUrlWmsService) {}
+  @Output() layerChecked = new EventEmitter<string>();
 
   checked(layer): void {
     this.layerChecked.emit(layer);

--- a/projects/hslayers/common/layer-table/wms-layer-highlight.directive.ts
+++ b/projects/hslayers/common/layer-table/wms-layer-highlight.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, ElementRef, HostBinding} from '@angular/core';
+import {Directive, ElementRef, HostBinding, inject} from '@angular/core';
 import {isOverflown} from 'hslayers-ng/services/utils';
 
 @Directive({
@@ -6,9 +6,11 @@ import {isOverflown} from 'hslayers-ng/services/utils';
   standalone: true,
 })
 export class WmsLayerHighlightDirective {
+  private elRef = inject(ElementRef);
+
   @HostBinding('class.hs-wms-highlighted') highlighted = false;
 
-  constructor(private elRef: ElementRef) {
+  constructor() {
     setTimeout(() => {
       this.highlighted = isOverflown(this.elRef.nativeElement);
     }, 500);

--- a/projects/hslayers/common/layman/access-rights/layman-access-rights.component.ts
+++ b/projects/hslayers/common/layman/access-rights/layman-access-rights.component.ts
@@ -6,6 +6,7 @@ import {
   Output,
   signal,
   WritableSignal,
+  inject,
 } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {FormsModule} from '@angular/forms';
@@ -60,6 +61,10 @@ export type AccessRightsType = 'read' | 'write';
   imports: [TranslatePipe, FilterPipe, FormsModule, NgTemplateOutlet],
 })
 export class HsCommonLaymanAccessRightsComponent implements OnInit {
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private $http = inject(HttpClient);
+  private hsLog = inject(HsLogService);
+
   @Input() access_rights: AccessRightsModel;
   defaultAccessRights: AccessRightsModel;
   @Input() collapsed: boolean = false;
@@ -79,11 +84,6 @@ export class HsCommonLaymanAccessRightsComponent implements OnInit {
 
   userSearch: string;
   endpoint: HsEndpoint;
-  constructor(
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private $http: HttpClient,
-    private hsLog: HsLogService,
-  ) {}
   async ngOnInit(): Promise<void> {
     this.endpoint = this.hsCommonLaymanService.layman();
     this.defaultAccessRights = JSON.parse(JSON.stringify(this.access_rights));

--- a/projects/hslayers/common/layman/layman-login.component.ts
+++ b/projects/hslayers/common/layman/layman-login.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit, ViewRef} from '@angular/core';
+import {Component, Input, OnInit, ViewRef, inject} from '@angular/core';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -15,17 +15,17 @@ import {
   imports: [TranslatePipe],
 })
 export class HsLaymanLoginComponent implements HsDialogComponent, OnInit {
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  private sanitizer = inject(DomSanitizer);
+
   @Input() data: {
     url: string;
   };
   viewRef: ViewRef;
   url: SafeResourceUrl;
-  constructor(
-    public HsCommonLaymanService: HsCommonLaymanService,
-    public HsDialogContainerService: HsDialogContainerService,
-    private sanitizer: DomSanitizer,
-  ) {
-    this.HsCommonLaymanService.layman$
+  constructor() {
+    this.hsCommonLaymanService.layman$
       .pipe(takeUntilDestroyed())
       .subscribe(() => {
         this.close();
@@ -36,6 +36,6 @@ export class HsLaymanLoginComponent implements HsDialogComponent, OnInit {
     this.url = this.sanitizer.bypassSecurityTrustResourceUrl(this.data.url);
   }
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/common/panels/panel-container.component.ts
+++ b/projects/hslayers/common/panels/panel-container.component.ts
@@ -9,6 +9,7 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {ReplaySubject} from 'rxjs';
 
@@ -18,7 +19,6 @@ import {HsPanelComponent} from './panel-component.interface';
 import {HsPanelContainerServiceInterface} from './panel-container.service.interface';
 import {HsPanelHostDirective} from './panel-host.directive';
 import {HsPanelItem} from './panel-item';
-import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'hs-panel-container',
@@ -26,6 +26,9 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
   standalone: false,
 })
 export class HsPanelContainerComponent implements OnInit, OnDestroy {
+  private hsConfig = inject(HsConfig);
+  private hsLog = inject(HsLogService);
+
   @ViewChild(HsPanelHostDirective, {static: true})
   panelHost: HsPanelHostDirective;
   /**
@@ -46,11 +49,6 @@ export class HsPanelContainerComponent implements OnInit, OnDestroy {
   @Output() init = new EventEmitter<void>();
   interval: any;
   private destroyRef = inject(DestroyRef);
-
-  constructor(
-    private hsConfig: HsConfig,
-    private hsLog: HsLogService,
-  ) {}
 
   ngOnDestroy(): void {
     if (this.service.panelObserver && this.reusePanelObserver !== true) {

--- a/projects/hslayers/common/panels/panel-header/panel-header.component.ts
+++ b/projects/hslayers/common/panels/panel-header/panel-header.component.ts
@@ -1,4 +1,4 @@
-import {AsyncPipe, NgClass} from '@angular/common';
+import {AsyncPipe} from '@angular/common';
 
 import {BehaviorSubject} from 'rxjs';
 import {
@@ -34,6 +34,11 @@ export function toArray(panels: string) {
   styleUrl: './panel-header.component.scss',
 })
 export class HsPanelHeaderComponent implements OnInit {
+  hsLayoutService = inject(HsLayoutService);
+  private hsLanguageService = inject(HsLanguageService);
+  private elementRef = inject(ElementRef);
+  private cdr = inject(ChangeDetectorRef);
+
   @ViewChild('extraButtonsContainer', {static: true})
   extraButtons: ElementRef;
   active: string;
@@ -50,13 +55,6 @@ export class HsPanelHeaderComponent implements OnInit {
 
   @Output() tabSelected = new EventEmitter<string>();
   @Input() selectedTab$: BehaviorSubject<string>;
-
-  constructor(
-    public HsLayoutService: HsLayoutService,
-    private hsLanguageService: HsLanguageService,
-    private ElementRef: ElementRef,
-    private cdr: ChangeDetectorRef,
-  ) {}
 
   ngOnInit() {
     if (!this.selectedTab$) {

--- a/projects/hslayers/common/panels/panel-host.directive.ts
+++ b/projects/hslayers/common/panels/panel-host.directive.ts
@@ -1,9 +1,9 @@
-import {Directive, ViewContainerRef} from '@angular/core';
+import {Directive, ViewContainerRef, inject} from '@angular/core';
 
 @Directive({
   selector: '[hsPanelHost]',
   standalone: false,
 })
 export class HsPanelHostDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }

--- a/projects/hslayers/common/query-popup/query-popup-base.service.ts
+++ b/projects/hslayers/common/query-popup/query-popup-base.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 import {ReplaySubject} from 'rxjs';
 
 import {Feature} from 'ol';
@@ -15,13 +15,11 @@ import {getName, getPopUp, getTitle} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsQueryPopupBaseService extends HsQueryPopupData {
-  constructor(
-    public hsMapService: HsMapService,
-    public zone: NgZone,
-    public hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
-  ) {
-    super();
-  }
+  hsMapService = inject(HsMapService);
+  zone = inject(NgZone);
+  hsQueryPopupWidgetContainerService = inject(
+    HsQueryPopupWidgetContainerService,
+  );
 
   /**
    * Fill features for the popup

--- a/projects/hslayers/common/query-popup/query-popup-widget-container.service.ts
+++ b/projects/hslayers/common/query-popup/query-popup-widget-container.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {ReplaySubject} from 'rxjs';
 
 import {HsClearLayerComponent} from './widgets/clear-layer.component';
@@ -14,16 +14,14 @@ import {WidgetItem} from 'hslayers-ng/types';
   providedIn: 'root',
 })
 export class HsQueryPopupWidgetContainerService extends HsPanelContainerService {
+  private hsConfig = inject(HsConfig);
+
   queryPopupWidgets: WidgetItem[] = [
     {name: 'layer-name', component: HsLayerNameComponent},
     {name: 'feature-info', component: HsFeatureInfoComponent},
     {name: 'clear-layer', component: HsClearLayerComponent},
     {name: 'dynamic-text', component: HsDynamicTextComponent},
   ];
-
-  constructor(private hsConfig: HsConfig) {
-    super();
-  }
 
   cleanup() {
     console.warn('TODO: HsQueryPopupWidgetContainerService cleanup');

--- a/projects/hslayers/common/query-popup/query-popup.component.ts
+++ b/projects/hslayers/common/query-popup/query-popup.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   OnInit,
   ViewRef,
+  inject,
 } from '@angular/core';
 
 import {BehaviorSubject} from 'rxjs';
@@ -45,6 +46,14 @@ import {getFeatures} from 'hslayers-ng/common/extensions';
 export class HsQueryPopupComponent
   implements OnDestroy, HsDialogComponent, AfterViewInit, OnInit
 {
+  private hsEventBusService = inject(HsEventBusService);
+  private hsMapService = inject(HsMapService);
+  private elementRef = inject(ElementRef);
+  hsQueryPopupWidgetContainerService = inject(
+    HsQueryPopupWidgetContainerService,
+  );
+  private hsConfig = inject(HsConfig);
+
   getFeatures = getFeatures;
   attributesForHover = [];
   dialogItem?: HsDialogItem;
@@ -54,16 +63,8 @@ export class HsQueryPopupComponent
   };
   isVisible$ = new BehaviorSubject(true);
 
-  constructor(
-    private hsEventBusService: HsEventBusService,
-    private hsMapService: HsMapService,
-    private ElementRef: ElementRef,
-    public hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
-    private hsConfig: HsConfig,
-  ) {}
-
   ngAfterViewInit(): void {
-    this.data.service.registerPopup(this.ElementRef.nativeElement);
+    this.data.service.registerPopup(this.elementRef.nativeElement);
   }
 
   ngOnInit() {

--- a/projects/hslayers/common/query-popup/query-popup.service.ts
+++ b/projects/hslayers/common/query-popup/query-popup.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 
 import {Feature, Map, Overlay} from 'ol';
 import {Geometry} from 'ol/geom';
@@ -21,16 +21,15 @@ export class HsQueryPopupService
   extends HsQueryPopupBaseService
   implements HsQueryPopupServiceModel
 {
-  constructor(
-    public hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    public zone: NgZone,
-    private HsQueryBaseService: HsQueryBaseService,
-    public hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService,
-    private hsQueryVectorService: HsQueryVectorService,
-  ) {
-    super(hsMapService, zone, hsQueryPopupWidgetContainerService);
+  hsMapService: HsMapService;
+  private hsConfig = inject(HsConfig);
+  zone: NgZone;
+  private hsQueryBaseService = inject(HsQueryBaseService);
+  hsQueryPopupWidgetContainerService: HsQueryPopupWidgetContainerService;
+  private hsQueryVectorService = inject(HsQueryVectorService);
 
+  constructor() {
+    super();
     this.hsMapService.loaded().then((map) => {
       if (
         this.hsConfig.popUpDisplay &&
@@ -79,12 +78,12 @@ export class HsQueryPopupService
       return;
     }
     if (
-      !this.HsQueryBaseService.queryActive &&
+      !this.hsQueryBaseService.queryActive &&
       this.hsConfig.popUpDisplay === 'click'
     ) {
       return;
     }
-    let tmpFeatures = this.HsQueryBaseService.getFeaturesUnderMouse(
+    let tmpFeatures = this.hsQueryBaseService.getFeaturesUnderMouse(
       e.map,
       e.pixel,
     );

--- a/projects/hslayers/common/query-popup/widgets/clear-layer.component.ts
+++ b/projects/hslayers/common/query-popup/widgets/clear-layer.component.ts
@@ -1,4 +1,10 @@
-import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+  inject,
+} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -21,18 +27,15 @@ export class HsClearLayerComponent
   extends HsQueryPopupWidgetBaseComponent
   implements OnInit
 {
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsLanguageService = inject(HsLanguageService);
+
   @Input() data: {
     layerDescriptor: any;
     service: HsQueryPopupServiceModel;
   };
   name = 'clear-layer';
   layerDescriptor: any;
-  constructor(
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsLanguageService: HsLanguageService,
-  ) {
-    super();
-  }
   ngOnInit(): void {
     this.layerDescriptor = this.data.layerDescriptor;
   }

--- a/projects/hslayers/common/query-popup/widgets/dynamic-text.component.ts
+++ b/projects/hslayers/common/query-popup/widgets/dynamic-text.component.ts
@@ -1,4 +1,10 @@
-import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+  inject,
+} from '@angular/core';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 
 import {Feature} from 'ol';
@@ -18,16 +24,14 @@ export class HsDynamicTextComponent
   extends HsQueryPopupWidgetBaseComponent
   implements OnInit
 {
+  private sanitizer = inject(DomSanitizer);
+
   layerDescriptor: any;
   name = 'dynamic-text';
 
   @Input() data: {
     layerDescriptor: HsLayerDescriptor;
   };
-
-  constructor(private sanitizer: DomSanitizer) {
-    super();
-  }
 
   ngOnInit(): void {
     this.layerDescriptor = this.data.layerDescriptor;

--- a/projects/hslayers/common/query-popup/widgets/feature-info.component.ts
+++ b/projects/hslayers/common/query-popup/widgets/feature-info.component.ts
@@ -1,4 +1,10 @@
-import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+  inject,
+} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
@@ -27,6 +33,10 @@ export class HsFeatureInfoComponent
   extends HsQueryPopupWidgetBaseComponent
   implements OnInit
 {
+  private hsLanguageService = inject(HsLanguageService);
+  private hsQueryVectorService = inject(HsQueryVectorService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+
   layerDescriptor: any;
   attributesForHover: any[] = [];
   name = 'feature-info';
@@ -35,14 +45,6 @@ export class HsFeatureInfoComponent
     attributesForHover: any[];
     service: HsQueryPopupServiceModel;
   };
-
-  constructor(
-    private hsLanguageService: HsLanguageService,
-    private hsQueryVectorService: HsQueryVectorService,
-    private hsDialogContainerService: HsDialogContainerService,
-  ) {
-    super();
-  }
   ngOnInit(): void {
     this.layerDescriptor = this.data.layerDescriptor;
     this.attributesForHover = this.data.attributesForHover;

--- a/projects/hslayers/common/remove-multiple/remove-layer-dialog.component.ts
+++ b/projects/hslayers/common/remove-multiple/remove-layer-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewRef} from '@angular/core';
+import {Component, OnInit, ViewRef, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 
@@ -43,6 +43,11 @@ export type HsRmLayerDialogResponse = {
   standalone: false,
 })
 export class HsRmLayerDialogComponent implements HsDialogComponent, OnInit {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  service = inject(HsRemoveLayerDialogService);
+  private hsLanguageService = inject(HsLanguageService);
+  private commonLaymanService = inject(HsCommonLaymanService);
+
   dialogItem: HsDialogItem;
   _selectAll = false;
   isAuthenticated: boolean;
@@ -50,13 +55,6 @@ export class HsRmLayerDialogComponent implements HsDialogComponent, OnInit {
   deleteFrom: (typeof this.data)['deleteFromOptions'][number];
 
   deleteAllowed = false;
-
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public service: HsRemoveLayerDialogService,
-    private hsLanguageService: HsLanguageService,
-    private commonLaymanService: HsCommonLaymanService,
-  ) {}
   viewRef: ViewRef;
   /**
    * @param deleteFromOptions - From where the layer should be deleted eg. map, catalogue map&catalogue
@@ -84,12 +82,12 @@ export class HsRmLayerDialogComponent implements HsDialogComponent, OnInit {
     }
   }
   yes(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve({value: 'yes', type: this.deleteFrom});
   }
 
   no(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve({value: 'no'});
   }
 

--- a/projects/hslayers/common/remove-multiple/remove-layer-dialog.service.ts
+++ b/projects/hslayers/common/remove-multiple/remove-layer-dialog.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -26,14 +26,12 @@ export type RemoveLayerWrapper = {
   providedIn: 'root',
 })
 export class HsRemoveLayerDialogService {
-  constructor(
-    private hsMapService: HsMapService,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsLaymanService: HsLaymanService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsDialogContainerService: HsDialogContainerService,
-  ) {}
+  private hsMapService = inject(HsMapService);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsLaymanService = inject(HsLaymanService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
 
   /**
    * Create a remove layer wrapper

--- a/projects/hslayers/common/toast/toast.component.ts
+++ b/projects/hslayers/common/toast/toast.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, input} from '@angular/core';
+import {Component, computed, input, inject} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 
 import {HsToastService} from './toast.service';
@@ -28,12 +28,10 @@ import {HsConfig, ToastPosition} from 'hslayers-ng/config';
   },
 })
 export class HsToastComponent {
-  position = input<ToastPosition>('bottom-center');
+  hsToastService = inject(HsToastService);
+  private hsConfig = inject(HsConfig);
 
-  constructor(
-    public hsToastService: HsToastService,
-    private hsConfig: HsConfig,
-  ) {}
+  position = input<ToastPosition>('bottom-center');
 
   /**
    * Signal that tracks config changes

--- a/projects/hslayers/common/toast/toast.service.ts
+++ b/projects/hslayers/common/toast/toast.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, TemplateRef, signal} from '@angular/core';
+import {Injectable, TemplateRef, signal, inject} from '@angular/core';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {HsLanguageService} from 'hslayers-ng/services/language';
@@ -46,12 +46,10 @@ export type customToastOptions = {
   providedIn: 'root',
 })
 export class HsToastService {
-  private toastsSignal = signal<Toast[]>([]);
+  hsLanguageService = inject(HsLanguageService);
+  private hsConfig = inject(HsConfig);
 
-  constructor(
-    public HsLanguageService: HsLanguageService,
-    private hsConfig: HsConfig,
-  ) {}
+  private toastsSignal = signal<Toast[]>([]);
 
   get toasts() {
     return this.toastsSignal();
@@ -108,11 +106,11 @@ export class HsToastService {
     this.show(
       options.disableLocalization
         ? text
-        : this.HsLanguageService.getTranslation(text, undefined),
+        : this.hsLanguageService.getTranslation(text, undefined),
       {
         header: options.disableLocalization
           ? header
-          : this.HsLanguageService.getTranslation(header, undefined),
+          : this.hsLanguageService.getTranslation(header, undefined),
         delay:
           options.customDelay || (this.hsConfig.errorToastDuration ?? 7000),
         autohide: true,
@@ -120,7 +118,7 @@ export class HsToastService {
         serviceCalledFrom: options.serviceCalledFrom,
         details:
           options.details?.map((detail) =>
-            this.HsLanguageService.getTranslation(detail, undefined),
+            this.hsLanguageService.getTranslation(detail, undefined),
           ) || [],
       },
     );

--- a/projects/hslayers/components/add-data/add-data.component.ts
+++ b/projects/hslayers/components/add-data/add-data.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {Observable, of, switchMap} from 'rxjs';
 
 import {
@@ -21,7 +21,6 @@ import {
 import {HsPanelBaseComponent} from 'hslayers-ng/common/panels';
 import {HsRemoveLayerDialogService} from 'hslayers-ng/common/remove-multiple';
 import {HsShareUrlService} from 'hslayers-ng/services/share';
-import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'hs-add-data',
@@ -29,20 +28,20 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
   standalone: false,
 })
 export class HsAddDataComponent extends HsPanelBaseComponent implements OnInit {
+  hsAddDataService = inject(HsAddDataService);
+  hsShareUrlService = inject(HsShareUrlService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  hsAddDataCatalogueService = inject(HsAddDataCatalogueService);
+  private hsRemoveLayerDialogService = inject(HsRemoveLayerDialogService);
+  private hsLaymanService = inject(HsLaymanService);
+  /*
+   * Make sure the hsLayerSynchronizerService is available in the setups with add-data
+   */
+  private hsLayerSynchronizerService = inject(HsLayerSynchronizerService);
+
   layersAvailable: Observable<boolean>;
-  constructor(
-    public hsAddDataService: HsAddDataService,
-    public hsShareUrlService: HsShareUrlService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    private hsDialogContainerService: HsDialogContainerService,
-    public hsAddDataCatalogueService: HsAddDataCatalogueService,
-    private hsRemoveLayerDialogService: HsRemoveLayerDialogService,
-    private hsLaymanService: HsLaymanService,
-    /**
-     * Make sure the hsLayerSynchronizerService is available in the setups with add-data
-     */
-    private hsLayerSynchronizerService: HsLayerSynchronizerService,
-  ) {
+  constructor() {
     super();
     this.layersAvailable =
       this.hsAddDataCatalogueService.addDataCatalogueLoaded.pipe(

--- a/projects/hslayers/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
+++ b/projects/hslayers/components/add-data/catalogue/catalogue-list-item/catalogue-list-item.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, input} from '@angular/core';
+import {Component, computed, input, inject} from '@angular/core';
 import {NgClass, NgStyle} from '@angular/common';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -33,6 +33,14 @@ import {HsCommonLaymanService} from 'hslayers-ng/common/layman';
   imports: [NgClass, NgStyle, TranslatePipe],
 })
 export class HsCatalogueListItemComponent {
+  private hsDatasourcesMetadataService = inject(HsCatalogueMetadataService);
+  hsAddDataCatalogueService = inject(HsAddDataCatalogueService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsLaymanBrowserService = inject(HsLaymanBrowserService);
+  private hsLog = inject(HsLogService);
+  private hsRemoveLayerDialogService = inject(HsRemoveLayerDialogService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+
   layer = input<HsAddDataLayerDescriptor>();
 
   title = computed(() => this.layer().title);
@@ -58,16 +66,6 @@ export class HsCatalogueListItemComponent {
   loadingInfo = false;
 
   loadingMetadata = false;
-
-  constructor(
-    private hsDatasourcesMetadataService: HsCatalogueMetadataService,
-    public hsAddDataCatalogueService: HsAddDataCatalogueService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsLaymanBrowserService: HsLaymanBrowserService,
-    private hsLog: HsLogService,
-    private hsRemoveLayerDialogService: HsRemoveLayerDialogService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-  ) {}
 
   /**
    * Toggle add layer options

--- a/projects/hslayers/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.ts
+++ b/projects/hslayers/components/add-data/catalogue/catalogue-metadata/catalogue-metadata.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, input, ViewRef} from '@angular/core';
+import {Component, computed, input, ViewRef, inject} from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {transform} from 'ol/proj';
@@ -28,6 +28,12 @@ import {HsMapService} from 'hslayers-ng/services/map';
   imports: [HsUiExtensionsRecursiveDdComponent, TranslatePipe],
 })
 export class HsCatalogueMetadataComponent implements HsDialogComponent {
+  hsConfig = inject(HsConfig);
+  hsAddDataCatalogueService = inject(HsAddDataCatalogueService);
+  hsAddDataCatalogueMapService = inject(HsAddDataCatalogueMapService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  private hsMapService = inject(HsMapService);
+
   data = input<{
     selectedLayer: HsAddDataLayerDescriptor;
     selectedDS: HsEndpoint;
@@ -81,14 +87,6 @@ export class HsCatalogueMetadataComponent implements HsDialogComponent {
 
   viewRef: ViewRef;
   excludedKeys: string[] = ['feature', 'thumbnail', 'endpoint'];
-
-  constructor(
-    public hsConfig: HsConfig,
-    public hsAddDataCatalogueService: HsAddDataCatalogueService,
-    public hsAddDataCatalogueMapService: HsAddDataCatalogueMapService,
-    public hsDialogContainerService: HsDialogContainerService,
-    private hsMapService: HsMapService,
-  ) {}
 
   /**
    * @param type - Type in which the layer shall be added (WMS, WFS, etc.)

--- a/projects/hslayers/components/add-data/catalogue/catalogue.component.ts
+++ b/projects/hslayers/components/add-data/catalogue/catalogue.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, OnInit, signal} from '@angular/core';
+import {Component, computed, OnInit, signal, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -33,6 +33,15 @@ import {HsCatalogueListItemComponent} from './catalogue-list-item/catalogue-list
   ],
 })
 export class HsAddDataCatalogueComponent implements OnInit {
+  hsLanguageService = inject(HsLanguageService);
+  hsConfig = inject(HsConfig);
+  hsAddDataCatalogueService = inject(HsAddDataCatalogueService);
+  hsAddDataCatalogueMapService = inject(HsAddDataCatalogueMapService);
+  hsLayoutService = inject(HsLayoutService);
+  hsLaymanService = inject(HsLaymanService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsAddDataService = inject(HsAddDataService);
+
   types: any[];
   data: any;
   advancedSearch: boolean;
@@ -46,16 +55,7 @@ export class HsAddDataCatalogueComponent implements OnInit {
   readonly dataTypes = ['all', 'service', 'dataset'];
   readonly sortbyTypes = ['date', 'title', 'bbox'];
 
-  constructor(
-    public hsLanguageService: HsLanguageService,
-    public hsConfig: HsConfig,
-    public hsAddDataCatalogueService: HsAddDataCatalogueService,
-    public hsAddDataCatalogueMapService: HsAddDataCatalogueMapService,
-    public hsLayoutService: HsLayoutService,
-    public hsLaymanService: HsLaymanService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private hsAddDataService: HsAddDataService,
-  ) {
+  constructor() {
     this.advancedSearch = false;
   }
 

--- a/projects/hslayers/components/add-data/common/add-layer-authorized/add-layer-authorized.component.ts
+++ b/projects/hslayers/components/add-data/common/add-layer-authorized/add-layer-authorized.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 
 import {FileDataObject} from 'hslayers-ng/types';
 import {HsAddDataCommonFileService} from 'hslayers-ng/services/add-data';
@@ -10,12 +10,10 @@ import {HsLaymanService} from 'hslayers-ng/services/save-map';
   standalone: false,
 })
 export class HsAddLayerAuthorizedComponent {
-  @Input() data: FileDataObject;
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  hsLaymanService = inject(HsLaymanService);
 
-  constructor(
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    public hsLaymanService: HsLaymanService,
-  ) {}
+  @Input() data: FileDataObject;
 
   async add(): Promise<void> {
     await this.hsAddDataCommonFileService.addAsService(this.data);

--- a/projects/hslayers/components/add-data/common/advanced-options/advanced-options.component.ts
+++ b/projects/hslayers/components/add-data/common/advanced-options/advanced-options.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 
 import {
   FileDataObject,
@@ -17,10 +17,11 @@ export type VectorFileDataType = IntersectWithTooltip<
   standalone: false,
 })
 export class HsAdvancedOptionsComponent implements OnInit {
+  private hsAddDataVectorService = inject(HsAddDataVectorService);
+
   @Input() data: VectorFileDataType;
 
   isKml: boolean;
-  constructor(private hsAddDataVectorService: HsAddDataVectorService) {}
   ngOnInit(): void {
     this.isKml = this.hsAddDataVectorService.isKml(
       this.data.type,

--- a/projects/hslayers/components/add-data/common/new-layer-form/new-layer-form.component.ts
+++ b/projects/hslayers/components/add-data/common/new-layer-form/new-layer-form.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 
 import {FileDataObject} from 'hslayers-ng/types';
 import {HsAddDataCommonFileService} from 'hslayers-ng/services/add-data';
@@ -12,6 +12,10 @@ import {HsUploadedFiles} from 'hslayers-ng/common/upload';
   standalone: false,
 })
 export class HsNewLayerFormComponent implements OnInit {
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  private hsFileService = inject(HsFileService);
+  hsLaymanService = inject(HsLaymanService);
+
   advancedPanelVisible = false;
   @Input() data: FileDataObject;
 
@@ -19,11 +23,6 @@ export class HsNewLayerFormComponent implements OnInit {
     list: string;
     title: string;
   };
-  constructor(
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    private hsFileService: HsFileService,
-    public hsLaymanService: HsLaymanService,
-  ) {}
 
   ngOnInit() {
     this.allowedStyles = {

--- a/projects/hslayers/components/add-data/common/target-position/target-position.component.ts
+++ b/projects/hslayers/components/add-data/common/target-position/target-position.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, Output, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -12,10 +12,10 @@ import {HsLayerManagerService} from 'hslayers-ng/services/layer-manager';
   standalone: false,
 })
 export class HsPositionComponent {
+  hsLayerManagerService = inject(HsLayerManagerService);
+
   @Input() addUnder: Layer<Source> | null;
   @Output() addUnderChange = new EventEmitter<Layer<Source> | null>();
-
-  constructor(public hsLayerManagerService: HsLayerManagerService) {}
 
   updateChanges(): void {
     this.addUnderChange.next(this.addUnder);

--- a/projects/hslayers/components/add-data/common/url/add/add.component.ts
+++ b/projects/hslayers/components/add-data/common/url/add/add.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 
 import {HsAddDataUrlService} from 'hslayers-ng/services/add-data';
 import {HsUrlTypeServiceModel, Service} from 'hslayers-ng/types';
@@ -9,13 +9,13 @@ import {HsUrlTypeServiceModel, Service} from 'hslayers-ng/types';
   standalone: false,
 })
 export class HsUrlAddComponent {
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+
   @Input() services?: Service[];
 
   @Input() layers: {name: string; checked: boolean}[];
   @Input() injectedService: HsUrlTypeServiceModel;
   _selectAll = true;
-
-  constructor(public hsAddDataUrlService: HsAddDataUrlService) {}
 
   /**
    * Select all records from service.

--- a/projects/hslayers/components/add-data/common/url/details/details.component.ts
+++ b/projects/hslayers/components/add-data/common/url/details/details.component.ts
@@ -1,4 +1,4 @@
-import {AfterContentInit, Component, Input} from '@angular/core';
+import {AfterContentInit, Component, Input, inject} from '@angular/core';
 
 import {
   AddDataUrlType,
@@ -13,13 +13,15 @@ import {HsAddDataCommonService} from 'hslayers-ng/services/add-data';
   standalone: false,
 })
 export class HsUrlDetailsComponent implements AfterContentInit {
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+
   @Input() injectedService: HsUrlTypeServiceModel;
   @Input() type: AddDataUrlType;
 
   data: UrlDataObject;
   getDimensionValues: any;
   advancedPanelVisible = false;
-  constructor(public hsAddDataCommonService: HsAddDataCommonService) {}
+
   ngAfterContentInit(): void {
     this.data = this.injectedService.data;
     if (this.type == 'wms') {

--- a/projects/hslayers/components/add-data/common/url/progress/progress.component.ts
+++ b/projects/hslayers/components/add-data/common/url/progress/progress.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
 
@@ -9,5 +9,5 @@ import {HsEventBusService} from 'hslayers-ng/services/event-bus';
   standalone: false,
 })
 export class HsUrlProgressComponent {
-  constructor(public hsEventBusService: HsEventBusService) {}
+  hsEventBusService = inject(HsEventBusService);
 }

--- a/projects/hslayers/components/add-data/common/url/url.component.ts
+++ b/projects/hslayers/components/add-data/common/url/url.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, Output, inject} from '@angular/core';
 
 import {HsHistoryListService} from 'hslayers-ng/common/history-list';
 
@@ -8,6 +8,8 @@ import {HsHistoryListService} from 'hslayers-ng/common/history-list';
   standalone: false,
 })
 export class HsCommonUrlComponent {
+  private historyListService = inject(HsHistoryListService);
+
   items;
   what;
   @Input() type: any;
@@ -17,7 +19,7 @@ export class HsCommonUrlComponent {
   @Output() urlChange = new EventEmitter<any>();
   @Output() connect = new EventEmitter<any>();
 
-  constructor(private historyListService: HsHistoryListService) {
+  constructor() {
     this.items = this.historyListService.readSourceHistory(this.what);
   }
 

--- a/projects/hslayers/components/add-data/file/file-base.component.ts
+++ b/projects/hslayers/components/add-data/file/file-base.component.ts
@@ -30,6 +30,11 @@ import {HsUploadComponent} from 'hslayers-ng/common/upload';
   standalone: false,
 })
 export class HsAddDataFileBaseComponent implements OnInit, AfterViewInit {
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  hsLayoutService = inject(HsLayoutService);
+  hsConfig = inject(HsConfig);
+
   app: string;
   data: FileDataObject;
   fileInput: ElementRef;
@@ -38,12 +43,6 @@ export class HsAddDataFileBaseComponent implements OnInit, AfterViewInit {
   private destroyRef = inject(DestroyRef);
 
   @ViewChild(HsUploadComponent) hsUploadComponent: HsUploadComponent;
-  constructor(
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    public hsLayoutService: HsLayoutService,
-    public hsConfig: HsConfig,
-  ) {}
 
   clearInput(): void {
     if (this.fileInput) {

--- a/projects/hslayers/components/add-data/file/file.component.ts
+++ b/projects/hslayers/components/add-data/file/file.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {AddDataFileType, FILES_SUPPORTED} from 'hslayers-ng/types';
 import {AddDataFileValues} from './file-type-values';
@@ -11,13 +11,13 @@ import {HsLanguageService} from 'hslayers-ng/services/language';
   standalone: false,
 })
 export class HsAddDataFileComponent {
+  hsConfig = inject(HsConfig);
+  hsLanguageService = inject(HsLanguageService);
+
   typeSelected: AddDataFileType;
   types: {id: AddDataFileType; text: string}[];
 
-  constructor(
-    public hsConfig: HsConfig,
-    public hsLanguageService: HsLanguageService,
-  ) {
+  constructor() {
     if (Array.isArray(this.hsConfig.uploadTypes)) {
       this.types = this.hsConfig.uploadTypes
         .filter((type) => FILES_SUPPORTED.includes(type))

--- a/projects/hslayers/components/add-data/file/file.service.ts
+++ b/projects/hslayers/components/add-data/file/file.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {FileDataObject} from 'hslayers-ng/types';
 import {HsAddDataCommonFileService} from 'hslayers-ng/services/add-data';
@@ -7,11 +7,10 @@ import {HsUploadedFiles} from 'hslayers-ng/common/upload';
 
 @Injectable({providedIn: 'root'})
 export class HsFileService {
+  hsLanguageService = inject(HsLanguageService);
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+
   fileUploadErrorHeader = 'ADDLAYERS.couldNotUploadSelectedFile';
-  constructor(
-    public hsLanguageService: HsLanguageService,
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-  ) {}
 
   async read(evt: HsUploadedFiles, readAsText: boolean = false): Promise<void> {
     const filesRead = [];

--- a/projects/hslayers/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
+++ b/projects/hslayers/components/add-data/file/raster/raster-timeseries/raster-timeseries.component.ts
@@ -22,6 +22,10 @@ import {HsToastService} from 'hslayers-ng/common/toast';
   standalone: false,
 })
 export class RasterTimeseriesComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private hsToastService = inject(HsToastService);
+  private hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+
   @Input() data: FileDataObject;
 
   @ViewChild('acc') accordion: NgbAccordionDirective;
@@ -48,11 +52,7 @@ export class RasterTimeseriesComponent implements OnInit {
     },
   ];
 
-  constructor(
-    private fb: FormBuilder,
-    private hsToastService: HsToastService,
-    private hsAddDataCommonFileService: HsAddDataCommonFileService,
-  ) {
+  constructor() {
     this.form = this.fb.group({
       /* Regex string encoding of date pattern used in file name  */
       regex: ['', Validators.required],

--- a/projects/hslayers/components/add-data/file/raster/raster.component.ts
+++ b/projects/hslayers/components/add-data/file/raster/raster.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 
 import {AddDataFileType} from 'hslayers-ng/types';
 import {
@@ -20,21 +20,14 @@ export class HsFileRasterComponent
   extends HsAddDataFileBaseComponent
   implements OnInit
 {
+  hsFileService = inject(HsFileService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  hsLayoutService = inject(HsLayoutService);
+  hsConfig = inject(HsConfig);
+
   @Input() fileType: Extract<AddDataFileType, 'raster' | 'raster-ts'>;
-  constructor(
-    public hsFileService: HsFileService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    public hsLayoutService: HsLayoutService,
-    public hsConfig: HsConfig,
-  ) {
-    super(
-      hsAddDataCommonService,
-      hsAddDataCommonFileService,
-      hsLayoutService,
-      hsConfig,
-    );
-  }
+
   ngOnInit(): void {
     this.baseFileType = this.fileType;
     this.acceptedFormats =

--- a/projects/hslayers/components/add-data/file/shp/shp.component.ts
+++ b/projects/hslayers/components/add-data/file/shp/shp.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, OnInit} from '@angular/core';
+import {AfterViewInit, Component, OnInit, inject} from '@angular/core';
 
 import {AddDataFileType} from 'hslayers-ng/types';
 import {DEFAULT_SHP_LOAD_TYPE} from '../../enums/load-types.const';
@@ -21,21 +21,13 @@ export class HsFileShpComponent
   extends HsAddDataFileBaseComponent
   implements OnInit, AfterViewInit
 {
+  hsFileService = inject(HsFileService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  hsLayoutService = inject(HsLayoutService);
+  hsConfig = inject(HsConfig);
+
   fileType: AddDataFileType = 'shp';
-  constructor(
-    public hsFileService: HsFileService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    public hsLayoutService: HsLayoutService,
-    public hsConfig: HsConfig,
-  ) {
-    super(
-      hsAddDataCommonService,
-      hsAddDataCommonFileService,
-      hsLayoutService,
-      hsConfig,
-    );
-  }
 
   ngAfterViewInit(): void {
     this.fileInput = this.hsUploadComponent.getFileInput();

--- a/projects/hslayers/components/add-data/url/add-data-url.component.ts
+++ b/projects/hslayers/components/add-data/url/add-data-url.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {AddDataUrlType, SERVICES_SUPPORTED_BY_URL} from 'hslayers-ng/types';
 import {AddDataUrlValues} from './add-data-url-values';
@@ -20,19 +20,17 @@ import {HsShareUrlService} from 'hslayers-ng/services/share';
   standalone: false,
 })
 export class HsAddDataUrlComponent implements OnInit {
-  types: {id: AddDataUrlType; text: string}[];
+  hsConfig = inject(HsConfig);
+  hsLanguageService = inject(HsLanguageService);
+  hsShareUrlService = inject(HsShareUrlService);
+  hsLog = inject(HsLogService);
+  hsLayoutService = inject(HsLayoutService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsDialogContainerService = inject(HsDialogContainerService);
 
-  constructor(
-    public hsConfig: HsConfig,
-    public hsLanguageService: HsLanguageService,
-    public hsShareUrlService: HsShareUrlService,
-    public hsLog: HsLogService,
-    public hsLayoutService: HsLayoutService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsDialogContainerService: HsDialogContainerService,
-  ) {}
+  types: {id: AddDataUrlType; text: string}[];
 
   ngOnInit() {
     if (Array.isArray(this.hsConfig.connectTypes)) {

--- a/projects/hslayers/components/add-data/url/arcgis/arcgis.component.ts
+++ b/projects/hslayers/components/add-data/url/arcgis/arcgis.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {
   HsAddDataCommonService,
@@ -12,9 +12,7 @@ import {
   standalone: false,
 })
 export class HsUrlArcGisComponent {
-  constructor(
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsUrlArcGisService: HsUrlArcGisService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-  ) {}
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsUrlArcGisService = inject(HsUrlArcGisService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
 }

--- a/projects/hslayers/components/add-data/url/geosparql/geosparql.component.ts
+++ b/projects/hslayers/components/add-data/url/geosparql/geosparql.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {
   HsAddDataCommonFileService,
@@ -15,6 +15,13 @@ import {HsUrlGeoSparqlService} from './geosparql.service';
   standalone: false,
 })
 export class HsUrlGeoSparqlComponent {
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  hsAddDataVectorService = inject(HsAddDataVectorService);
+  hsHistoryListService = inject(HsHistoryListService);
+  hsLayoutService = inject(HsLayoutService);
+  hsUrlGeoSparqlService = inject(HsUrlGeoSparqlService);
+
   querySuccessful: boolean;
   showDetails: boolean;
   validEndpoint: boolean;
@@ -30,14 +37,7 @@ export class HsUrlGeoSparqlComponent {
     url?: string;
   };
 
-  constructor(
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    public hsAddDataVectorService: HsAddDataVectorService,
-    public hsHistoryListService: HsHistoryListService,
-    public hsLayoutService: HsLayoutService,
-    public hsUrlGeoSparqlService: HsUrlGeoSparqlService,
-  ) {
+  constructor() {
     this.data = {
       type: 'sparql',
     };

--- a/projects/hslayers/components/add-data/url/geosparql/geosparql.service.ts
+++ b/projects/hslayers/components/add-data/url/geosparql/geosparql.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {lastValueFrom, takeUntil} from 'rxjs';
 
 import {HsAddDataUrlService} from 'hslayers-ng/services/add-data';
@@ -11,16 +11,16 @@ import {UrlDataObject} from 'hslayers-ng/types';
 
 @Injectable({providedIn: 'root'})
 export class HsUrlGeoSparqlService {
+  httpClient = inject(HttpClient);
+  hsEventBusService = inject(HsEventBusService);
+  hsLanguageService = inject(HsLanguageService);
+  hsLog = inject(HsLogService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  private hsToastService = inject(HsToastService);
+
   data: UrlDataObject;
 
-  constructor(
-    public httpClient: HttpClient,
-    public hsEventBusService: HsEventBusService,
-    public hsLanguageService: HsLanguageService,
-    public hsLog: HsLogService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    private hsToastService: HsToastService,
-  ) {
+  constructor() {
     this.data = {
       table: {
         trackBy: 'id',

--- a/projects/hslayers/components/add-data/url/wfs/wfs.component.ts
+++ b/projects/hslayers/components/add-data/url/wfs/wfs.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {
   HsAddDataCommonService,
@@ -12,10 +12,9 @@ import {
   standalone: false,
 })
 export class HsUrlWfsComponent {
-  title = ''; //FIXME: unused
-  constructor(
-    public hsUrlWfsService: HsUrlWfsService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-  ) {}
+  hsUrlWfsService = inject(HsUrlWfsService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+
+  title = '';
 }

--- a/projects/hslayers/components/add-data/url/wms/wms.component.ts
+++ b/projects/hslayers/components/add-data/url/wms/wms.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {
   HsAddDataCommonService,
@@ -12,9 +12,7 @@ import {
   standalone: false,
 })
 export class HsUrlWmsComponent {
-  constructor(
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    public hsUrlWmsService: HsUrlWmsService,
-  ) {}
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  hsUrlWmsService = inject(HsUrlWmsService);
 }

--- a/projects/hslayers/components/add-data/url/wmts/wmts.component.ts
+++ b/projects/hslayers/components/add-data/url/wmts/wmts.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {
   HsAddDataCommonService,
@@ -12,9 +12,7 @@ import {
   standalone: false,
 })
 export class HsUrlWmtsComponent {
-  constructor(
-    public hsAddDataOwsService: HsAddDataOwsService,
-    public hsUrlWmtsService: HsUrlWmtsService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-  ) {}
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  hsUrlWmtsService = inject(HsUrlWmtsService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
 }

--- a/projects/hslayers/components/add-data/vector/vector-url-parser.service.ts
+++ b/projects/hslayers/components/add-data/vector/vector-url-parser.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {HsAddDataVectorService} from 'hslayers-ng/services/add-data';
 import {HsMapService} from 'hslayers-ng/services/map';
@@ -8,11 +8,11 @@ import {HsShareUrlService} from 'hslayers-ng/services/share';
   providedIn: 'root',
 })
 export class HsVectorUrlParserService {
-  constructor(
-    public hsMapService: HsMapService,
-    public hsShareUrlService: HsShareUrlService,
-    public hsAddDataVectorService: HsAddDataVectorService,
-  ) {
+  hsMapService = inject(HsMapService);
+  hsShareUrlService = inject(HsShareUrlService);
+  hsAddDataVectorService = inject(HsAddDataVectorService);
+
+  constructor() {
     this.hsMapService.loaded().then((map) => {
       this.checkUrlParamsAndAdd();
     });

--- a/projects/hslayers/components/add-data/vector/vector-url/vector-url.component.ts
+++ b/projects/hslayers/components/add-data/vector/vector-url/vector-url.component.ts
@@ -18,17 +18,16 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
   standalone: false,
 })
 export class HsAddDataVectorUrlComponent implements OnInit {
+  hsHistoryListService = inject(HsHistoryListService);
+  hsAddDataVectorService = inject(HsAddDataVectorService);
+  hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  hsLayoutService = inject(HsLayoutService);
+
   @Input() fileType: 'geojson' | 'kml' | 'gpx';
 
   data: VectorDataObject;
   private destroyRef = inject(DestroyRef);
 
-  constructor(
-    public hsHistoryListService: HsHistoryListService,
-    public hsAddDataVectorService: HsAddDataVectorService,
-    public hsAddDataCommonFileService: HsAddDataCommonFileService,
-    public hsLayoutService: HsLayoutService,
-  ) {}
   connect = async (): Promise<void> => {
     const obtainable = await this.hsAddDataCommonFileService.isUrlObtainable(
       this.data.url,

--- a/projects/hslayers/components/compositions/compositions-catalogue.service.ts
+++ b/projects/hslayers/components/compositions/compositions-catalogue.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 
 import {Observable, filter, forkJoin} from 'rxjs';
 
@@ -22,6 +22,15 @@ import {debounce} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsCompositionsCatalogueService {
+  hsMapService = inject(HsMapService);
+  hsCompositionsService = inject(HsCompositionsService);
+  hsLayoutService = inject(HsLayoutService);
+  hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  hsEventBusService = inject(HsEventBusService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private _zone = inject(NgZone);
+
   compositionEntries: HsMapCompositionDescriptor[] = [];
   /**
    *List of sort by values (currently hard-coded selection),that will be applied in compositions lookup
@@ -60,16 +69,7 @@ export class HsCompositionsCatalogueService {
   loadCompositionsQuery: any;
   endpoints: HsEndpoint[] = this.hsCommonEndpointsService.endpoints();
   extentChangeSuppressed = false;
-  constructor(
-    public hsMapService: HsMapService,
-    public hsCompositionsService: HsCompositionsService,
-    public hsLayoutService: HsLayoutService,
-    public hsCommonEndpointsService: HsCommonEndpointsService,
-    public hsEventBusService: HsEventBusService,
-    public hsDialogContainerService: HsDialogContainerService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private _zone: NgZone,
-  ) {
+  constructor() {
     this.hsLayoutService.mainpanel$.subscribe((which) => {
       if (
         this.hsLayoutService.mainpanel === 'compositions' ||
@@ -164,9 +164,11 @@ export class HsCompositionsCatalogueService {
         observables.push(this.loadCompositionFromEndpoint(endpoint));
       }
       this.loadCompositionsQuery = forkJoin(observables).subscribe(() => {
-        suspendLimitCalculation
-          ? this.createCompositionList()
-          : this.calculateEndpointLimits();
+        if (suspendLimitCalculation) {
+          this.createCompositionList();
+        } else {
+          this.calculateEndpointLimits();
+        }
       });
     });
   }

--- a/projects/hslayers/components/compositions/compositions-list-item.component.ts
+++ b/projects/hslayers/components/compositions/compositions-list-item.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 
 import {HsCompositionsCatalogueService} from './compositions-catalogue.service';
 import {HsCompositionsDeleteDialogComponent} from './dialogs/delete-dialog.component';
@@ -18,18 +18,18 @@ import {HsCommonLaymanService} from 'hslayers-ng/common/layman';
   standalone: false,
 })
 export class HsCompositionsListItemComponent {
+  private hsCompositionsService = inject(HsCompositionsService);
+  private hsToastService = inject(HsToastService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsConfig = inject(HsConfig);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsCompositionsCatalogueService = inject(
+    HsCompositionsCatalogueService,
+  );
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+
   @Input() composition: HsMapCompositionDescriptor;
   @Input() selectedCompId: string;
-
-  constructor(
-    private hsCompositionsService: HsCompositionsService,
-    private hsToastService: HsToastService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsConfig: HsConfig,
-    private hsLanguageService: HsLanguageService,
-    private hsCompositionsCatalogueService: HsCompositionsCatalogueService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-  ) {}
 
   /**
    * Load selected composition

--- a/projects/hslayers/components/compositions/compositions-map.service.ts
+++ b/projects/hslayers/components/compositions/compositions-map.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {EventsKey} from 'ol/events';
 import {Feature} from 'ol';
@@ -23,15 +23,15 @@ import {setHighlighted} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsCompositionsMapService {
+  private hsMapService = inject(HsMapService);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsSaveMapService = inject(HsSaveMapService);
+  private hsCommonEndpointsService = inject(HsCommonEndpointsService);
+
   extentLayer: VectorLayer<VectorSource<Feature>>;
   pointerMoveListener: EventsKey;
 
-  constructor(
-    private hsMapService: HsMapService,
-    private hsLayoutService: HsLayoutService,
-    private hsSaveMapService: HsSaveMapService,
-    private hsCommonEndpointsService: HsCommonEndpointsService,
-  ) {
+  constructor() {
     this.hsLayoutService.mainpanel$.subscribe((which) => {
       if (this.extentLayer) {
         if (

--- a/projects/hslayers/components/compositions/compositions.component.ts
+++ b/projects/hslayers/components/compositions/compositions.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, OnInit, signal} from '@angular/core';
+import {Component, computed, OnInit, signal, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {filter} from 'rxjs/operators';
 
@@ -24,6 +24,20 @@ export class HsCompositionsComponent
   extends HsPanelBaseComponent
   implements OnInit
 {
+  hsConfig = inject(HsConfig);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsCompositionsService = inject(HsCompositionsService);
+  private hsCompositionsParserService = inject(HsCompositionsParserService);
+  private hsCompositionsMapService = inject(HsCompositionsMapService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  hsCompositionsCatalogueService = inject(HsCompositionsCatalogueService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  /*
+   * Make sure the hsLayerSynchronizerService is available in the setups with add-data
+   */
+  private hsLayerSynchronizerService = inject(HsLayerSynchronizerService);
+
   keywordsVisible = false;
   themesVisible = false;
   urlToAdd = '';
@@ -37,21 +51,7 @@ export class HsCompositionsComponent
   loadFilteredCompositions: any;
   name = 'compositions';
 
-  constructor(
-    public hsConfig: HsConfig,
-    private hsEventBusService: HsEventBusService,
-    private hsCompositionsService: HsCompositionsService,
-    private hsCompositionsParserService: HsCompositionsParserService,
-    private hsCompositionsMapService: HsCompositionsMapService,
-    private hsDialogContainerService: HsDialogContainerService,
-    public hsCompositionsCatalogueService: HsCompositionsCatalogueService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonEndpointsService: HsCommonEndpointsService,
-    /**
-     * Make sure the hsLayerSynchronizerService is available in the setups with add-data
-     */
-    private hsLayerSynchronizerService: HsLayerSynchronizerService,
-  ) {
+  constructor() {
     super();
 
     this.hsEventBusService.vectorQueryFeatureSelection

--- a/projects/hslayers/components/compositions/compositions.service.ts
+++ b/projects/hslayers/components/compositions/compositions.service.ts
@@ -1,9 +1,9 @@
 import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
-import {Observable, Subject, filter, lastValueFrom, pipe} from 'rxjs';
+import {Observable, Subject, lastValueFrom} from 'rxjs';
 
 import {DuplicateHandling, HsMapService} from 'hslayers-ng/services/map';
 import {HS_PRMS, HsShareUrlService} from 'hslayers-ng/services/share';
@@ -25,29 +25,29 @@ import {HsProxyService} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsCompositionsService {
+  private http = inject(HttpClient);
+  private hsMapService = inject(HsMapService);
+  private hsCompositionsParserService = inject(HsCompositionsParserService);
+  private hsConfig = inject(HsConfig);
+  private HsShareUrlService = inject(HsShareUrlService);
+  private hsCompositionsMickaService = inject(HsCompositionsMickaService);
+  private hsCompositionsLaymanService = inject(HsCompositionsLaymanService);
+  private hsLanguageService = inject(HsLanguageService);
+  private $log = inject(HsLogService);
+  private hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  private hsCompositionsMapService = inject(HsCompositionsMapService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsToastService = inject(HsToastService);
+  private hsLayerManagerService = inject(HsLayerManagerService);
+  private hsProxyService = inject(HsProxyService);
+
   data: any = {};
   compositionToLoad: {url: string; title: string};
   notSavedOrEditedCompositionLoading: Subject<{url: string; record?: any}> =
     new Subject();
   compositionNotFoundAtUrl: Subject<any> = new Subject();
   shareId: string;
-  constructor(
-    private http: HttpClient,
-    private hsMapService: HsMapService,
-    private hsCompositionsParserService: HsCompositionsParserService,
-    private hsConfig: HsConfig,
-    private HsShareUrlService: HsShareUrlService,
-    private hsCompositionsMickaService: HsCompositionsMickaService,
-    private hsCompositionsLaymanService: HsCompositionsLaymanService,
-    private hsLanguageService: HsLanguageService,
-    private $log: HsLogService,
-    private hsCommonEndpointsService: HsCommonEndpointsService,
-    private hsCompositionsMapService: HsCompositionsMapService,
-    private hsEventBusService: HsEventBusService,
-    private hsToastService: HsToastService,
-    private hsLayerManagerService: HsLayerManagerService,
-    private hsProxyService: HsProxyService,
-  ) {
+  constructor() {
     this.hsEventBusService.compositionEdits.subscribe(() => {
       this.hsCompositionsParserService.composition_edited = true;
     });
@@ -58,9 +58,11 @@ export class HsCompositionsService {
     });
 
     const permalink = this.HsShareUrlService.getParamValue(HS_PRMS.permalink);
-    permalink
-      ? this.parsePermalinkLayers(permalink)
-      : this.tryParseCompositionFromUrlParam();
+    if (permalink) {
+      this.parsePermalinkLayers(permalink);
+    } else {
+      this.tryParseCompositionFromUrlParam();
+    }
 
     if (this.hsConfig.base_layers && !permalink) {
       this.loadBaseLayersComposition();

--- a/projects/hslayers/components/compositions/dialogs/delete-dialog.component.ts
+++ b/projects/hslayers/components/compositions/dialogs/delete-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 
 import {HsCompositionsService} from '../compositions.service';
 import {
@@ -11,16 +11,14 @@ import {
   standalone: false,
 })
 export class HsCompositionsDeleteDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsCompositionsService = inject(HsCompositionsService);
+
   viewRef: ViewRef;
   data: any;
 
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public HsCompositionsService: HsCompositionsService,
-  ) {}
-
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 
   /**
@@ -28,7 +26,7 @@ export class HsCompositionsDeleteDialogComponent implements HsDialogComponent {
    * Delete selected composition from project (including deletion from composition server, useful for user created compositions)
    */
   async delete(composition): Promise<void> {
-    await this.HsCompositionsService.deleteComposition(composition);
+    await this.hsCompositionsService.deleteComposition(composition);
     this.close();
   }
 }

--- a/projects/hslayers/components/compositions/dialogs/info-dialog.component.html
+++ b/projects/hslayers/components/compositions/dialogs/info-dialog.component.html
@@ -85,7 +85,7 @@
           </div>
           <div *ngFor="let metadata of data.info.metadata | keyvalue">
             <div class="row" *ngIf="metadata.value">
-              <div class="col-md-3"><b>{{HsCompositionsService.translateString('COMPOSITIONS.dialogInfo.metadata', metadata.key)}}</b></div>
+              <div class="col-md-3"><b>{{hsCompositionsService.translateString('COMPOSITIONS.dialogInfo.metadata', metadata.key)}}</b></div>
               <div class="col-md-9" style="overflow-wrap: break-word">{{metadata.value}}</div>
             </div>
           </div>
@@ -101,7 +101,7 @@
           <div>
             @if (data.value) {
             <div class="row">
-              <div class="col-md-4"><b>{{HsCompositionsService.translateString('SAVECOMPOSITION.form',
+              <div class="col-md-4"><b>{{hsCompositionsService.translateString('SAVECOMPOSITION.form',
                   data.key)}}</b></div>
               <div class="col-md-8">{{data.value}}</div>
             </div>
@@ -116,7 +116,7 @@
           @if (data.value) {
           <div class="row">
             <div class="col-md-4" style="word-break:break-all">
-              <b>{{HsCompositionsService.translateString('SAVECOMPOSITION.form', data.key)}}</b>
+              <b>{{hsCompositionsService.translateString('SAVECOMPOSITION.form', data.key)}}</b>
             </div>
             <div class="col-md-8">{{data.value}}</div>
           </div>

--- a/projects/hslayers/components/compositions/dialogs/info-dialog.component.ts
+++ b/projects/hslayers/components/compositions/dialogs/info-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 import {KeyValuePipe} from '@angular/common';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -16,6 +16,9 @@ import {HsClipboardTextComponent} from 'hslayers-ng/common/clipboard-text';
   imports: [TranslatePipe, HsClipboardTextComponent, KeyValuePipe],
 })
 export class HsCompositionsInfoDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsCompositionsService = inject(HsCompositionsService);
+
   viewRef: ViewRef;
   data: {
     info: {
@@ -33,12 +36,8 @@ export class HsCompositionsInfoDialogComponent implements HsDialogComponent {
       [key: string]: any;
     };
   };
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public HsCompositionsService: HsCompositionsService,
-  ) {}
 
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/components/compositions/dialogs/overwrite-dialog.component.ts
+++ b/projects/hslayers/components/compositions/dialogs/overwrite-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 
 import {HsCompositionsParserService} from 'hslayers-ng/services/compositions';
 import {HsCompositionsService} from '../compositions.service';
@@ -16,26 +16,24 @@ import {HsSaveMapManagerService} from 'hslayers-ng/components/save-map';
 export class HsCompositionsOverwriteDialogComponent
   implements HsDialogComponent
 {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsCompositionsService = inject(HsCompositionsService);
+  hsSaveMapManagerService = inject(HsSaveMapManagerService);
+  hsCompositionParserService = inject(HsCompositionsParserService);
+
   viewRef: ViewRef;
   data: any;
 
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public HsCompositionsService: HsCompositionsService,
-    public HsSaveMapManagerService: HsSaveMapManagerService,
-    public hsCompositionParserService: HsCompositionsParserService,
-  ) {}
-
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 
   /**
    * Load new composition without saving old composition
    */
   overwrite() {
-    this.HsCompositionsService.loadComposition(
-      this.HsCompositionsService.compositionToLoad.url,
+    this.hsCompositionsService.loadComposition(
+      this.hsCompositionsService.compositionToLoad.url,
       true,
     );
     this.close();
@@ -45,7 +43,7 @@ export class HsCompositionsOverwriteDialogComponent
    * Save currently loaded composition first
    */
   save() {
-    this.HsSaveMapManagerService.openPanel(null);
+    this.hsSaveMapManagerService.openPanel(null);
     this.close();
   }
 
@@ -53,8 +51,8 @@ export class HsCompositionsOverwriteDialogComponent
    * Load new composition (with service_parser Load function) and merge it with old composition
    */
   add() {
-    this.HsCompositionsService.loadComposition(
-      this.HsCompositionsService.compositionToLoad.url,
+    this.hsCompositionsService.loadComposition(
+      this.hsCompositionsService.compositionToLoad.url,
       false,
     );
     this.close();

--- a/projects/hslayers/components/compositions/dialogs/share-dialog.component.ts
+++ b/projects/hslayers/components/compositions/dialogs/share-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 
 import {
   HsDialogComponent,
@@ -11,20 +11,18 @@ import {HsShareService} from 'hslayers-ng/components/share';
   standalone: false,
 })
 export class HsCompositionsShareDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsShareService = inject(HsShareService);
+
   viewRef: ViewRef;
   data: {url; title; abstract};
 
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public HsShareService: HsShareService,
-  ) {}
-
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 
   shareOnSocial() {
-    this.HsShareService.openInShareApi(
+    this.hsShareService.openInShareApi(
       this.data.title,
       this.data.abstract,
       this.data.url,

--- a/projects/hslayers/components/compositions/endpoints/compositions-layman.service.ts
+++ b/projects/hslayers/components/compositions/endpoints/compositions-layman.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Observable, catchError, lastValueFrom, map, of, timeout} from 'rxjs';
 import {transformExtent} from 'ol/proj';
@@ -23,15 +23,13 @@ import {addExtentFeature} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsCompositionsLaymanService {
-  constructor(
-    private $http: HttpClient,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCompositionsParserService: HsCompositionsParserService,
-    private hsEventBusService: HsEventBusService,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsMapService: HsMapService,
-  ) {}
+  private $http = inject(HttpClient);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCompositionsParserService = inject(HsCompositionsParserService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsMapService = inject(HsMapService);
 
   /**
    * Load composition list from the external Layman server

--- a/projects/hslayers/components/compositions/endpoints/compositions-micka.service.ts
+++ b/projects/hslayers/components/compositions/endpoints/compositions-micka.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Observable, catchError, map, of, timeout} from 'rxjs';
 
@@ -14,15 +14,13 @@ import {addExtentFeature, HsProxyService} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsCompositionsMickaService {
-  constructor(
-    private $http: HttpClient,
-    private hsMapService: HsMapService,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsLog: HsLogService,
-    private hsCompositionsParserService: HsCompositionsParserService,
-    private hsProxyService: HsProxyService,
-  ) {}
+  private $http = inject(HttpClient);
+  private hsMapService = inject(HsMapService);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsLog = inject(HsLogService);
+  private hsCompositionsParserService = inject(HsCompositionsParserService);
+  private hsProxyService = inject(HsProxyService);
 
   /**
    * Get Micka compositions query URL

--- a/projects/hslayers/components/draw/draw-edit/draw-edit.component.html
+++ b/projects/hslayers/components/draw/draw-edit/draw-edit.component.html
@@ -1,4 +1,4 @@
-@if (HsQueryBaseService.features.length === 0) {
+@if (hsQueryBaseService.features.length === 0) {
   <div class="alert alert-info w-75 m-auto mt-3 text-center" role="alert"
     >
     {{'DRAW.featureEditor.selectFeatureToEdit' | translate }}
@@ -11,7 +11,7 @@
   @for (option of editOptions; track option) {
     <button class="btn btn-sm btn-light btn-outline-primary"
       [ngClass]="{active: selectedType === option }" (click)="selectGeomOperation(option)">
-      {{HsLanguageService.getTranslationIgnoreNonExisting('DRAW.featureEditor.editOptions',option, undefined)}}
+      {{hsLanguageService.getTranslationIgnoreNonExisting('DRAW.featureEditor.editOptions',option, undefined)}}
     </button>
   }
 </div>
@@ -22,29 +22,29 @@
       {{'DRAW.featureEditor.drawNewFeature' | translate }}
       @if (selectedType !== 'split') {
         <button class="w-50 btn btn-sm btn-light btn-outline-primary"
-          (click)="setType('Polygon')" [ngClass]="{active: HsDrawService.type==='Polygon' }"
+          (click)="setType('Polygon')" [ngClass]="{active: hsDrawService.type==='Polygon' }"
           [title]="'COMMON.polygon' | translate ">
           <i class="fa-solid fa-draw-polygon"></i>
         </button>
       }
       @if (selectedType === 'split') {
         <button class="w-50 btn btn-sm btn-light btn-outline-primary"
-          [ngClass]="{active: HsDrawService.type==='LineString' }" (click)="setType('LineString')"
+          [ngClass]="{active: hsDrawService.type==='LineString' }" (click)="setType('LineString')"
           data-toggle="tooltip" [title]="'COMMON.line' | translate ">
           <i class="fa-solid fa-slash"></i>
         </button>
       }
       <span class="py-1"> {{'DRAW.featureEditor.orSelectOne' | translate }}
       </span>
-      <button class="w-50 btn btn-sm btn-light btn-outline-primary" [ngClass]="{active: !HsDrawService.type }"
-        (click)="setType(HsDrawService.type)" data-toggle="tooltip" [title]="'COMMON.line' | translate ">
+      <button class="w-50 btn btn-sm btn-light btn-outline-primary" [ngClass]="{active: !hsDrawService.type }"
+        (click)="setType(hsDrawService.type)" data-toggle="tooltip" [title]="'COMMON.line' | translate ">
         <i class="fa-solid fa-arrow-pointer"></i>
       </button>
     </div>
     @if (selectedType) {
       <button class="btn btn-primary m-2 w-100" (click)="modify(selectedType)"
-        [disabled]="HsQueryBaseService.features.length < 2">{{'COMMON.continue' | translate }}:
-        {{HsLanguageService.getTranslationIgnoreNonExisting('DRAW.featureEditor.editOptions',selectedType,
+        [disabled]="hsQueryBaseService.features.length < 2">{{'COMMON.continue' | translate }}:
+        {{hsLanguageService.getTranslationIgnoreNonExisting('DRAW.featureEditor.editOptions',selectedType,
       undefined)}}</button>
     }
   </div>

--- a/projects/hslayers/components/draw/draw-layer-metadata/draw-layer-metadata.component.ts
+++ b/projects/hslayers/components/draw/draw-layer-metadata/draw-layer-metadata.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit, ViewRef} from '@angular/core';
+import {Component, Input, OnInit, ViewRef, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgClass} from '@angular/common';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -45,6 +45,11 @@ import {
 export class HsDrawLayerMetadataDialogComponent
   implements HsDialogComponent, OnInit
 {
+  hsMapService = inject(HsMapService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  hsDrawService = inject(HsDrawService);
+
   @Input() data: object;
 
   newLayerPath: string;
@@ -64,13 +69,6 @@ export class HsDrawLayerMetadataDialogComponent
   tmpFeatures: FeatureLike[] = [];
   viewRef: ViewRef;
 
-  constructor(
-    public HsMapService: HsMapService,
-    public HsDialogContainerService: HsDialogContainerService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    public hsDrawService: HsDrawService,
-  ) {}
-
   ngOnInit(): void {
     this.title = getTitle(this.layer) || '';
     this.path = getPath(this.layer) || '';
@@ -89,9 +87,9 @@ export class HsDrawLayerMetadataDialogComponent
 
       setName(this.layer, getLaymanFriendlyLayerName(getTitle(this.layer)));
       const tmpLayer =
-        this.HsMapService.findLayerByTitle('tmpDrawLayer') || null;
+        this.hsMapService.findLayerByTitle('tmpDrawLayer') || null;
       if (tmpLayer) {
-        this.HsMapService.getMap().removeLayer(tmpLayer);
+        this.hsMapService.getMap().removeLayer(tmpLayer);
       }
 
       this.attributes.forEach((a) => {
@@ -123,12 +121,12 @@ export class HsDrawLayerMetadataDialogComponent
         const event = this.getFeatureEvent();
         this.layer.getSource().dispatchEvent(event);
         this.hsDrawService.tmpDrawLayer = false;
-        this.HsDialogContainerService.destroy(this);
+        this.hsDialogContainerService.destroy(this);
       });
     } catch (error) {
       console.error('Error in confirm method:', error);
       this.hsDrawService.tmpDrawLayer = false;
-      this.HsDialogContainerService.destroy(this);
+      this.hsDialogContainerService.destroy(this);
     }
   }
 
@@ -146,7 +144,7 @@ export class HsDrawLayerMetadataDialogComponent
 
   cancel(): void {
     this.hsDrawService.selectedLayer = this.hsDrawService.previouslySelected;
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 
   pathChanged(): void {
@@ -159,6 +157,6 @@ export class HsDrawLayerMetadataDialogComponent
 
   selectLayer(layer): void {
     this.hsDrawService.selectLayer(layer);
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/components/draw/draw-panel/draw-panel.component.html
+++ b/projects/hslayers/components/draw/draw-panel/draw-panel.component.html
@@ -2,42 +2,42 @@
 
 <div class="d-flex flex-column">
   <div class="d-flex m-auto py-2 justify-content-around" style="white-space: nowrap;">
-    <button type="button" class="btn rounded btn-primary hs-toolbar-button" (click)="HsDrawService.saveDrawingLayer()"
+    <button type="button" class="btn rounded btn-primary hs-toolbar-button" (click)="hsDrawService.saveDrawingLayer()"
       [ngClass]="{'btn-sm' : sidebarPosition !== 'bottom'}">
       {{'COMMON.newDrawingLayer' | translate }}
     </button>
-    <button type="button" (click)="HsDrawService.setType(HsDrawService.type)"
+    <button type="button" (click)="hsDrawService.setType(hsDrawService.type)"
       [ngClass]="{'btn-sm' : sidebarPosition !== 'bottom'}" class="btn ms-1 rounded btn-primary hs-toolbar-button"
-      [disabled]="!HsDrawService.type">
+      [disabled]="!hsDrawService.type">
       {{'DRAW.disableDrawing' | translate }}
     </button>
   </div>
   <div class="btn-group w-100  m-auto justify-content-center"
     [ngClass]="sidebarPosition === 'bottom' ? 'btn-group-lg' : 'btn-group-sm'">
-    @if (HsDrawService.drawableLayersAvailable || HsDrawService.tmpDrawLayer) {
+    @if (hsDrawService.drawableLayersAvailable || hsDrawService.tmpDrawLayer) {
     <div class="flex-row w-100 m-auto justify-content-center align-items-center text-primary py-3 py-md-0"
       style="display: flex;">
       <p class="m-0 p-0">{{'DRAW.drawingTo' | translate }}</p>
       <div ngbDropdown style="max-width: 50%;" placement="bottom">
         <button type="button" class="btn btn-sm rounded-0 hs-toolbar-button d-flex align-items-center mw-100"
-          ngbDropdownToggle (click)="HsDrawService.fillDrawableLayers()"
-          [ngClass]="{'btn-light btn-outline-danger border-0' : HsDrawService.tmpDrawLayer,'dropdown-toggle' : HsDrawService.drawableLayersAvailable }"
-          [disabled]="!HsDrawService.drawableLayersAvailable">
-          <div class="text-truncate">{{HsDrawService.selectedLayerString()}}</div>
+          ngbDropdownToggle (click)="hsDrawService.fillDrawableLayers()"
+          [ngClass]="{'btn-light btn-outline-danger border-0' : hsDrawService.tmpDrawLayer,'dropdown-toggle' : hsDrawService.drawableLayersAvailable }"
+          [disabled]="!hsDrawService.drawableLayersAvailable">
+          <div class="text-truncate">{{hsDrawService.selectedLayerString()}}</div>
         </button>
         <div ngbDropdownMenu style="max-width: 15em;">
-          @if (HsDrawService.drawableLayers.length > 0) {
+          @if (hsDrawService.drawableLayers.length > 0) {
           <div class="d-flex align-items-center w-100 flex-column">
             <label class=" bg-primary w-100 text-light m-0 p-1">{{'DRAW.activeLayers' |
               translate }}</label>
-            @for (layer of HsDrawService.drawableLayers; track layer) {
+            @for (layer of hsDrawService.drawableLayers; track layer) {
             <a class="dropdown-item text-truncate" data-toggle="tooltip"
               [title]="'LAYERS.' + getTitle(layer) | translate : {fallbackValue: getTitle(layer)} " (click)="selectLayer(layer)">{{getTitle(layer) |
               translate }}</a>
             }<!-- TODO: Remove function call from template -->
           </div>
           }
-          @if (HsDrawService.drawableLaymanLayers.length > 0) {
+          @if (hsDrawService.drawableLaymanLayers.length > 0) {
           <div class="d-flex align-items-center w-100 flex-column">
             <div class=" bg-primary w-100 text-light m-0 p-1">
               <div class="d-flex justify-content-between">
@@ -49,14 +49,14 @@
               @if (onlyMineFilterVisible) {
               <div class="p-0 input-group-text border-0 justify-content-center bg-white">
                 <label class="m-0">
-                  <input type="checkbox" name="onlyMine" [(ngModel)]="HsDrawService.onlyMine"
-                    (ngModelChange)="HsDrawService.fillDrawableLayers(); onlyMineFilterVisible = !onlyMineFilterVisible">
+                  <input type="checkbox" name="onlyMine" [(ngModel)]="hsDrawService.onlyMine"
+                    (ngModelChange)="hsDrawService.fillDrawableLayers(); onlyMineFilterVisible = !onlyMineFilterVisible">
                   {{'COMPOSITIONS.onlyMine' | translate }}
                 </label>
               </div>
               }
             </div>
-            @for (layer of HsDrawService.drawableLaymanLayers; track layer) {
+            @for (layer of hsDrawService.drawableLaymanLayers; track layer) {
             <a class="dropdown-item text-truncate" data-toggle="tooltip" [title]="'LAYERS.' + layer.title | translate : {fallbackValue: layer.title} "
               (click)="selectLayer(layer)">{{'LAYERS.' + layer.title | translate : {fallbackValue: layer.title} }}</a>
             }
@@ -64,36 +64,36 @@
           }
         </div>
       </div>
-      @if (HsDrawService.tmpDrawLayer) {
+      @if (hsDrawService.tmpDrawLayer) {
       <button type="button" class="btn btn-light btn-outline-primary border-0 btn-sm"
-        (click)="HsDrawService.saveDrawingLayer()" [title]="'DRAW.saveDrawingToLayer' | translate ">
+        (click)="hsDrawService.saveDrawingLayer()" [title]="'DRAW.saveDrawingToLayer' | translate ">
         <i class="fa-solid fa-save"></i>
       </button>
       }
-      @if (HsDrawService.hasSomeDrawables) {
-      @if (HsDrawService.moreThanOneDrawable === true) {
+      @if (hsDrawService.hasSomeDrawables) {
+      @if (hsDrawService.moreThanOneDrawable === true) {
       <div ngbDropdown placement="bottom-right" display="dynamic" style="white-space: nowrap;"
         #removeLayersDropdown="ngbDropdown">
         <button type="button" ngbDropdownToggle class="btn btn-light  btn-outline-danger btn-sm"
-          [disabled]="!HsDrawService.drawableLayersAvailable" style="border: none !important;">
+          [disabled]="!hsDrawService.drawableLayersAvailable" style="border: none !important;">
           <i class="fa-solid fa-trash"></i>
         </button>
         <div ngbDropdownMenu class="flex-column px-1 py-2">
           <div class="d-flex align-items-center w-100 flex-column">
-            @if (HsDrawService.selectedLayer) {
+            @if (hsDrawService.selectedLayer) {
             <a class="dropdown-item"
-              (click)="HsDrawService.removeLayer(); removeLayersDropdown.close()">{{'COMMON.removeLayer'
+              (click)="hsDrawService.removeLayer(); removeLayersDropdown.close()">{{'COMMON.removeLayer'
               |
               translate }}</a>
             }
             <a class="dropdown-item"
-              (click)="HsDrawService.removeMultipleLayers(); removeLayersDropdown.close()">{{'DRAW.removeMultipleLayers'
+              (click)="hsDrawService.removeMultipleLayers(); removeLayersDropdown.close()">{{'DRAW.removeMultipleLayers'
               | translate }}</a>
           </div>
         </div>
       </div>
       } @else {
-      <button type="button" class="btn btn-light  btn-outline-danger btn-sm" (click)="HsDrawService.removeLayer()"
+      <button type="button" class="btn btn-light  btn-outline-danger btn-sm" (click)="hsDrawService.removeLayer()"
         [title]="'COMMON.removeLayer' | translate " style="border: none !important;">
         <i class="fa-solid fa-trash"></i>
       </button>
@@ -110,14 +110,14 @@
 <div class="rounded-0 my-1 draw-buttons d-flex justify-content-center"
   [ngClass]="sidebarPosition === 'bottom' ? 'btn-group-lg' : 'btn-group-sm'">
   @for (tool of drawTools; track tool.type) {
-  <button class="btn btn-light btn-outline-primary" [ngClass]="{active: HsDrawService.type === tool.type}"
+  <button class="btn btn-light btn-outline-primary" [ngClass]="{active: hsDrawService.type === tool.type}"
     (click)="setType(tool.type)" data-toggle="tooltip" [title]="tool.title | translate">
     <i [class]="tool.icon"></i>
   </button>
   }
   <div ngbDropdown placement="bottom-right" class="btn-group btn-group-sm" role="group"
     #selectionTypeDropdown="ngbDropdown">
-    <button ngbDropdownToggle type="button" [ngClass]="{active: !HsDrawService.type }"
+    <button ngbDropdownToggle type="button" [ngClass]="{active: !hsDrawService.type }"
       [title]="'STYLER.selection' | translate " class="btn btn-light btn-outline-primary">
       <i class="fa-solid fa-cursor"></i>
     </button>
@@ -126,14 +126,14 @@
         <div class="d-flex flex-row justify-content-around align-items-baseline">
           <label class="ms-1 cursor-pointer" for="draw-boxSelection">{{'DRAW.boxSelection' |
             translate }}</label>
-          <input type="checkbox" [(ngModel)]="HsDrawService.boxSelectionActive"
-            (change)="HsDrawService.toggleBoxSelection();selectionTypeDropdown.close()" id="draw-boxSelection"
+          <input type="checkbox" [(ngModel)]="hsDrawService.boxSelectionActive"
+            (change)="hsDrawService.toggleBoxSelection();selectionTypeDropdown.close()" id="draw-boxSelection"
             name="filterByExtent" class="cursor-pointer">
         </div>
-        <button class="btn btn-primary btn-sm hs-draw-selectAll" [disabled]="!HsDrawService.selectedLayer"
-          (click)="HsDrawService.selectAllFeatures();selectionTypeDropdown.close()" data-toggle="tooltip"
+        <button class="btn btn-primary btn-sm hs-draw-selectAll" [disabled]="!hsDrawService.selectedLayer"
+          (click)="hsDrawService.selectAllFeatures();selectionTypeDropdown.close()" data-toggle="tooltip"
           [title]="'DRAW.deselectAllFeatures' | translate ">
-          {{translateString('DRAW',HsDrawService.toggleSelectionString)}}
+          {{translateString('DRAW',hsDrawService.toggleSelectionString)}}
           <!-- TODO: Remove function call from template -->
         </button>
       </div>
@@ -144,24 +144,24 @@
   <div style="font-size: 0.9rem;">
     <div class="pb-2">
       <div class="form-check">
-        <input class="d-none" type="checkbox" id="hs-draw-snap" [(ngModel)]="HsDrawService.snapActive"
-          (change)="HsDrawService.toggleSnapping()" />
+        <input class="d-none" type="checkbox" id="hs-draw-snap" [(ngModel)]="hsDrawService.snapActive"
+          (change)="hsDrawService.toggleSnapping()" />
         <label for="hs-draw-snap"
-          [ngClass]="{'hs-checkmark':HsDrawService.snapActive,'hs-uncheckmark':!HsDrawService.snapActive}">{{'DRAW.allowSnapping'
+          [ngClass]="{'hs-checkmark':hsDrawService.snapActive,'hs-uncheckmark':!hsDrawService.snapActive}">{{'DRAW.allowSnapping'
           | translate }}</label>
       </div>
-      @if (HsDrawService.snapActive && HsDrawService.drawableLayers.length > 1 && !inToolbar()) {
+      @if (hsDrawService.snapActive && hsDrawService.drawableLayers.length > 1 && !inToolbar()) {
       <div class="d-flex align-items-center card flex-row justify-content-around mx-3 text-primary">
         <p class="m-0 p-0">{{'DRAW.snapTo' | translate }}:</p>
         <div ngbDropdown placement="bottom" class="w-50 d-flex justify-content-center">
           <button ngbDropdownToggle type="button"
             class="btn btn-sm rounded-0 hs-toolbar-button d-flex align-items-center mw-100"
-            (click)=" HsDrawService.fillDrawableLayers() " style=" font-size: small;">
-            <div class="mw-100 text-truncate">{{HsDrawService.snapLayerString()}}</div>
+            (click)=" hsDrawService.fillDrawableLayers() " style=" font-size: small;">
+            <div class="mw-100 text-truncate">{{hsDrawService.snapLayerString()}}</div>
           </button>
           <div ngbDropdownMenu style="max-width: 150%;">
             <div class="d-flex align-items-center w-100 flex-column">
-              @for (layer of HsDrawService.drawableLayers; track layer) {
+              @for (layer of hsDrawService.drawableLayers; track layer) {
               <a class="dropdown-item text-truncate" data-toggle="tooltip"
                 [title]="'LAYERS.' + getTitle(layer) | translate : {fallbackValue: getTitle(layer)} " (click)="changeSnapSource(layer)">{{'LAYERS.' + getTitle(layer)
                 | translate : {fallbackValue: getTitle(layer)} }}</a>

--- a/projects/hslayers/components/draw/draw-panel/draw-panel.component.ts
+++ b/projects/hslayers/components/draw/draw-panel/draw-panel.component.ts
@@ -1,5 +1,5 @@
 import {AsyncPipe, NgClass} from '@angular/common';
-import {Component, input} from '@angular/core';
+import {Component, input, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -20,15 +20,13 @@ interface DrawToolDefinition {
 @Component({
   selector: 'hs-draw-panel',
   templateUrl: './draw-panel.component.html',
-  imports: [
-    AsyncPipe,
-    TranslatePipe,
-    NgClass,
-    FormsModule,
-    NgbDropdownModule,
-  ],
+  imports: [AsyncPipe, TranslatePipe, NgClass, FormsModule, NgbDropdownModule],
 })
 export class HsDrawPanelComponent {
+  hsDrawService = inject(HsDrawService);
+  hsLayoutService = inject(HsLayoutService);
+  hsLanguageService = inject(HsLanguageService);
+
   inToolbar = input<boolean>(false);
 
   onFeatureSelected: any;
@@ -56,39 +54,33 @@ export class HsDrawPanelComponent {
     },
   ];
 
-  constructor(
-    public HsDrawService: HsDrawService,
-    public hsLayoutService: HsLayoutService,
-    public HsLanguageService: HsLanguageService,
-  ) {}
-
   translateString(module: string, text: string): string {
-    return this.HsLanguageService.getTranslationIgnoreNonExisting(module, text);
+    return this.hsLanguageService.getTranslationIgnoreNonExisting(module, text);
   }
 
   changeSnapSource(layer): void {
-    this.HsDrawService.changeSnapSource(layer);
+    this.hsDrawService.changeSnapSource(layer);
   }
 
   setType(what): void {
-    const type = this.HsDrawService.setType(what);
+    const type = this.hsDrawService.setType(what);
     if (type) {
       this.activateDrawing(this.hsLayoutService.mainpanel === 'draw');
     }
   }
 
   activateDrawing(withStyle?): void {
-    this.HsDrawService.activateDrawing({
+    this.hsDrawService.activateDrawing({
       changeStyle: withStyle ? () => this.changeStyle() : undefined,
     });
   }
 
   selectLayer(layer): void {
-    this.HsDrawService.selectLayer(layer);
+    this.hsDrawService.selectLayer(layer);
   }
 
   updateStyle(): void {
-    this.HsDrawService.updateStyle(() => this.changeStyle());
+    this.hsDrawService.updateStyle(() => this.changeStyle());
   }
 
   /**

--- a/projects/hslayers/components/draw/draw-toolbar/draw-toolbar.component.ts
+++ b/projects/hslayers/components/draw/draw-toolbar/draw-toolbar.component.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -50,17 +50,17 @@ import {isLayerDrawable} from 'hslayers-ng/services/utils';
   ],
 })
 export class HsDrawToolbarComponent extends HsGuiOverlayBaseComponent {
+  hsDrawService = inject(HsDrawService);
+  private hsMapService = inject(HsMapService);
+  private hsEventBusService = inject(HsEventBusService);
+
   drawToolbarExpanded = false;
   onlyMineFilterVisible = false;
   name = 'drawToolbar';
   getTitle = getTitle;
-  constructor(
-    public hsDrawService: HsDrawService,
-    private hsMapService: HsMapService,
-    private hsEventBusService: HsEventBusService,
-  ) {
-    super();
 
+  constructor() {
+    super();
     /**
      * Add listener for initial layers
      */

--- a/projects/hslayers/components/draw/draw.component.html
+++ b/projects/hslayers/components/draw/draw.component.html
@@ -20,11 +20,11 @@
   }
   }
   }
-  @if (HsDrawService.pendingLayers.length > 0) {
+  @if (hsDrawService.pendingLayers.length > 0) {
   <div class="m-auto w-100 p-3">
     <div class="alert alert-warning text-justify">
       <ol>
-        @for (layer of HsDrawService.pendingLayers(); track layer) {
+        @for (layer of hsDrawService.pendingLayers(); track layer) {
         <li>
           {{'DRAW.loadingLayer' | translate }} <strong>{{layer}}</strong>
         </li>

--- a/projects/hslayers/components/draw/draw.component.ts
+++ b/projects/hslayers/components/draw/draw.component.ts
@@ -1,6 +1,6 @@
 import {AsyncPipe, NgClass} from '@angular/common';
 import {BehaviorSubject} from 'rxjs';
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -30,23 +30,20 @@ import {HsDrawPanelComponent} from './draw-panel/draw-panel.component';
   ],
 })
 export class HsDrawComponent extends HsPanelBaseComponent implements OnInit {
+  hsDrawService = inject(HsDrawService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   name = 'draw';
   selectedOption = new BehaviorSubject('draw');
-  constructor(
-    public HsDrawService: HsDrawService,
-    public HsDialogContainerService: HsDialogContainerService,
-  ) {
-    super();
-  }
 
   ngOnInit(): void {
-    this.HsDrawService.layerMetadataDialog
+    this.hsDrawService.layerMetadataDialog
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(async () => {
         const {HsDrawLayerMetadataDialogComponent} = await import(
           './draw-layer-metadata/draw-layer-metadata.component'
         );
-        this.HsDialogContainerService.create(
+        this.hsDialogContainerService.create(
           HsDrawLayerMetadataDialogComponent,
           {},
         );
@@ -56,7 +53,7 @@ export class HsDrawComponent extends HsPanelBaseComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((option) => {
         if (option == 'edit') {
-          this.HsDrawService.setType(this.HsDrawService.type);
+          this.hsDrawService.setType(this.hsDrawService.type);
         }
       });
   }

--- a/projects/hslayers/components/feature-table/feature-table.component.ts
+++ b/projects/hslayers/components/feature-table/feature-table.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Vector as VectorLayer} from 'ol/layer';
@@ -19,16 +19,13 @@ export class HsFeatureTableComponent
   extends HsPanelBaseComponent
   implements OnInit
 {
+  private hsFeatureTableService = inject(HsFeatureTableService);
+  private hsConfig = inject(HsConfig);
+  private hsMapService = inject(HsMapService);
+  private hsSidebarService = inject(HsSidebarService);
+
   layers: VectorLayer<VectorSource<Feature>>[] = [];
   name = 'feature-table';
-  constructor(
-    private hsFeatureTableService: HsFeatureTableService,
-    private hsConfig: HsConfig,
-    private hsMapService: HsMapService,
-    private hsSidebarService: HsSidebarService,
-  ) {
-    super();
-  }
 
   ngOnInit(): void {
     this.hsSidebarService.addButton({

--- a/projects/hslayers/components/feature-table/feature-table.service.ts
+++ b/projects/hslayers/components/feature-table/feature-table.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Cluster, Source, Vector as VectorSource} from 'ol/source';
 import {Feature} from 'ol';
@@ -17,6 +17,8 @@ import {isLayerVectorLayer, isLayerClustered} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsFeatureTableService {
+  private hsQueryVectorService = inject(HsQueryVectorService);
+
   /**
    * Trigger for reverse sorting
    */
@@ -29,7 +31,6 @@ export class HsFeatureTableService {
    * all feature attributes for HTML table
    */
   features: HsFeatureDescriptor[] = [];
-  constructor(private hsQueryVectorService: HsQueryVectorService) {}
 
   /**
    * Checks if layer is vectorLayer and is visible in layer_manager, to exclude layers, such as, point Clicked
@@ -171,9 +172,12 @@ export class HsFeatureTableService {
    */
   sortFeaturesBy(valueName): void {
     if (this.features !== undefined && this.features.length > 1) {
-      this.lastSortValue === valueName //if last sort by value is the same as current sort table list in reverse
-        ? (this.sortReverse = !this.sortReverse)
-        : (this.sortReverse = false);
+      // If last sort by value is the same as current, reverse the sort order
+      if (this.lastSortValue === valueName) {
+        this.sortReverse = !this.sortReverse;
+      } else {
+        this.sortReverse = false;
+      }
       this.features = this.features.sort((a, b) =>
         this.sortFeatures(a, b, valueName),
       );
@@ -216,7 +220,9 @@ export class HsFeatureTableService {
     if (typeof aFeature == 'number' && typeof bFeature == 'number') {
       position = aFeature - bFeature;
     }
-    this.sortReverse ? (position = position * -1) : position;
+    if (this.sortReverse) {
+      position = position * -1;
+    }
     this.lastSortValue = valueName;
     return position;
   }

--- a/projects/hslayers/components/feature-table/layer-features.component.ts
+++ b/projects/hslayers/components/feature-table/layer-features.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
@@ -36,6 +36,10 @@ type Operation = {
   standalone: false,
 })
 export class HsLayerFeaturesComponent implements OnInit {
+  hsFeatureTableService = inject(HsFeatureTableService);
+  hsMapService = inject(HsMapService);
+  hsLanguageService = inject(HsLanguageService);
+
   /**
    * Input layer from HsConfig.layersInFeatureTable property array
    */
@@ -45,11 +49,6 @@ export class HsLayerFeaturesComponent implements OnInit {
    */
   showFeatureStats = false;
   searchedFeatures = '';
-  constructor(
-    public hsFeatureTableService: HsFeatureTableService,
-    public hsMapService: HsMapService,
-    public hsLanguageService: HsLanguageService,
-  ) {}
 
   /**
    * Activate listeners for any layer source changes to update the html table

--- a/projects/hslayers/components/geolocation/geolocation.component.ts
+++ b/projects/hslayers/components/geolocation/geolocation.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 
 import {HsGeolocationService} from './geolocation.service';
 import {HsGuiOverlayBaseComponent} from 'hslayers-ng/common/panels';
@@ -11,13 +11,11 @@ export class HsGeolocationComponent
   extends HsGuiOverlayBaseComponent
   implements OnInit
 {
+  private hsGeolocationService = inject(HsGeolocationService);
+
   collapsed: boolean;
 
   name = 'geolocationButton';
-
-  constructor(private hsGeolocationService: HsGeolocationService) {
-    super();
-  }
   ngOnInit(): void {
     this.collapsed = true;
     super.ngOnInit();

--- a/projects/hslayers/components/info/info.component.ts
+++ b/projects/hslayers/components/info/info.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {map} from 'rxjs/operators';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -12,6 +12,8 @@ import {getTitle} from 'hslayers-ng/common/extensions';
   standalone: false,
 })
 export class HsInfoComponent extends HsGuiOverlayBaseComponent {
+  private hsEventBusService = inject(HsEventBusService);
+
   /**
    * Store if composition is loaded
    */
@@ -32,7 +34,8 @@ export class HsInfoComponent extends HsGuiOverlayBaseComponent {
     takeUntilDestroyed(this.destroyRef),
   );
   name = 'info';
-  constructor(private hsEventBusService: HsEventBusService) {
+
+  constructor() {
     super();
     this.hsEventBusService.compositionLoads
       .pipe(takeUntilDestroyed())

--- a/projects/hslayers/components/language/language.component.html
+++ b/projects/hslayers/components/language/language.component.html
@@ -4,7 +4,7 @@
     </hs-panel-header>
     <div class="card-body">
       <ul class="m-3 list-group m-auto w-75 py-md-2">
-        @for (lang of available_languages; track lang) {
+        @for (lang of availableLanguages; track lang) {
           <button class="btn m-2 m-md-1 p-4 p-md-2"
             [ngClass]="isCurrentLang(lang.key) ? ' btn-primary' : ' btn-secondary'"
           (click)="setLanguage(lang.key)">{{lang.name}}</button>

--- a/projects/hslayers/components/language/language.component.ts
+++ b/projects/hslayers/components/language/language.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {HsConfig} from 'hslayers-ng/config';
@@ -14,24 +14,24 @@ export class HsLanguageComponent
   extends HsPanelBaseComponent
   implements OnInit
 {
-  available_languages: any;
-  name = 'language';
-  constructor(
-    private hsLanguageService: HsLanguageService,
-    private hsConfig: HsConfig,
-  ) {
-    super();
+  private hsLanguageService = inject(HsLanguageService);
+  private hsConfig = inject(HsConfig);
 
+  availableLanguages: any;
+  name = 'language';
+
+  constructor() {
+    super();
     this.hsConfig.configChanges.pipe(takeUntilDestroyed()).subscribe(() => {
       if (this.hsConfig.additionalLanguages) {
-        this.available_languages =
+        this.availableLanguages =
           this.hsLanguageService.listAvailableLanguages();
       }
     });
   }
 
   ngOnInit(): void {
-    this.available_languages = this.hsLanguageService.listAvailableLanguages();
+    this.availableLanguages = this.hsLanguageService.listAvailableLanguages();
     super.ngOnInit();
   }
 

--- a/projects/hslayers/components/layer-manager/dialogs/copy-layer-dialog.component.ts
+++ b/projects/hslayers/components/layer-manager/dialogs/copy-layer-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 
 import {
   HsDialogComponent,
@@ -11,8 +11,9 @@ import {
   standalone: false,
 })
 export class HsCopyLayerDialogComponent implements HsDialogComponent {
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   dialogItem: HsDialogItem;
-  constructor(public HsDialogContainerService: HsDialogContainerService) {}
   viewRef: ViewRef;
   data: {
     title: string;
@@ -21,7 +22,7 @@ export class HsCopyLayerDialogComponent implements HsDialogComponent {
   };
 
   yes(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve({
       confirmed: 'yes',
       layerTitle: this.data.layerTitle,
@@ -29,7 +30,7 @@ export class HsCopyLayerDialogComponent implements HsDialogComponent {
   }
 
   no(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve('no');
   }
 }

--- a/projects/hslayers/components/layer-manager/dialogs/remove-all-dialog.component.ts
+++ b/projects/hslayers/components/layer-manager/dialogs/remove-all-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ViewRef} from '@angular/core';
+import {Component, Input, ViewRef, inject} from '@angular/core';
 
 import {HsCompositionsParserService} from 'hslayers-ng/services/compositions';
 import {
@@ -24,16 +24,14 @@ import {
 export class HsLayerManagerRemoveAllDialogComponent
   implements HsDialogComponent
 {
+  hsLayerManagerService = inject(HsLayerManagerService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsEventBusService = inject(HsEventBusService);
+  hsCompositionsParserService = inject(HsCompositionsParserService);
+  private hsMapService = inject(HsMapService);
+
   @Input() data: any;
   viewRef: ViewRef;
-
-  constructor(
-    public HsLayerManagerService: HsLayerManagerService,
-    public HsDialogContainerService: HsDialogContainerService,
-    public HsEventBusService: HsEventBusService,
-    public hsCompositionsParserService: HsCompositionsParserService,
-    private hsMapService: HsMapService,
-  ) {}
 
   /**
    * Remove all non-base layers that were added to the map by user.
@@ -60,10 +58,10 @@ export class HsLayerManagerRemoveAllDialogComponent
       this.hsMapService.getMap().removeLayer(to_be_removed.shift());
     }
 
-    this.HsEventBusService.addedLayersRemoved.next();
+    this.hsEventBusService.addedLayersRemoved.next();
 
     if (reloadComposition) {
-      this.HsEventBusService.compositionLoadStarts.next(
+      this.hsEventBusService.compositionLoadStarts.next(
         this.data.composition_id,
       );
     }
@@ -71,6 +69,6 @@ export class HsLayerManagerRemoveAllDialogComponent
   }
 
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/components/layer-manager/dialogs/remove-layer-dialog.component.ts
+++ b/projects/hslayers/components/layer-manager/dialogs/remove-layer-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ViewRef} from '@angular/core';
+import {Component, Input, ViewRef, inject} from '@angular/core';
 
 import {
   HsDialogComponent,
@@ -16,28 +16,26 @@ import {HsMapService} from 'hslayers-ng/services/map';
 export class HsLayerManagerRemoveLayerDialogComponent
   implements HsDialogComponent
 {
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsEventBusService = inject(HsEventBusService);
+  hsDrawService = inject(HsDrawService);
+  hsMapService = inject(HsMapService);
+
   @Input() data: any;
   viewRef: ViewRef;
 
-  constructor(
-    public HsDialogContainerService: HsDialogContainerService,
-    public HsEventBusService: HsEventBusService,
-    public HsDrawService: HsDrawService,
-    public HsMapService: HsMapService,
-  ) {}
-
   removeLayer(): void {
-    if (this.HsDrawService.selectedLayer == this.data.olLayer) {
-      this.HsDrawService.selectedLayer = null;
+    if (this.hsDrawService.selectedLayer == this.data.olLayer) {
+      this.hsDrawService.selectedLayer = null;
     }
-    this.HsMapService.getMap().removeLayer(this.data.olLayer);
-    this.HsDrawService.fillDrawableLayers();
+    this.hsMapService.getMap().removeLayer(this.data.olLayer);
+    this.hsDrawService.fillDrawableLayers();
 
-    this.HsEventBusService.layerManagerUpdates.next(null);
+    this.hsEventBusService.layerManagerUpdates.next(null);
     this.close();
   }
 
   close(): void {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
   }
 }

--- a/projects/hslayers/components/layer-manager/dimensions/layer-editor-dimensions.component.ts
+++ b/projects/hslayers/components/layer-manager/dimensions/layer-editor-dimensions.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {filter, merge} from 'rxjs';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -9,7 +9,6 @@ import {
 } from 'hslayers-ng/services/get-capabilities';
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
 import {HsLayerEditorWidgetBaseComponent} from '../widgets/layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 import {HsMapService} from 'hslayers-ng/services/map';
 import {isFunction} from 'hslayers-ng/services/utils';
 import {getDimensions} from 'hslayers-ng/common/extensions';
@@ -23,18 +22,16 @@ export class HsLayerEditorDimensionsComponent
   extends HsLayerEditorWidgetBaseComponent
   implements OnInit
 {
+  hsDimensionService = inject(HsDimensionService);
+  hsDimensionTimeService = inject(HsDimensionTimeService);
+  hsMapService = inject(HsMapService);
+  hsEventBusService = inject(HsEventBusService);
+
   name = 'dimensions';
   dimensions: Array<HsDimensionDescriptor> = [];
 
-  constructor(
-    public hsDimensionService: HsDimensionService,
-    public hsDimensionTimeService: HsDimensionTimeService,
-    public hsMapService: HsMapService,
-    public hsEventBusService: HsEventBusService,
-    hsLayerSelectorService: HsLayerSelectorService,
-  ) {
-    super(hsLayerSelectorService);
-
+  constructor() {
+    super();
     merge(
       this.hsEventBusService.layerDimensionDefinitionChanges.pipe(
         filter((layer) => layer === this.olLayer),

--- a/projects/hslayers/components/layer-manager/dimensions/layer-manager-time-editor.component.ts
+++ b/projects/hslayers/components/layer-manager/dimensions/layer-manager-time-editor.component.ts
@@ -1,5 +1,5 @@
 import {CommonModule, NgClass} from '@angular/common';
-import {Component, Input, OnInit, ViewChild} from '@angular/core';
+import {Component, Input, OnInit, ViewChild, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgbTooltipModule} from '@ng-bootstrap/ng-bootstrap';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -25,6 +25,11 @@ import {HsLayoutService} from 'hslayers-ng/services/layout';
   ],
 })
 export class HsLayerManagerTimeEditorComponent implements OnInit {
+  hsEventBusService = inject(HsEventBusService);
+  hsDimensionTimeService = inject(HsDimensionTimeService);
+  hsLayoutService = inject(HsLayoutService);
+  hsConfig = inject(HsConfig);
+
   @Input() layer: HsLayerDescriptor;
 
   availableTimes: Array<string>;
@@ -41,12 +46,7 @@ export class HsLayerManagerTimeEditorComponent implements OnInit {
   timeDisplayFormat = 'yyyy-MM-dd HH:mm:ss z';
   timesInSync: boolean;
 
-  constructor(
-    public hsEventBusService: HsEventBusService,
-    public hsDimensionTimeService: HsDimensionTimeService,
-    public hsLayoutService: HsLayoutService,
-    public hsConfig: HsConfig,
-  ) {
+  constructor() {
     this.hsDimensionTimeService.layerTimeChanges
       .pipe(takeUntilDestroyed())
       .subscribe(({layer: layerDescriptor, time}) => {

--- a/projects/hslayers/components/layer-manager/editor/layer-editor.component.html
+++ b/projects/hslayers/components/layer-manager/editor/layer-editor.component.html
@@ -10,11 +10,11 @@
       </form>
       @if (currLayer.visible && getBase(currLayer.layer)) {
       <div class="btn-group m-auto d-flex w-75">
-        <button class="btn btn-sm btn-outline-primary  w-50" (click)="HsLayerManagerService.setGreyscale(currLayer)"
+        <button class="btn btn-sm btn-outline-primary  w-50" (click)="hsLayerManagerService.setGreyscale(currLayer)"
           [ngClass]="{'active' : !getGreyscale(currLayer.layer)}" data-toggle="tooltip"
           [title]="'LAYERMANAGER.layerEditor.zoomToLayer' | translate  ">{{'COMMON.color' |
           translate }}</button>
-        <button class="btn btn-sm btn-outline-primary  w-50" (click)="HsLayerManagerService.setGreyscale(currLayer)"
+        <button class="btn btn-sm btn-outline-primary  w-50" (click)="hsLayerManagerService.setGreyscale(currLayer)"
           [ngClass]="{'active' : getGreyscale(currLayer.layer)}" data-toggle="tooltip"
           [title]="'LAYERMANAGER.layerEditor.styleLayer' | translate  ">{{'LAYERMANAGER.baseMapGallery.greyscale'
           | translate }}</button>
@@ -45,7 +45,7 @@
         <i class="fa-solid fa-filter"></i>
       </button>
       }
-      <button class="btn btn-primary" (click)="styleLayer()" [disabled]="!layerIsStyleable()" data-toggle="tooltip"
+      <button class="btn btn-primary" (click)="styleLayer()" [disabled]="!layerIsStylable()" data-toggle="tooltip"
         [title]="'LAYERMANAGER.layerEditor.styleLayer' | translate  "><i class="fa-solid fa-paintbrush"></i></button>
       <button class="btn btn-primary" (click)="toggleLayerRename()" data-toggle="tooltip"
         [title]="'COMMON.renameLayer' | translate  "><i class="fa-solid fa-font"></i></button>

--- a/projects/hslayers/components/layer-manager/editor/layer-editor.component.ts
+++ b/projects/hslayers/components/layer-manager/editor/layer-editor.component.ts
@@ -46,11 +46,21 @@ import {layerIsZoomable, layerIsStyleable} from 'hslayers-ng/services/utils';
   imports: [NgClass, FormsModule, TranslatePipe, HsPanelHelpersModule],
 })
 export class HsLayerEditorComponent {
+  private hsConfig = inject(HsConfig);
+  private hsStylerService = inject(HsStylerService);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsLayerEditorService = inject(HsLayerEditorService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsLayerManagerUtilsService = inject(HsLayerManagerUtilsService);
+  private hsLayerManagerCopyLayerService = inject(
+    HsLayerManagerCopyLayerService,
+  );
+  hsLayerManagerService = inject(HsLayerManagerService);
+  hsWidgetContainerService = inject(HsLayerEditorWidgetContainerService);
+
   layer = input.required<HsLayerDescriptor>();
   olLayer = computed(() => this.layer()?.layer || undefined);
-
-  HsLayerManagerService = inject(HsLayerManagerService);
-  hsWidgetContainerService = inject(HsLayerEditorWidgetContainerService);
 
   layerNodeAvailable = signal(false);
   layer_renamer_visible = signal(false);
@@ -61,7 +71,7 @@ export class HsLayerEditorComponent {
   getGreyscale = getGreyscale;
 
   layerIsZoomable = computed(() => layerIsZoomable(this.olLayer()));
-  layerIsStyleable = computed(() => layerIsStyleable(this.olLayer()));
+  layerIsStylable = computed(() => layerIsStyleable(this.olLayer()));
   isLayerRemovable = computed(() => {
     const layer = this.olLayer();
     return (
@@ -69,7 +79,7 @@ export class HsLayerEditorComponent {
     );
   });
   isVectorLayer = computed(() =>
-    this.HsLayerEditorService.isLayerVectorLayer(this.olLayer()),
+    this.hsLayerEditorService.isLayerVectorLayer(this.olLayer()),
   );
   wfsFilterEnabled = computed(() => {
     return (
@@ -81,16 +91,7 @@ export class HsLayerEditorComponent {
 
   titleUnsaved = computed(() => this.layerTitle() != getTitle(this.olLayer()));
 
-  constructor(
-    private hsConfig: HsConfig,
-    private HsStylerService: HsStylerService,
-    private HsLayoutService: HsLayoutService,
-    private HsLayerEditorService: HsLayerEditorService,
-    private HsEventBusService: HsEventBusService,
-    private HsDialogContainerService: HsDialogContainerService,
-    private hsLayerManagerUtilsService: HsLayerManagerUtilsService,
-    private hsLayerManagerCopyLayerService: HsLayerManagerCopyLayerService,
-  ) {
+  constructor() {
     toObservable(this.layer)
       .pipe(
         map((layer) => {
@@ -126,7 +127,7 @@ export class HsLayerEditorComponent {
    * @returns an empty promise
    */
   async createSaveDialog() {
-    const dialog = this.HsDialogContainerService.create(
+    const dialog = this.hsDialogContainerService.create(
       HsConfirmDialogComponent,
       {
         message: 'LAYERMANAGER.layerEditor.savegeojson',
@@ -146,7 +147,7 @@ export class HsLayerEditorComponent {
    * @returns a promise
    */
   zoomToLayer(): Promise<any> {
-    return this.HsLayerEditorService.zoomToLayer(this.olLayer());
+    return this.hsLayerEditorService.zoomToLayer(this.olLayer());
   }
 
   /**
@@ -154,8 +155,8 @@ export class HsLayerEditorComponent {
    */
   styleLayer() {
     const layer = this.olLayer();
-    this.HsStylerService.layer.set(layer as VectorLayer<VectorSource<Feature>>);
-    this.HsLayoutService.setMainPanel('styler');
+    this.hsStylerService.layer.set(layer as VectorLayer<VectorSource<Feature>>);
+    this.hsLayoutService.setMainPanel('styler');
   }
 
   /**
@@ -167,7 +168,7 @@ export class HsLayerEditorComponent {
   }
 
   removeLayer(): void {
-    this.HsDialogContainerService.create(
+    this.hsDialogContainerService.create(
       HsLayerManagerRemoveLayerDialogComponent,
       {olLayer: this.olLayer()},
     );
@@ -181,18 +182,18 @@ export class HsLayerEditorComponent {
     if (layer == undefined) {
       return;
     }
-    this.HsLayerEditorService.layerTitleChange.next({
+    this.hsLayerEditorService.layerTitleChange.next({
       newTitle: this.layerTitle(),
       oldTitle: getTitle(layer),
       layer,
     });
     setTitle(layer, this.layerTitle());
-    this.HsEventBusService.layerManagerUpdates.next(null);
+    this.hsEventBusService.layerManagerUpdates.next(null);
     this.toggleLayerRename();
   }
 
   async copyLayer(): Promise<void> {
-    const dialog = this.HsDialogContainerService.create(
+    const dialog = this.hsDialogContainerService.create(
       HsCopyLayerDialogComponent,
       {
         message: 'LAYERMANAGER.layerEditor.copyLayer',
@@ -211,6 +212,6 @@ export class HsLayerEditorComponent {
    * layer will be automatically selected via hsLayerSelectorService
    */
   openWfsFilter() {
-    this.HsLayoutService.setMainPanel('wfsFilter');
+    this.hsLayoutService.setMainPanel('wfsFilter');
   }
 }

--- a/projects/hslayers/components/layer-manager/editor/sublayers/layer-editor-sub-layer-checkboxes.component.ts
+++ b/projects/hslayers/components/layer-manager/editor/sublayers/layer-editor-sub-layer-checkboxes.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, computed, input} from '@angular/core';
+import {Component, OnInit, computed, input, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgClass} from '@angular/common';
 
@@ -13,6 +13,10 @@ import {HsSublayer} from 'hslayers-ng/types';
   imports: [FormsModule, NgClass],
 })
 export class HsLayerEditorSubLayerCheckboxesComponent implements OnInit {
+  private hsLayerEditorSublayerService = inject(HsLayerEditorSublayerService);
+  hsLayerManagerVisibilityService = inject(HsLayerManagerVisibilityService);
+  private hsConfig = inject(HsConfig);
+
   parent = input<HsSublayer>();
   subLayer = input.required<HsSublayer>();
 
@@ -28,12 +32,6 @@ export class HsLayerEditorSubLayerCheckboxesComponent implements OnInit {
 
   app: string;
   expanded = false;
-
-  constructor(
-    private hsLayerEditorSublayerService: HsLayerEditorSublayerService,
-    public hsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-    private hsConfig: HsConfig,
-  ) {}
 
   ngOnInit() {
     this.app = this.hsConfig.id;

--- a/projects/hslayers/components/layer-manager/editor/sublayers/layer-editor-sub-layer.service.ts
+++ b/projects/hslayers/components/layer-manager/editor/sublayers/layer-editor-sub-layer.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {HsLayerDescriptor, HsSublayer, HsWmsLayer} from 'hslayers-ng/types';
 import {HsLayerManagerVisibilityService} from 'hslayers-ng/services/layer-manager';
@@ -13,15 +13,13 @@ import {
   providedIn: 'root',
 })
 export class HsLayerEditorSublayerService {
+  private hsLayerManagerVisibilityService = inject(
+    HsLayerManagerVisibilityService,
+  );
+
   layer: HsLayerDescriptor;
-
   populatedLayers: Array<any> = [];
-
   sublayers: HsSublayer[] = [];
-
-  constructor(
-    private hsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-  ) {}
 
   getSubLayers(layer: HsLayerDescriptor): HsSublayer[] {
     return layer ? this.populateSubLayers(layer) : [];

--- a/projects/hslayers/components/layer-manager/editor/sublayers/layer-editor-sublayers.component.ts
+++ b/projects/hslayers/components/layer-manager/editor/sublayers/layer-editor-sublayers.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, input} from '@angular/core';
+import {Component, computed, input, inject} from '@angular/core';
 
 import {HsLayerDescriptor} from 'hslayers-ng/types';
 import {HsLayerEditorSubLayerCheckboxesComponent} from './layer-editor-sub-layer-checkboxes.component';
@@ -17,12 +17,10 @@ import {HsLayerEditorSublayerService} from './layer-editor-sub-layer.service';
   imports: [HsLayerEditorSubLayerCheckboxesComponent],
 })
 export class HsLayerEditorSublayersComponent {
+  private hsLayerEditorSublayerService = inject(HsLayerEditorSublayerService);
+
   layer = input.required<HsLayerDescriptor>();
   subLayers = computed(() =>
-    this.HsLayerEditorSublayerService.getSubLayers(this.layer()),
+    this.hsLayerEditorSublayerService.getSubLayers(this.layer()),
   );
-
-  constructor(
-    private HsLayerEditorSublayerService: HsLayerEditorSublayerService,
-  ) {}
 }

--- a/projects/hslayers/components/layer-manager/gallery/layer-manager-gallery.component.ts
+++ b/projects/hslayers/components/layer-manager/gallery/layer-manager-gallery.component.ts
@@ -27,18 +27,14 @@ import {getBase} from 'hslayers-ng/common/extensions';
   imports: [CommonModule, TranslatePipe, NgbDropdownModule],
 })
 export class HsLayerManagerGalleryComponent extends HsGuiOverlayBaseComponent {
+  hsLayerManagerService = inject(HsLayerManagerService);
+  private hsLayerSelectorService = inject(HsLayerSelectorService);
+  hsLayerManagerVisibilityService = inject(HsLayerManagerVisibilityService);
+
   @ViewChild('galleryDropdown', {static: false}) dropdown: NgbDropdown;
   name = 'basemapGallery';
 
   private hsDialogContainerService = inject(HsDialogContainerService);
-
-  constructor(
-    public hsLayerManagerService: HsLayerManagerService,
-    private hsLayerSelectorService: HsLayerSelectorService,
-    public hsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-  ) {
-    super();
-  }
 
   toggleBasemap(layer?: HsLayerDescriptor): void {
     if (layer) {

--- a/projects/hslayers/components/layer-manager/layer-manager.component.ts
+++ b/projects/hslayers/components/layer-manager/layer-manager.component.ts
@@ -5,6 +5,7 @@ import {
   OnInit,
   ViewChild,
   signal,
+  inject,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -56,6 +57,17 @@ export class HsLayerManagerComponent
   extends HsPanelBaseComponent
   implements OnInit, AfterViewInit
 {
+  hsCore = inject(HslayersService);
+  hsLayerManagerService = inject(HsLayerManagerService);
+  hsEventBusService = inject(HsEventBusService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsConfig = inject(HsConfig);
+  hsLayerListService = inject(HsLayerListService);
+  private hsRemoveLayerDialogService = inject(HsRemoveLayerDialogService);
+  hsLayerSelectorService = inject(HsLayerSelectorService);
+  hsLayerManagerVisibilityService = inject(HsLayerManagerVisibilityService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+
   @ViewChild('filterInput', {static: false}) filterInput: ElementRef;
 
   filteredBaselayers$: Observable<HsLayerDescriptor[]>;
@@ -123,18 +135,8 @@ export class HsLayerManagerComponent
   getThumbnail = getThumbnail;
   name = 'layerManager';
   layerTooltipDelay = 0;
-  constructor(
-    public hsCore: HslayersService,
-    public hsLayerManagerService: HsLayerManagerService,
-    public hsEventBusService: HsEventBusService,
-    public hsDialogContainerService: HsDialogContainerService,
-    public hsConfig: HsConfig,
-    public hsLayerListService: HsLayerListService,
-    private HsRemoveLayerDialogService: HsRemoveLayerDialogService,
-    public hsLayerSelectorService: HsLayerSelectorService,
-    public hsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-  ) {
+
+  constructor() {
     super();
     this.cesiumActive$ = merge(
       this.hsEventBusService.cesiumLoads.pipe(
@@ -347,7 +349,7 @@ export class HsLayerManagerComponent
    * Creates remove-layer dialog which allows for single/multiple layer removal
    */
   removeMultipleLayers() {
-    this.HsRemoveLayerDialogService.removeMultipleLayers(
+    this.hsRemoveLayerDialogService.removeMultipleLayers(
       this.hsLayerManagerService.data.layers
         .filter((layer) => layer.showInLayerManager)
         .map((l) => {

--- a/projects/hslayers/components/layer-manager/logical-list/layer-list-item/layer-list-item.component.ts
+++ b/projects/hslayers/components/layer-manager/logical-list/layer-list-item/layer-list-item.component.ts
@@ -6,6 +6,7 @@ import {
   computed,
   input,
   viewChild,
+  inject,
 } from '@angular/core';
 import {
   NgbProgressbarModule,
@@ -44,6 +45,16 @@ import {layerInvalid} from 'hslayers-ng/services/utils';
   ],
 })
 export class HsLayerListItemComponent implements OnInit {
+  hsConfig = inject(HsConfig);
+  private hsLayerManagerService = inject(HsLayerManagerService);
+  private hsLayerSelectorService = inject(HsLayerSelectorService);
+  private hsDimensionTimeService = inject(HsDimensionTimeService);
+  private hsLayerListService = inject(HsLayerListService);
+  private hsLayerManagerVisibilityService = inject(
+    HsLayerManagerVisibilityService,
+  );
+  private hsLayerEditorService = inject(HsLayerEditorService);
+
   layer = input.required<HsLayerDescriptor>();
 
   isSelected = computed(
@@ -85,16 +96,6 @@ export class HsLayerListItemComponent implements OnInit {
     }
     return false;
   });
-
-  constructor(
-    public hsConfig: HsConfig,
-    private hsLayerManagerService: HsLayerManagerService,
-    private hsLayerSelectorService: HsLayerSelectorService,
-    private hsDimensionTimeService: HsDimensionTimeService,
-    private hsLayerListService: HsLayerListService,
-    private hsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-    private hsLayerEditorService: HsLayerEditorService,
-  ) {}
 
   ngOnInit() {
     /**

--- a/projects/hslayers/components/layer-manager/logical-list/layer-manager-layerlist.component.ts
+++ b/projects/hslayers/components/layer-manager/logical-list/layer-manager-layerlist.component.ts
@@ -1,5 +1,5 @@
 import {AsyncPipe} from '@angular/common';
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 import {Observable, map} from 'rxjs';
 import {combineLatestWith, filter, startWith} from 'rxjs/operators';
 import {toObservable} from '@angular/core/rxjs-interop';
@@ -15,14 +15,14 @@ import {HsLayerManagerService} from 'hslayers-ng/services/layer-manager';
   imports: [HsLayerListItemComponent, AsyncPipe],
 })
 export class HsLayerListComponent {
+  hsConfig = inject(HsConfig);
+  hsLayerManagerService = inject(HsLayerManagerService);
+
   @Input({required: true}) folder: string;
 
   filteredLayers: Observable<HsLayerDescriptor[]>;
 
-  constructor(
-    public hsConfig: HsConfig,
-    public hsLayerManagerService: HsLayerManagerService,
-  ) {
+  constructor() {
     this.filteredLayers = this.hsLayerManagerService.data.filter.pipe(
       startWith(''),
       combineLatestWith(

--- a/projects/hslayers/components/layer-manager/logical-list/layer-manager-layerlist.service.ts
+++ b/projects/hslayers/components/layer-manager/logical-list/layer-manager-layerlist.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {HsLayerDescriptor, HsSublayer} from 'hslayers-ng/types';
 import {HsLayerEditorSublayerService} from '../editor/sublayers/layer-editor-sub-layer.service';
@@ -9,10 +9,8 @@ import {isLayerQueryable} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsLayerListService {
-  constructor(
-    public hsLayerManagerService: HsLayerManagerService,
-    public hsLayerEditorSublayerService: HsLayerEditorSublayerService,
-  ) {}
+  hsLayerManagerService = inject(HsLayerManagerService);
+  hsLayerEditorSublayerService = inject(HsLayerEditorSublayerService);
 
   /**
    * Controls state of layer's sublayers checkboxes with layer visibility changes

--- a/projects/hslayers/components/layer-manager/physical-list/physical-layerlist.component.ts
+++ b/projects/hslayers/components/layer-manager/physical-list/physical-layerlist.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   OnDestroy,
   OnInit,
+  inject,
 } from '@angular/core';
 
 import {Subscription} from 'rxjs';
@@ -19,12 +20,11 @@ import {HsLayerShiftingService} from 'hslayers-ng/services/layer-shifting';
   standalone: false,
 })
 export class HsLayerPhysicalListComponent implements OnDestroy, OnInit {
+  private hsEventBusService = inject(HsEventBusService);
+  private hsLayerShiftingService = inject(HsLayerShiftingService);
+
   layerManagerUpdatesSubscription: Subscription;
   layerShiftingAppRef;
-  constructor(
-    private hsEventBusService: HsEventBusService,
-    private hsLayerShiftingService: HsLayerShiftingService,
-  ) {}
 
   ngOnInit(): void {
     this.layerShiftingAppRef = this.hsLayerShiftingService;

--- a/projects/hslayers/components/layer-manager/widgets/cluster-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/cluster-widget.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {Cluster} from 'ol/source';
 import {Feature} from 'ol';
@@ -6,7 +6,6 @@ import {Feature} from 'ol';
 import {HsConfig} from 'hslayers-ng/config';
 import {HsLayerEditorService} from '../editor/layer-editor.service';
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 
 @Component({
   selector: 'hs-cluster-widget',
@@ -17,18 +16,13 @@ export class HsClusterWidgetComponent
   extends HsLayerEditorWidgetBaseComponent
   implements OnInit
 {
+  private hsLayerEditorService = inject(HsLayerEditorService);
+  private hsConfig = inject(HsConfig);
+
   name = 'cluster-widget';
   distance = {
     value: 40,
   };
-
-  constructor(
-    hsLayerSelectorService: HsLayerSelectorService,
-    private HsLayerEditorService: HsLayerEditorService,
-    private hsConfig: HsConfig,
-  ) {
-    super(hsLayerSelectorService);
-  }
 
   ngOnInit() {
     /* Call super ngOnInit manually as it's getting overridden by local one */
@@ -44,7 +38,7 @@ export class HsClusterWidgetComponent
     if (!this.layerDescriptor) {
       return;
     }
-    this.HsLayerEditorService.cluster(
+    this.hsLayerEditorService.cluster(
       this.olLayer,
       newValue,
       this.distance.value,
@@ -58,7 +52,7 @@ export class HsClusterWidgetComponent
     if (!this.layerDescriptor) {
       return;
     }
-    return this.HsLayerEditorService.cluster(
+    return this.hsLayerEditorService.cluster(
       this.olLayer,
       undefined,
       this.distance.value,
@@ -88,7 +82,7 @@ export class HsClusterWidgetComponent
       return;
     }
     const layer = this.olLayer;
-    if (!this.HsLayerEditorService.isLayerVectorLayer(layer)) {
+    if (!this.hsLayerEditorService.isLayerVectorLayer(layer)) {
       return;
     }
     return true;

--- a/projects/hslayers/components/layer-manager/widgets/extent-widget/extent-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/extent-widget/extent-widget.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {Observable, map} from 'rxjs';
 
 import {HsLayerEditorWidgetBaseComponent} from '../layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 import {
   getWmsOriginalExtent,
   setWmsOriginalExtent,
@@ -16,11 +15,11 @@ import {getLayerParams, isLayerWMS} from 'hslayers-ng/services/utils';
 })
 export class HsExtentWidgetComponent extends HsLayerEditorWidgetBaseComponent {
   name = 'extent-widget';
-
   ignoreExtent: boolean;
   isEnabled: Observable<boolean>;
-  constructor(hsLayerSelectorService: HsLayerSelectorService) {
-    super(hsLayerSelectorService);
+
+  constructor() {
+    super();
     this.isEnabled = this.layerDescriptor.pipe(
       map((l) => {
         const originalExtent = getWmsOriginalExtent(l.layer);

--- a/projects/hslayers/components/layer-manager/widgets/idw-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/idw-widget.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import colorScales from 'colormap/colorScale';
 import {Feature} from 'ol';
@@ -7,7 +7,6 @@ import {Vector as VectorSource} from 'ol/source';
 import {HsConfig} from 'hslayers-ng/config';
 import {HsLanguageService} from 'hslayers-ng/services/language';
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 import {instOf, listNumericAttributes} from 'hslayers-ng/services/utils';
 import {InterpolatedSource} from 'hslayers-ng/common/layers';
 
@@ -24,6 +23,9 @@ export class HsIdwWidgetComponent
   extends HsLayerEditorWidgetBaseComponent
   implements OnInit
 {
+  hsLanguageService = inject(HsLanguageService);
+  hsConfig = inject(HsConfig);
+
   weightAttribute: string;
   attributes: string[];
   name = 'idw-widget';
@@ -32,14 +34,6 @@ export class HsIdwWidgetComponent
   reversed: boolean;
   min: number | string = '';
   max: number | string = '';
-
-  constructor(
-    public HsLanguageService: HsLanguageService,
-    hsLayerSelectorService: HsLayerSelectorService,
-    public hsConfig: HsConfig,
-  ) {
-    super(hsLayerSelectorService);
-  }
 
   ngOnInit(): void {
     super.ngOnInit();

--- a/projects/hslayers/components/layer-manager/widgets/layer-editor-widget-base.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/layer-editor-widget-base.component.ts
@@ -15,6 +15,8 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 export class HsLayerEditorWidgetBaseComponent
   implements HsPanelComponent, OnInit
 {
+  hsLayerSelectorService = inject(HsLayerSelectorService);
+
   /**
    * This could be used to enable/disable widgets by name on HsConfig level
    */
@@ -28,7 +30,7 @@ export class HsLayerEditorWidgetBaseComponent
   baseComponentInitRun = false;
   destroyRef = inject(DestroyRef);
 
-  constructor(public hsLayerSelectorService: HsLayerSelectorService) {
+  constructor() {
     this.layerDescriptor.subscribe((descriptor) => {
       this.olLayer = descriptor?.layer;
     });

--- a/projects/hslayers/components/layer-manager/widgets/layer-folder-widget/layer-folder-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/layer-folder-widget/layer-folder-widget.component.ts
@@ -5,10 +5,7 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {HsDialogContainerService} from 'hslayers-ng/common/dialogs';
-import {
-  HsLayerManagerFolderService,
-  HsLayerSelectorService,
-} from 'hslayers-ng/services/layer-manager';
+import {HsLayerManagerFolderService} from 'hslayers-ng/services/layer-manager';
 import {getBase, setPath} from 'hslayers-ng/common/extensions';
 
 import {HsLayerEditorWidgetBaseComponent} from '../layer-editor-widget-base.component';
@@ -26,9 +23,8 @@ export class HsLayerFolderWidgetComponent extends HsLayerEditorWidgetBaseCompone
   hsDialogContainerService = inject(HsDialogContainerService);
   folderService = inject(HsLayerManagerFolderService);
 
-  constructor(hsLayerSelectorService: HsLayerSelectorService) {
-    super(hsLayerSelectorService);
-
+  constructor() {
+    super();
     this.isEnabled = this.layerDescriptor.pipe(
       takeUntilDestroyed(),
       map((layer) => {

--- a/projects/hslayers/components/layer-manager/widgets/layer-type-switcher-widget/layer-type-switcher-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/layer-type-switcher-widget/layer-type-switcher-widget.component.ts
@@ -16,7 +16,6 @@ import {
   HsLayerManagerLoadingProgressService,
   HsLayerManagerService,
   HsLayerManagerVisibilityService,
-  HsLayerSelectorService,
 } from 'hslayers-ng/services/layer-manager';
 import {
   instOf,
@@ -39,7 +38,6 @@ export class HsLayerTypeSwitcherWidgetComponent extends HsLayerEditorWidgetBaseC
   );
   private loadingProgressSerice = inject(HsLayerManagerLoadingProgressService);
   private folderService = inject(HsLayerManagerFolderService);
-
   private hsEventBusService = inject(HsEventBusService);
   private hsDialogContainerService = inject(HsDialogContainerService);
   private layerEditorService = inject(HsLayerEditorService);
@@ -51,9 +49,8 @@ export class HsLayerTypeSwitcherWidgetComponent extends HsLayerEditorWidgetBaseC
 
   typeChanged$: Observable<void>;
 
-  constructor(hsLayerSelectorService: HsLayerSelectorService) {
-    super(hsLayerSelectorService);
-
+  constructor() {
+    super();
     this.isEnabled = this.layerDescriptor.pipe(
       map((layer) => {
         const source = layer.layer.getSource();

--- a/projects/hslayers/components/layer-manager/widgets/legend-widget.component.html
+++ b/projects/hslayers/components/layer-manager/widgets/legend-widget.component.html
@@ -1,11 +1,11 @@
 @if (olLayer) {
   <div>
-    @if (HsLayerEditorService.legendVisible()) {
+    @if (hsLayerEditorService.legendVisible()) {
       <div><!-- TODO: Remove function call from template -->
         <p style="text-align: center; font-weight: bold">
           {{ "COMMON.legend" | translate }}
         </p>
-        <hs-legend-layer [layer]="HsLayerEditorService.legendDescriptor">
+        <hs-legend-layer [layer]="hsLayerEditorService.legendDescriptor">
         </hs-legend-layer>
         <hr />
       </div>

--- a/projects/hslayers/components/layer-manager/widgets/legend-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/legend-widget.component.ts
@@ -1,8 +1,7 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {HsLayerEditorService} from '../editor/layer-editor.service';
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 
 @Component({
   selector: 'hs-legend-widget',
@@ -10,11 +9,7 @@ import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
   standalone: false,
 })
 export class HsLegendWidgetComponent extends HsLayerEditorWidgetBaseComponent {
+  hsLayerEditorService = inject(HsLayerEditorService);
+
   name = 'legend-widget';
-  constructor(
-    hsLayerSelectorService: HsLayerSelectorService,
-    public HsLayerEditorService: HsLayerEditorService,
-  ) {
-    super(hsLayerSelectorService);
-  }
 }

--- a/projects/hslayers/components/layer-manager/widgets/metadata-widget.component.html
+++ b/projects/hslayers/components/layer-manager/widgets/metadata-widget.component.html
@@ -29,7 +29,7 @@
   <div class="form-group" [hidden]="!abstract">
     <label>{{ "COMMON.abstract" | translate }}</label>
     <p [innerHtml]="
-        HsLayerManagerService.makeSafeAndTranslate('LAYERS', abstract)
+        hsLayerManagerService.makeSafeAndTranslate('LAYERS', abstract)
       "></p><!-- TODO: Remove function call from template -->
   </div>
 }

--- a/projects/hslayers/components/layer-manager/widgets/metadata-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/metadata-widget.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {HsLanguageService} from 'hslayers-ng/services/language';
 import {HsLayerDescriptor} from 'hslayers-ng/types';
@@ -6,7 +6,6 @@ import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.compo
 import {
   HsLayerManagerMetadataService,
   HsLayerManagerService,
-  HsLayerSelectorService,
 } from 'hslayers-ng/services/layer-manager';
 import {
   getAbstract,
@@ -20,17 +19,12 @@ import {
   standalone: false,
 })
 export class HsMetadataWidgetComponent extends HsLayerEditorWidgetBaseComponent {
+  hsLanguageService = inject(HsLanguageService);
+  metadataService = inject(HsLayerManagerMetadataService);
+  hsLayerManagerService = inject(HsLayerManagerService);
+
   name = 'metadata-widget';
   getAttribution = getAttribution;
-
-  constructor(
-    public HsLanguageService: HsLanguageService,
-    hsLayerSelectorService: HsLayerSelectorService,
-    public metadataService: HsLayerManagerMetadataService,
-    public HsLayerManagerService: HsLayerManagerService,
-  ) {
-    super(hsLayerSelectorService);
-  }
 
   /**
    * Determines if layer has copyright information available

--- a/projects/hslayers/components/layer-manager/widgets/opacity-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/opacity-widget.component.ts
@@ -1,8 +1,7 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 
 @Component({
   selector: 'hs-opacity-widget',
@@ -10,13 +9,9 @@ import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
   standalone: false,
 })
 export class HsOpacityWidgetComponent extends HsLayerEditorWidgetBaseComponent {
+  private hsEventBusService = inject(HsEventBusService);
+
   name = 'opacity-widget';
-  constructor(
-    hsLayerSelectorService: HsLayerSelectorService,
-    private hsEventBusService: HsEventBusService,
-  ) {
-    super(hsLayerSelectorService);
-  }
 
   /**
    * Set selected layer's opacity and emits "compositionchanged"

--- a/projects/hslayers/components/layer-manager/widgets/scale-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/scale-widget.component.ts
@@ -1,9 +1,8 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {METERS_PER_UNIT} from 'ol/proj';
 
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 import {HsMapService} from 'hslayers-ng/services/map';
 import {calculateResolutionFromScale} from 'hslayers-ng/services/utils';
 
@@ -13,14 +12,9 @@ import {calculateResolutionFromScale} from 'hslayers-ng/services/utils';
   standalone: false,
 })
 export class HsScaleWidgetComponent extends HsLayerEditorWidgetBaseComponent {
-  name = 'scale-widget';
+  hsMapService = inject(HsMapService);
 
-  constructor(
-    hsLayerSelectorService: HsLayerSelectorService,
-    public hsMapService: HsMapService,
-  ) {
-    super(hsLayerSelectorService);
-  }
+  name = 'scale-widget';
 
   /**
    * Test if selected layer has min and max resolution set

--- a/projects/hslayers/components/layer-manager/widgets/type-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/type-widget.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 import {HsLayerEditorWidgetBaseComponent} from './layer-editor-widget-base.component';
-import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 
 @Component({
   selector: 'hs-type-widget',
@@ -10,9 +9,5 @@ import {HsLayerSelectorService} from 'hslayers-ng/services/layer-manager';
 })
 export class HsTypeWidgetComponent extends HsLayerEditorWidgetBaseComponent {
   showCheck = false;
-
-  constructor(hsLayerSelectorService: HsLayerSelectorService) {
-    super(hsLayerSelectorService);
-  }
   name = 'type-widget';
 }

--- a/projects/hslayers/components/layer-manager/widgets/wms-source-widget/wms-source-widget.component.ts
+++ b/projects/hslayers/components/layer-manager/widgets/wms-source-widget/wms-source-widget.component.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {Observable, map, tap} from 'rxjs';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -20,18 +20,17 @@ import {HsMapService} from 'hslayers-ng/services/map';
   templateUrl: './wms-source-widget.component.html',
 })
 export class HsWmsSourceWidgetComponent extends HsLayerEditorWidgetBaseComponent {
+  private hsMapService = inject(HsMapService);
+  private hsLayerShiftingService = inject(HsLayerShiftingService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+
   name = 'wms-source-widget';
   isEnabled: Observable<boolean>;
 
   options = ['Tile', 'Image'];
   currentType: string;
-  constructor(
-    hsLayerSelectorService: HsLayerSelectorService,
-    private hsMapService: HsMapService,
-    private hsLayerShiftingService: HsLayerShiftingService,
-    private hsDialogContainerService: HsDialogContainerService,
-  ) {
-    super(hsLayerSelectorService);
+  constructor() {
+    super();
     this.isEnabled = this.layerDescriptor.pipe(
       tap((l) => {
         this.currentType = instOf(l.layer, ImageLayer) ? 'Image' : 'Tile';

--- a/projects/hslayers/components/legend/legend-layer-static/legend-layer-static.component.ts
+++ b/projects/hslayers/components/legend/legend-layer-static/legend-layer-static.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 
 import {HsLegendDescriptor} from '../legend-descriptor.interface';
 import {HsLegendLayerStaticService} from './legend-layer-static.service';
@@ -11,10 +11,10 @@ import {getLegends} from 'hslayers-ng/common/extensions';
   standalone: false,
 })
 export class HsLegendLayerStaticComponent implements OnInit {
+  private hsLegendLayerStaticService = inject(HsLegendLayerStaticService);
+
   @Input() layer: HsLegendDescriptor;
   layerLegend: LayerLegend = {};
-
-  constructor(private hsLegendLayerStaticService: HsLegendLayerStaticService) {}
 
   ngOnInit(): void {
     if (getLegends(this.layer.lyr)) {

--- a/projects/hslayers/components/legend/legend-layer-static/legend-layer-static.service.ts
+++ b/projects/hslayers/components/legend/legend-layer-static/legend-layer-static.service.ts
@@ -1,5 +1,5 @@
 import {DomSanitizer} from '@angular/platform-browser';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -11,7 +11,7 @@ import {getLegends} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsLegendLayerStaticService {
-  constructor(private sanitizer: DomSanitizer) {}
+  private sanitizer = inject(DomSanitizer);
 
   fillContent(lyr: Layer<Source>): LayerLegend {
     const layerLegend: LayerLegend = {};

--- a/projects/hslayers/components/legend/legend-layer/legend-layer.component.ts
+++ b/projects/hslayers/components/legend/legend-layer/legend-layer.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit, signal} from '@angular/core';
+import {Component, Input, OnInit, signal, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {HsCustomLegendCategory} from '../legend-custom-category.type';
@@ -12,6 +12,9 @@ import {HsStylerService} from 'hslayers-ng/services/styler';
   standalone: false,
 })
 export class HsLegendLayerComponent implements OnInit {
+  hsLegendService = inject(HsLegendService);
+  hsStylerService = inject(HsStylerService);
+
   @Input() layer: HsLegendDescriptor;
 
   legendCategories: HsCustomLegendCategory[];
@@ -22,10 +25,7 @@ export class HsLegendLayerComponent implements OnInit {
    */
   defaultIconHeight = 32;
 
-  constructor(
-    public hsLegendService: HsLegendService,
-    public hsStylerService: HsStylerService,
-  ) {
+  constructor() {
     this.hsStylerService.onSet
       .pipe(takeUntilDestroyed())
       .subscribe(async (layer) => {

--- a/projects/hslayers/components/legend/legend.component.ts
+++ b/projects/hslayers/components/legend/legend.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import BaseLayer from 'ol/layer/Base';
@@ -25,17 +25,14 @@ import {InterpolatedSource} from 'hslayers-ng/common/layers';
   standalone: false,
 })
 export class HsLegendComponent extends HsPanelBaseComponent implements OnInit {
+  hsLegendService = inject(HsLegendService);
+  hsMapService = inject(HsMapService);
+  hsQueuesService = inject(HsQueuesService);
+  hsLanguageService = inject(HsLanguageService);
+
   layerDescriptors = [];
   titleSearch = '';
   name = 'legend';
-  constructor(
-    public hsLegendService: HsLegendService,
-    public hsMapService: HsMapService,
-    public hsQueuesService: HsQueuesService,
-    public hsLanguageService: HsLanguageService,
-  ) {
-    super();
-  }
 
   ngOnInit(): void {
     this.hsMapService.loaded().then((map) => {

--- a/projects/hslayers/components/legend/legend.service.ts
+++ b/projects/hslayers/components/legend/legend.service.ts
@@ -1,5 +1,5 @@
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import LegendRenderer from 'geostyler-legend/dist/LegendRenderer/LegendRenderer';
 import {Feature} from 'ol';
@@ -44,13 +44,13 @@ import {
   providedIn: 'root',
 })
 export class HsLegendService {
-  constructor(
-    public hsStylerService: HsStylerService,
-    public hsLayerSelectorService: HsLayerSelectorService,
-    private hsLog: HsLogService,
-    private sanitizer: DomSanitizer,
-    private hsProxyService: HsProxyService,
-  ) {
+  hsStylerService = inject(HsStylerService);
+  hsLayerSelectorService = inject(HsLayerSelectorService);
+  private hsLog = inject(HsLogService);
+  private sanitizer = inject(DomSanitizer);
+  private hsProxyService = inject(HsProxyService);
+
+  constructor() {
     this.hsLayerSelectorService.layerSelected
       .pipe(filter((layer) => !!layer))
       .subscribe(async (layer) => {

--- a/projects/hslayers/components/map-swipe/map-swipe.component.ts
+++ b/projects/hslayers/components/map-swipe/map-swipe.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
 import {
   CdkDragDrop,
@@ -20,19 +20,15 @@ import {HsPanelBaseComponent} from 'hslayers-ng/common/panels';
   standalone: false,
 })
 export class HsMapSwipeComponent extends HsPanelBaseComponent {
+  hsMapSwipeService = inject(HsMapSwipeService);
+  private hsLayerShiftingService = inject(HsLayerShiftingService);
+
   swipeSide = SwipeSide;
   placeholders = {
     entire: true,
     left: true,
     right: true,
   };
-  constructor(
-    public hsMapSwipeService: HsMapSwipeService,
-    private hsLayerShiftingService: HsLayerShiftingService,
-  ) {
-    super();
-  }
-
   name = 'mapSwipe';
   swipeOptions = ['vertical', 'horizontal'];
 

--- a/projects/hslayers/components/map-swipe/map-swipe.service.ts
+++ b/projects/hslayers/components/map-swipe/map-swipe.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 import {Observable, merge} from 'rxjs';
 import {buffer, filter, first, map, switchMap, take} from 'rxjs/operators';
 
@@ -35,6 +35,17 @@ export enum SwipeSide {
   providedIn: 'root',
 })
 export class HsMapSwipeService {
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+  private hsLayerShiftingService = inject(HsLayerShiftingService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsLayerManagerService = inject(HsLayerManagerService);
+  private hsShareUrlService = inject(HsShareUrlService);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsLayerEditorService = inject(HsLayerEditorService);
+  private hsLog = inject(HsLogService);
+  private zone = inject(NgZone);
+
   swipeCtrl: SwipeControl;
   rightLayers: LayerListItem[] = [];
   leftLayers: LayerListItem[] = [];
@@ -44,18 +55,8 @@ export class HsMapSwipeService {
   swipeControlActive: boolean;
   orientation: 'vertical' | 'horizontal';
   orientationVertical = true;
-  constructor(
-    private hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    private hsLayerShiftingService: HsLayerShiftingService,
-    private hsEventBusService: HsEventBusService,
-    private hsLayerManagerService: HsLayerManagerService,
-    private hsShareUrlService: HsShareUrlService,
-    private hsLayoutService: HsLayoutService,
-    private hsLayerEditorService: HsLayerEditorService,
-    private hsLog: HsLogService,
-    private zone: NgZone,
-  ) {
+
+  constructor() {
     this.swipeCtrl = null;
     this.rightLayers = [];
     this.leftLayers = [];
@@ -257,9 +258,11 @@ export class HsMapSwipeService {
       );
       if (layerFound !== undefined) {
         this.setLayerActive(layerFound);
-        this.wasMoved
-          ? this.moveSwipeLayer(layerFound)
-          : this.addSwipeLayer(layerFound);
+        if (this.wasMoved) {
+          this.moveSwipeLayer(layerFound);
+        } else {
+          this.addSwipeLayer(layerFound);
+        }
         this.checkForMissingLayers();
       } else {
         this.removeCompletely(l);

--- a/projects/hslayers/components/measure/measure.component.ts
+++ b/projects/hslayers/components/measure/measure.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, OnInit, PLATFORM_ID} from '@angular/core';
+import {Component, OnInit, PLATFORM_ID, inject} from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -12,20 +12,16 @@ import {HsPanelBaseComponent} from 'hslayers-ng/common/panels';
   standalone: false,
 })
 export class HsMeasureComponent extends HsPanelBaseComponent implements OnInit {
+  private hsEventBusService = inject(HsEventBusService);
+  hsMeasureService = inject(HsMeasureService);
+  private platformId = inject(PLATFORM_ID);
+
   type: string;
   name = 'measure';
-  constructor(
-    private hsEventBusService: HsEventBusService,
-    public hsMeasureService: HsMeasureService,
-    @Inject(PLATFORM_ID) private platformId: any,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     super.ngOnInit();
     this.type = 'distance';
-
     if (isPlatformBrowser(this.platformId)) {
       document.addEventListener('keyup', (e) => {
         if (e.key == 'Control') {

--- a/projects/hslayers/components/print/legend-styler/legend-styler.component.ts
+++ b/projects/hslayers/components/print/legend-styler/legend-styler.component.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -17,16 +17,14 @@ import {LegendObj} from '../types/legend-object.type';
   imports: [CommonModule, FormsModule, TranslatePipe, ColorSketchModule],
 })
 export class HsPrintLegendStylerComponent {
+  hsLanguageService = inject(HsLanguageService);
+  private hsColorPickerService = inject(HsColorPickerService);
+
   bcColor: string;
   fillPickerVisible = false;
   positionOptions = POSITION_OPTIONS;
   legendWidths = CANVAS_SIZES;
   @Input() legendObj: LegendObj;
-
-  constructor(
-    public hsLanguageService: HsLanguageService,
-    private hsColorPickerService: HsColorPickerService,
-  ) {}
 
   /**
    * Triggered when color picker value has been selected

--- a/projects/hslayers/components/print/print-imprint.service.ts
+++ b/projects/hslayers/components/print/print-imprint.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {HsPrintLegendService} from './print-legend.service';
 import {HsShareThumbnailService} from 'hslayers-ng/services/share';
@@ -9,10 +9,8 @@ import {TextStyle} from './types/text-style.type';
   providedIn: 'root',
 })
 export class HsPrintImprintService {
-  constructor(
-    private hsPrintLegendService: HsPrintLegendService,
-    private hsShareThumbnailService: HsShareThumbnailService,
-  ) {}
+  private hsPrintLegendService = inject(HsPrintLegendService);
+  private hsShareThumbnailService = inject(HsShareThumbnailService);
 
   /**
    * Draw imprint canvas

--- a/projects/hslayers/components/print/print-legend.service.ts
+++ b/projects/hslayers/components/print/print-legend.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Observable, Subject, Subscription} from 'rxjs';
 
 import {Feature} from 'ol';
@@ -26,13 +26,13 @@ export class PrintLegendParams {
   providedIn: 'root',
 })
 export class HsPrintLegendService extends PrintLegendParams {
-  constructor(
-    private hsMapService: HsMapService,
-    private hsLegendService: HsLegendService,
-    private hsLegendLayerStaticService: HsLegendLayerStaticService,
-    private hsLanguageService: HsLanguageService,
-    private hsShareThumbnailService: HsShareThumbnailService,
-  ) {
+  private hsMapService = inject(HsMapService);
+  private hsLegendService = inject(HsLegendService);
+  private hsLegendLayerStaticService = inject(HsLegendLayerStaticService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsShareThumbnailService = inject(HsShareThumbnailService);
+
+  constructor() {
     super();
     this.cancelRequest.subscribe(() => {
       this.loadingExternalImages = false;
@@ -42,6 +42,7 @@ export class HsPrintLegendService extends PrintLegendParams {
       }
     });
   }
+
   /**
    * Convert svg to image
    * @param svgSource - Svg source
@@ -259,7 +260,8 @@ export class HsPrintLegendService extends PrintLegendParams {
    */
   private legendToSvg(source: string, layerTitle: string): string {
     const heightRegex = /height="([0-9]+)"/;
-    const height = Number(source.match(heightRegex)[1]) ?? 70;
+    const match = source.match(heightRegex);
+    const height = match && match[1] ? Number(match[1]) : 70;
     const svgSource = `<svg xmlns='http://www.w3.org/2000/svg' width='${
       this.legendWidth
     }' height='${height + 12}px'>

--- a/projects/hslayers/components/print/print-scale.service.ts
+++ b/projects/hslayers/components/print/print-scale.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Control, ScaleLine} from 'ol/control';
 
@@ -14,13 +14,14 @@ import {ScaleObj} from './types/scale-object.type';
   providedIn: 'root',
 })
 export class HsPrintScaleService {
+  private hsMapService = inject(HsMapService);
+  private hsPrintLegendService = inject(HsPrintLegendService);
+
   defaultScaleLine: Control = null;
   scaleBarCSS = SCALE_BAR_CLASSES;
   scaleLineCSS = SCALE_LINE_CLASSES;
-  constructor(
-    private hsMapService: HsMapService,
-    private hsPrintLegendService: HsPrintLegendService,
-  ) {
+
+  constructor() {
     this.hsMapService.loaded().then(() => {
       this.defaultScaleLine = this.getMapScale();
     });

--- a/projects/hslayers/components/print/print.component.ts
+++ b/projects/hslayers/components/print/print.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {HsPanelBaseComponent} from 'hslayers-ng/common/panels';
 import {HsPrintLegendService} from './print-legend.service';
@@ -13,6 +13,10 @@ import {Styler} from './types/styler.type';
   standalone: false,
 })
 export class HsPrintComponent extends HsPanelBaseComponent implements OnInit {
+  private hsPrintService = inject(HsPrintService);
+  private hsPrintScaleService = inject(HsPrintScaleService);
+  private hsPrintLegendService = inject(HsPrintLegendService);
+
   name = 'print';
   stylers: Styler[] = [
     {name: 'title', visible: false},
@@ -21,14 +25,6 @@ export class HsPrintComponent extends HsPanelBaseComponent implements OnInit {
     {name: 'scale', visible: false},
   ];
   print: PrintModel;
-
-  constructor(
-    private hsPrintService: HsPrintService,
-    private hsPrintScaleService: HsPrintScaleService,
-    private hsPrintLegendService: HsPrintLegendService,
-  ) {
-    super();
-  }
 
   ngOnInit(): void {
     this.setToDefault();

--- a/projects/hslayers/components/print/print.service.ts
+++ b/projects/hslayers/components/print/print.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {from, takeUntil} from 'rxjs';
 
@@ -15,14 +15,12 @@ import {xPos, yPos} from './types/xy-positions.type';
   providedIn: 'root',
 })
 export class HsPrintService {
-  constructor(
-    private hsMapService: HsMapService,
-    private hsShareThumbnailService: HsShareThumbnailService,
-    private hsPrintLegendService: HsPrintLegendService,
-    private hsPrintScaleService: HsPrintScaleService,
-    private hsPrintTitleService: HsPrintTitleService,
-    private hsPrintImprintService: HsPrintImprintService,
-  ) {}
+  private hsMapService = inject(HsMapService);
+  private hsShareThumbnailService = inject(HsShareThumbnailService);
+  private hsPrintLegendService = inject(HsPrintLegendService);
+  private hsPrintScaleService = inject(HsPrintScaleService);
+  private hsPrintTitleService = inject(HsPrintTitleService);
+  private hsPrintImprintService = inject(HsPrintImprintService);
 
   /**
    * Print styled print layout

--- a/projects/hslayers/components/print/scale-styler/scale-styler.component.ts
+++ b/projects/hslayers/components/print/scale-styler/scale-styler.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -13,13 +13,11 @@ import {ScaleObj} from '../types/scale-object.type';
   imports: [FormsModule, TranslatePipe],
 })
 export class HsPrintScaleStylerComponent {
+  private hsPrintScaleService = inject(HsPrintScaleService);
+  private hsLanguageService = inject(HsLanguageService);
+
   @Input() scaleObj: ScaleObj;
   stylingOptions = SCALE_STYLING_OPTIONS;
-
-  constructor(
-    private hsPrintScaleService: HsPrintScaleService,
-    private hsLanguageService: HsLanguageService,
-  ) {}
 
   /**
    * Triggered when scale object values have been changed

--- a/projects/hslayers/components/print/text-styler/text-styler.component.ts
+++ b/projects/hslayers/components/print/text-styler/text-styler.component.ts
@@ -1,5 +1,5 @@
 import {NgStyle} from '@angular/common';
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -22,6 +22,9 @@ export enum ColorPickers {
   imports: [NgStyle, FormsModule, TranslatePipe, ColorSketchModule],
 })
 export class HsPrintTextStylerComponent {
+  private hsColorPickerService = inject(HsColorPickerService);
+  private hsLanguageService = inject(HsLanguageService);
+
   @Input() textStyle: TextStyle;
   @Input() objectName: string;
   fillPickerVisible = false;
@@ -30,10 +33,6 @@ export class HsPrintTextStylerComponent {
   backgroundColor = 'white';
   stylingOptions = TEXT_STYLING_OPTIONS;
   positionOptions = POSITION_OPTIONS;
-  constructor(
-    private hsColorPickerService: HsColorPickerService,
-    private hsLanguageService: HsLanguageService,
-  ) {}
 
   /**
    * Triggered when color picker value has been selected

--- a/projects/hslayers/components/query/default-info-panel-body/default-info-panel-body.component.ts
+++ b/projects/hslayers/components/query/default-info-panel-body/default-info-panel-body.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {TranslatePipe} from '@ngx-translate/core';
 
@@ -11,8 +11,9 @@ import {HsQueryFeatureListComponent} from '../feature-list/feature-list.componen
   imports: [HsQueryFeatureListComponent, NgbDropdownModule, TranslatePipe],
 })
 export class HsQueryDefaultInfoPanelBodyComponent implements OnInit {
+  hsQueryBaseService = inject(HsQueryBaseService);
+
   featureInfoExpanded: boolean;
-  constructor(public hsQueryBaseService: HsQueryBaseService) {}
   ngOnInit(): void {
     this.featureInfoExpanded = true;
   }

--- a/projects/hslayers/components/query/feature-common.service.ts
+++ b/projects/hslayers/components/query/feature-common.service.ts
@@ -1,5 +1,5 @@
 import {BehaviorSubject, Observable} from 'rxjs';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
@@ -25,22 +25,21 @@ export interface exportFormats {
   providedIn: 'root',
 })
 export class HsFeatureCommonService {
+  private hsQueryVectorService = inject(HsQueryVectorService);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsMapService = inject(HsMapService);
+
   listSubject = new BehaviorSubject<Layer<Source>[]>([] as Layer<Source>[]);
 
   availableLayer$: Observable<Layer<Source>[]> =
     this.listSubject.asObservable();
 
-  constructor(
-    private hsQueryVectorService: HsQueryVectorService,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsMapService: HsMapService,
-  ) {
+  constructor() {
     this.hsMapService.loaded().then((map) => {
       map.getLayers().on('change:length', () => {
         this.updateLayerList();
       });
-
       this.updateLayerList();
     });
   }

--- a/projects/hslayers/components/query/feature-list/feature-list.component.ts
+++ b/projects/hslayers/components/query/feature-list/feature-list.component.ts
@@ -1,5 +1,5 @@
 import {AsyncPipe, NgClass, NgStyle, SlicePipe} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -34,6 +34,11 @@ import {getTitle} from 'hslayers-ng/common/extensions';
   ],
 })
 export class HsQueryFeatureListComponent {
+  private hsQueryVectorService = inject(HsQueryVectorService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  hsFeatureCommonService = inject(HsFeatureCommonService);
+  hsQueryBaseService = inject(HsQueryBaseService);
+
   exportMenuVisible;
   selectedFeaturesVisible = true;
   exportFormats: exportFormats[] = [
@@ -49,13 +54,6 @@ export class HsQueryFeatureListComponent {
   editMenuVisible = false;
   selectedLayer = null;
   getTitle = getTitle;
-
-  constructor(
-    private hsQueryVectorService: HsQueryVectorService,
-    private hsDialogContainerService: HsDialogContainerService,
-    public hsFeatureCommonService: HsFeatureCommonService,
-    public hsQueryBaseService: HsQueryBaseService,
-  ) {}
 
   /**
    * Track item by OpenLayers feature, ol_uid value

--- a/projects/hslayers/components/query/feature/feature.component.ts
+++ b/projects/hslayers/components/query/feature/feature.component.ts
@@ -1,5 +1,12 @@
 import {AsyncPipe, NgClass} from '@angular/common';
-import {Component, DestroyRef, OnInit, computed, input} from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  input,
+  inject,
+} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap';
 import {Observable, map} from 'rxjs';
@@ -30,6 +37,11 @@ import {isLayerEditable} from 'hslayers-ng/services/utils';
   ],
 })
 export class HsQueryFeatureComponent implements OnInit {
+  private hsMapService = inject(HsMapService);
+  private hsQueryVectorService = inject(HsQueryVectorService);
+  private hsFeatureCommonService = inject(HsFeatureCommonService);
+  private destroyRef = inject(DestroyRef);
+
   feature = input<HsFeatureDescriptor>();
 
   olFeature = computed(() => {
@@ -67,16 +79,9 @@ export class HsQueryFeatureComponent implements OnInit {
   getTitle = getTitle;
   availableLayers: Observable<Layer[]>;
 
-  constructor(
-    private hsMapService: HsMapService,
-    private hsQueryVectorService: HsQueryVectorService,
-    private hsFeatureCommonService: HsFeatureCommonService,
-    private DestroyRef: DestroyRef,
-  ) {}
-
   ngOnInit(): void {
     this.availableLayers = this.hsFeatureCommonService.availableLayer$.pipe(
-      takeUntilDestroyed(this.DestroyRef),
+      takeUntilDestroyed(this.destroyRef),
       map((layers) => {
         if (!this.olFeature()) {
           //Feature from WMS getFeatureInfo

--- a/projects/hslayers/components/query/query-wms.service.ts
+++ b/projects/hslayers/components/query/query-wms.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
@@ -28,16 +28,17 @@ import {jsonGetFeatureInfo} from 'hslayers-ng/common/get-feature-info';
   providedIn: 'root',
 })
 export class HsQueryWmsService {
+  private hsMapService = inject(HsMapService);
+  private hsLanguageService = inject(HsLanguageService);
+  private httpClient = inject(HttpClient);
+  private hsLogService = inject(HsLogService);
+  private hsQueryWmtsService = inject(HsQueryWmtsService);
+  private hsQueryBaseService = inject(HsQueryBaseService);
+  private hsProxyService = inject(HsProxyService);
+
   infoCounter = 0;
-  constructor(
-    private hsMapService: HsMapService,
-    private hsLanguageService: HsLanguageService,
-    private httpClient: HttpClient,
-    private hsLogService: HsLogService,
-    private hsQueryWmtsService: HsQueryWmtsService,
-    private hsQueryBaseService: HsQueryBaseService,
-    private hsProxyService: HsProxyService,
-  ) {
+
+  constructor() {
     this.hsQueryBaseService.getFeatureInfoStarted.subscribe((evt) => {
       this.infoCounter = 0;
       this.hsMapService.getLayersArray().forEach((layer: Layer<Source>) => {

--- a/projects/hslayers/components/query/query.component.ts
+++ b/projects/hslayers/components/query/query.component.ts
@@ -38,28 +38,24 @@ import {QUERY_INFO_PANEL} from './query.tokens';
   ],
 })
 export class HsQueryComponent extends HsPanelBaseComponent implements OnInit {
-  popup = new Popup();
-  popupOpens: Subject<any> = new Subject();
-  name = 'query';
-  //To deactivate queries (unsubscribe subscribers) per app
-  queryDeactivator = new Subject<void>();
-
+  hsQueryBaseService = inject(HsQueryBaseService);
+  private hsMapService = inject(HsMapService);
+  private hsLog = inject(HsLogService);
+  private hsQueryVectorService = inject(HsQueryVectorService);
+  private hsDrawService = inject(HsDrawService);
+  private hsQueryWmsService = inject(HsQueryWmsService);
   // Inject QUERY_INFO_PANEL if available, otherwise fallback to HsQueryDefaultInfoPanelBodyComponent
   infoPanelComponent =
     inject(QUERY_INFO_PANEL, {optional: true}) ||
     HsQueryDefaultInfoPanelBodyComponent;
   injector = inject(Injector);
 
-  constructor(
-    public hsQueryBaseService: HsQueryBaseService,
-    private hsMapService: HsMapService,
-    private hsLog: HsLogService,
-    private hsQueryVectorService: HsQueryVectorService,
-    private hsDrawService: HsDrawService,
-    private hsQueryWmsService: HsQueryWmsService,
-  ) {
-    super();
-  }
+  popup = new Popup();
+  popupOpens: Subject<any> = new Subject();
+  name = 'query';
+  //To deactivate queries (unsubscribe subscribers) per app
+  queryDeactivator = new Subject<void>();
+
   async ngOnInit() {
     super.ngOnInit();
     this.popupOpens

--- a/projects/hslayers/components/save-map/form/advanced-options/advanced-options.component.ts
+++ b/projects/hslayers/components/save-map/form/advanced-options/advanced-options.component.ts
@@ -38,6 +38,10 @@ export type saveMapLayer = {
   imports: [TranslatePipe, ReactiveFormsModule],
 })
 export class AdvancedOptionsComponent implements OnInit, OnDestroy {
+  parentContainer = inject(ControlContainer);
+  private hsMapService = inject(HsMapService);
+  private hsSaveMapService = inject(HsSaveMapService);
+
   @Input() thumbnail: HTMLImageElement;
 
   layers: saveMapLayer[];
@@ -52,12 +56,6 @@ export class AdvancedOptionsComponent implements OnInit, OnDestroy {
     false,
     this,
   );
-
-  constructor(
-    public parentContainer: ControlContainer,
-    private hsMapService: HsMapService,
-    private hsSaveMapService: HsSaveMapService,
-  ) {}
 
   get parentFormGroup() {
     return this.parentContainer.control as FormGroup;

--- a/projects/hslayers/components/save-map/form/form.component.ts
+++ b/projects/hslayers/components/save-map/form/form.component.ts
@@ -39,6 +39,9 @@ import {AdvancedOptionsComponent} from './advanced-options/advanced-options.comp
   ],
 })
 export class HsSaveMapFormComponent {
+  hsSaveMapManagerService = inject(HsSaveMapManagerService);
+  private hsLayoutService = inject(HsLayoutService);
+
   @Output() download = new EventEmitter<void>();
   private hsCommonLaymanService = inject(HsCommonLaymanService);
   private hsCompositionsParserService = inject(HsCompositionsParserService);
@@ -152,10 +155,7 @@ export class HsSaveMapFormComponent {
 
   isVisible: Observable<boolean>;
 
-  constructor(
-    public hsSaveMapManagerService: HsSaveMapManagerService,
-    private hsLayoutService: HsLayoutService,
-  ) {
+  constructor() {
     this.isVisible = this.hsLayoutService.mainpanel$.pipe(
       startWith(this.hsLayoutService.mainpanel),
       map((panel) => {

--- a/projects/hslayers/components/save-map/save-map-manager.service.ts
+++ b/projects/hslayers/components/save-map/save-map-manager.service.ts
@@ -9,7 +9,13 @@ import {
 } from 'rxjs';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {HttpClient} from '@angular/common/http';
-import {Injectable, signal, Signal, WritableSignal} from '@angular/core';
+import {
+  Injectable,
+  signal,
+  Signal,
+  WritableSignal,
+  inject,
+} from '@angular/core';
 
 import {
   AccessRightsModel,
@@ -85,6 +91,18 @@ export class HsSaveMapManagerParams {
   providedIn: 'root',
 })
 export class HsSaveMapManagerService extends HsSaveMapManagerParams {
+  private hsMapService = inject(HsMapService);
+  private hsSaveMapService = inject(HsSaveMapService);
+  private http = inject(HttpClient);
+  private hsShareService = inject(HsShareService);
+  private hsLaymanService = inject(HsLaymanService);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsLogService = inject(HsLogService);
+  private hsCompositionsParserService = inject(HsCompositionsParserService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsToastService = inject(HsToastService);
+
   private mapResets = this.hsEventBusService.mapResets.pipe(
     filter(() => {
       return (
@@ -135,22 +153,6 @@ export class HsSaveMapManagerService extends HsSaveMapManagerParams {
   });
 
   currentCompositionEditable: WritableSignal<boolean> = signal(false);
-
-  constructor(
-    private hsMapService: HsMapService,
-    private hsSaveMapService: HsSaveMapService,
-    private http: HttpClient,
-    private hsShareService: HsShareService,
-    private hsLaymanService: HsLaymanService,
-    private hsLayoutService: HsLayoutService,
-    private hsEventBusService: HsEventBusService,
-    private hsLogService: HsLogService,
-    private hsCompositionsParserService: HsCompositionsParserService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsToastService: HsToastService,
-  ) {
-    super();
-  }
 
   parseAccessRights(metadata: LaymanCompositionDescriptor): string {
     this.currentCompositionEditable.set(true);

--- a/projects/hslayers/components/save-map/save-map.component.ts
+++ b/projects/hslayers/components/save-map/save-map.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 import {HsCommonEndpointsService} from 'hslayers-ng/services/endpoints';
@@ -24,20 +24,17 @@ import {filter} from 'rxjs';
   standalone: false,
 })
 export class HsSaveMapComponent extends HsPanelBaseComponent implements OnInit {
+  private hsConfig = inject(HsConfig);
+  private hsSaveMapManagerService = inject(HsSaveMapManagerService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  private hsSaveMapService = inject(HsSaveMapService);
+
   name = 'saveMap';
 
   isAuthenticated = this.hsCommonLaymanService.isAuthenticated;
   localDownload = false;
 
-  constructor(
-    private hsConfig: HsConfig,
-    private hsSaveMapManagerService: HsSaveMapManagerService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonEndpointsService: HsCommonEndpointsService,
-    private hsSaveMapService: HsSaveMapService,
-  ) {
-    super();
-  }
   ngOnInit() {
     super.ngOnInit();
 

--- a/projects/hslayers/components/search/search-input.component.ts
+++ b/projects/hslayers/components/search/search-input.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Subscription} from 'rxjs';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -18,17 +18,17 @@ import {HsMapService} from 'hslayers-ng/services/map';
   imports: [FormsModule, TranslatePipe],
 })
 export class HsSearchInputComponent implements OnInit, OnDestroy {
+  private hsConfig = inject(HsConfig);
+  private hsSearchService = inject(HsSearchService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsShareUrlService = inject(HsShareUrlService);
+  private hsMapService = inject(HsMapService);
+
   query = '';
   searchInputVisible: boolean;
   clearVisible = false;
   searchResultsReceivedSubscription: Subscription;
-  constructor(
-    private hsConfig: HsConfig,
-    private hsSearchService: HsSearchService,
-    private hsEventBusService: HsEventBusService,
-    private hsShareUrlService: HsShareUrlService,
-    private hsMapService: HsMapService,
-  ) {
+  constructor() {
     this.searchResultsReceivedSubscription =
       this.hsEventBusService.searchResultsReceived.subscribe(() => {
         this.clearVisible = true;

--- a/projects/hslayers/components/search/search-results.component.ts
+++ b/projects/hslayers/components/search/search-results.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {KeyValuePipe, NgClass} from '@angular/common';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -24,13 +24,13 @@ import {setHighlighted} from 'hslayers-ng/common/extensions';
   `,
 })
 export class HsSearchResultsComponent {
+  private hsEventBusService = inject(HsEventBusService);
+  hsSearchService = inject(HsSearchService);
+
   searchResultsVisible: boolean;
   fcode_zoom_map: any;
 
-  constructor(
-    private hsEventBusService: HsEventBusService,
-    public hsSearchService: HsSearchService,
-  ) {
+  constructor() {
     this.hsEventBusService.searchResultsReceived
       .pipe(takeUntilDestroyed())
       .subscribe(() => {

--- a/projects/hslayers/components/search/search.component.ts
+++ b/projects/hslayers/components/search/search.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit, inject} from '@angular/core';
 
 import {Subscription} from 'rxjs';
 
@@ -16,17 +16,17 @@ export class HsSearchComponent
   extends HsPanelBaseComponent
   implements OnInit, OnDestroy
 {
+  private hsEventBusService = inject(HsEventBusService);
+  private hsConfig = inject(HsConfig);
+  hsLanguageService = inject(HsLanguageService);
+
   replace = false;
   clearVisible = false;
   searchInputVisible: boolean;
   searchResultsReceivedSubscription: Subscription;
   name = 'search';
 
-  constructor(
-    private hsEventBusService: HsEventBusService,
-    private hsConfig: HsConfig,
-    public hsLanguageService: HsLanguageService,
-  ) {
+  constructor() {
     super();
     this.searchResultsReceivedSubscription =
       this.hsEventBusService.searchResultsReceived.subscribe(() => {
@@ -40,8 +40,7 @@ export class HsSearchComponent
 
   ngOnInit(): void {
     super.ngOnInit();
-    window.innerWidth < this.hsConfig.mobileBreakpoint
-      ? (this.searchInputVisible = false)
-      : (this.searchInputVisible = true);
+    this.searchInputVisible =
+      window.innerWidth >= this.hsConfig.mobileBreakpoint;
   }
 }

--- a/projects/hslayers/components/search/search.service.ts
+++ b/projects/hslayers/components/search/search.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {Feature} from 'ol';
@@ -21,20 +21,20 @@ import {setShowInLayerManager, setTitle} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsSearchService {
+  private http = inject(HttpClient);
+  private hsConfig = inject(HsConfig);
+  private hsMapService = inject(HsMapService);
+  private hsStylerService = inject(HsStylerService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsProxyService = inject(HsProxyService);
+
   formatWKT = new WKT();
   canceler: Subject<any> = new Subject();
   searchResultsLayer: VectorLayer<VectorSource<Feature>>;
   pointerMoveEventKey;
   providers: {[key: string]: any} = {};
 
-  constructor(
-    private http: HttpClient,
-    private hsConfig: HsConfig,
-    private hsMapService: HsMapService,
-    private hsStylerService: HsStylerService,
-    private hsEventBusService: HsEventBusService,
-    private hsProxyService: HsProxyService,
-  ) {
+  constructor() {
     this.searchResultsLayer = new VectorLayer({
       source: new VectorSource({}),
       style: this.hsStylerService.pin_white_blue_highlight,

--- a/projects/hslayers/components/share/share.component.html
+++ b/projects/hslayers/components/share/share.component.html
@@ -6,42 +6,42 @@
       <div class="card-body">
         <div class="form-group">
           <label for="pure-map-link" class="control-label me-1">{{'PERMALINK.sharePureMap' | translate}}</label>
-          <a [href]="HsShareService.pureMapUrl" target="_blank"
-          id="pure-map-link">{{HsShareService.pureMapUrl}}</a>
+          <a [href]="hsShareService.pureMapUrl" target="_blank"
+          id="pure-map-link">{{hsShareService.pureMapUrl}}</a>
           <p><sub class="text-danger">{{'PERMALINK.sharesOnlyMap' | translate }}</sub></p>
         </div>
         <br>
           <div class="form-group">
             <label for="permalink-link" class="control-label me-1">{{'PERMALINK.permalink' |
             translate}}</label><br />
-            <a [href]="HsShareService.permalinkUrl" target="_blank" style="overflow-x: hidden;"
-            id="permalink-link">{{HsShareService.permalinkUrl}}</a>
+            <a [href]="hsShareService.permalinkUrl" target="_blank" style="overflow-x: hidden;"
+            id="permalink-link">{{hsShareService.permalinkUrl}}</a>
             <p><sub class="text-danger">{{'PERMALINK.sharesMapWith' | translate }}</sub></p>
           </div>
           <hr>
             <fieldset class="form-group">
               <label class="mb-2" style="font-size: 1.5em;" [for]="'share-link-' + app">{{'PERMALINK.linkFor' |
-                translate }}&nbsp;<span [hidden]="!HsCore.embeddedEnabled">{{'PERMALINK.embed' |
+                translate }}&nbsp;<span [hidden]="!hsCore.embeddedEnabled">{{'PERMALINK.embed' |
               translate }}/</span>{{'PERMALINK.socialShare' | translate}}
             </label>
             <div class="form-check">
               <label class="form-check-label">
                 <input type="radio" class="form-check-input" [name]="'share-link-' + app" value="puremap"
-                  [(ngModel)]="HsShareService.shareLink" (click)="updateEmbedCode()">
+                  [(ngModel)]="hsShareService.shareLink" (click)="updateEmbedCode()">
                 {{'PERMALINK.pureMap' | translate }}
               </label>
             </div>
             <div class="form-check">
               <label class="form-check-label">
                 <input type="radio" class="form-check-input" [name]="'share-link-' + app" value="permalink"
-                  [(ngModel)]="HsShareService.shareLink" (click)="updateEmbedCode()">
+                  [(ngModel)]="hsShareService.shareLink" (click)="updateEmbedCode()">
                 {{'PERMALINK.permalink' | translate }}
               </label>
             </div>
           </fieldset>
-          <div class="form-floating mb-3" [hidden]="!HsCore.embeddedEnabled">
+          <div class="form-floating mb-3" [hidden]="!hsCore.embeddedEnabled">
             <textarea class="form-control" style="height: 80px" id="permalink-embed"
-              [placeholder]="'PERMALINK.embedCode' | translate" [(ngModel)]="HsShareService.embedCode"
+              [placeholder]="'PERMALINK.embedCode' | translate" [(ngModel)]="hsShareService.embedCode"
             [ngModelOptions]="{standalone: true}"></textarea>
             <label for="permalink-embed" class="control-label">{{'PERMALINK.embedCode' | translate}}</label>
             <br>
@@ -52,14 +52,14 @@
                 <div class="form-floating mb-3" [title]="'COMMON.fillInName' | translate">
                   <input type="text" class="form-control" id="hs-prmlnk-title"
                     [placeholder]="'COMMON.name' | translate" (change)="invalidateShareUrl()"
-                    [(ngModel)]="HsShareService.title" [ngModelOptions]="{standalone: true}">
+                    [(ngModel)]="hsShareService.title" [ngModelOptions]="{standalone: true}">
                   <label for="hs-prmlnk-title" class="control-label">{{'COMMON.name' | translate
                   }}</label>
                 </div>
                 <div class="form-floating mb-3" [title]="'COMMON.fillInDescriptive' | translate">
                   <textarea class="form-control" id="hs-prmlnk-abstract"
                     [placeholder]="'COMMON.abstract' | translate" (change)="invalidateShareUrl()"
-                    [(ngModel)]="HsShareService.abstract"
+                    [(ngModel)]="hsShareService.abstract"
                   [ngModelOptions]="{standalone: true}">                    </textarea>
                   <label for="hs-prmlnk-abstract" class="control-label">{{'COMMON.abstract' | translate}}</label>
                 </div>

--- a/projects/hslayers/components/share/share.component.ts
+++ b/projects/hslayers/components/share/share.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {HsLanguageService} from 'hslayers-ng/services/language';
@@ -13,25 +13,22 @@ import {HslayersService} from 'hslayers-ng/core';
   standalone: false,
 })
 export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
+  hsShareService = inject(HsShareService);
+  hsShareUrlService = inject(HsShareUrlService);
+  hsCore = inject(HslayersService);
+  hsLanguageService = inject(HsLanguageService);
+  private hsConfig = inject(HsConfig);
+
   new_share = false;
   name = 'share';
   app: string;
-  constructor(
-    public HsShareService: HsShareService,
-    public HsShareUrlService: HsShareUrlService,
-    public HsCore: HslayersService,
-    public hsLanguageService: HsLanguageService,
-    private hsConfig: HsConfig,
-  ) {
-    super();
-  }
 
   /**
    * Create Iframe tag for embedded map
    * @returns Iframe tag with src attribute on embed Url and default width and height (1000x700px)
    */
   updateEmbedCode(): string {
-    return this.HsShareService.getEmbedCode();
+    return this.hsShareService.getEmbedCode();
   }
 
   /**
@@ -39,21 +36,21 @@ export class HsShareComponent extends HsPanelBaseComponent implements OnInit {
    * @returns Right share Url
    */
   getShareUrl(): string {
-    return this.HsShareService.getShareUrl();
+    return this.hsShareService.getShareUrl();
   }
 
   /**
    * Set share Url state invalid
    */
   invalidateShareUrl(): void {
-    this.HsShareService.invalidateShareUrl();
+    this.hsShareService.invalidateShareUrl();
   }
 
   /**
    * Create share post on selected social network
    */
   shareOnSocial(): void {
-    this.HsShareService.shareOnSocial(this.new_share);
+    this.hsShareService.shareOnSocial(this.new_share);
   }
 
   ngOnInit() {

--- a/projects/hslayers/components/sidebar/impressum.component.ts
+++ b/projects/hslayers/components/sidebar/impressum.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, signal} from '@angular/core';
+import {Component, computed, signal, inject} from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 
 import {HsConfig} from 'hslayers-ng/config';
@@ -10,6 +10,8 @@ import {HsConfig} from 'hslayers-ng/config';
   standalone: true,
 })
 export class HsImpressumComponent {
+  hsConfig = inject(HsConfig);
+
   version = signal('16.0.0-next.3');
   logoError = signal(false);
 
@@ -21,8 +23,6 @@ export class HsImpressumComponent {
     () =>
       `https://github.com/hslayers/hslayers-ng/releases/tag/${this.version()}`,
   );
-
-  constructor(public hsConfig: HsConfig) {}
 
   onLogoError(): void {
     this.logoError.set(true);

--- a/projects/hslayers/components/sidebar/mini-sidebar.component.ts
+++ b/projects/hslayers/components/sidebar/mini-sidebar.component.ts
@@ -14,31 +14,29 @@ import {HsSidebarService} from 'hslayers-ng/services/sidebar';
   standalone: false,
 })
 export class HsMiniSidebarComponent implements OnInit {
+  hsSidebarService = inject(HsSidebarService);
+  hsLayoutService = inject(HsLayoutService);
+  hsConfig = inject(HsConfig);
+  private hsEventBusService = inject(HsEventBusService);
+
   buttons: HsButton[] = [];
   miniSidebarButton: {title: string};
   private destroyRef = inject(DestroyRef);
 
   isVisible: Observable<boolean>;
 
-  constructor(
-    public HsSidebarService: HsSidebarService,
-    public HsLayoutService: HsLayoutService,
-    public HsConfig: HsConfig,
-    private HsEventBusService: HsEventBusService,
-  ) {}
-
   ngOnInit() {
-    this.HsSidebarService.buttons
+    this.hsSidebarService.buttons
       .pipe(takeUntilDestroyed(this.destroyRef))
       .pipe(startWith([]), delay(0))
       .subscribe((buttons) => {
-        this.buttons = this.HsSidebarService.prepareForTemplate(buttons);
+        this.buttons = this.hsSidebarService.prepareForTemplate(buttons);
       });
     this.miniSidebarButton = {
       title: 'SIDEBAR.additionalPanels',
     };
 
-    this.isVisible = this.HsLayoutService.mainpanel$.pipe(
+    this.isVisible = this.hsLayoutService.mainpanel$.pipe(
       map((which) => {
         return which == 'sidebar';
       }),
@@ -50,18 +48,18 @@ export class HsMiniSidebarComponent implements OnInit {
    * subset of important ones
    */
   toggleUnimportant(): void {
-    this.HsSidebarService.showUnimportant =
-      !this.HsSidebarService.showUnimportant;
+    this.hsSidebarService.showUnimportant =
+      !this.hsSidebarService.showUnimportant;
   }
 
   /**
    * Toggle sidebar mode between expanded and narrow
    */
   toggleSidebar(): void {
-    this.HsLayoutService.sidebarExpanded =
-      !this.HsLayoutService.sidebarExpanded;
+    this.hsLayoutService.sidebarExpanded =
+      !this.hsLayoutService.sidebarExpanded;
     setTimeout(() => {
-      this.HsEventBusService.mapSizeUpdates.next();
+      this.hsEventBusService.mapSizeUpdates.next();
     }, 110);
   }
 }

--- a/projects/hslayers/components/sidebar/sidebar.component.html
+++ b/projects/hslayers/components/sidebar/sidebar.component.html
@@ -1,20 +1,20 @@
 <div class="card hs-sidebar-list hs-main-panel list-group">
-  @if (HsLayoutService.minisidebar) {
+  @if (hsLayoutService.minisidebar) {
   <hs-panel-header class="sidebar-header w-100" name="additional"
     [title]="'SIDEBAR.additionalPanels' | translate "></hs-panel-header>
   }
 
-  @if (HsLayoutService.sidebarToggleable && {position: HsLayoutService.sidebarPosition | async}; as sidebar) {
+  @if (hsLayoutService.sidebarToggleable && {position: hsLayoutService.sidebarPosition | async}; as sidebar) {
   <span class="hs-sidebar-item list-group-item border-top-0" (click)="toggleSidebar()">
     <i class="menu-icon"
-      [ngClass]="HsLayoutService.sidebarExpanded ? (sidebar.position === 'left' ? 'fa-solid fa-chevron-left' : 'fa-solid fa-chevron-right') : (sidebar.position === 'left' ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-left')"></i>
+      [ngClass]="hsLayoutService.sidebarExpanded ? (sidebar.position === 'left' ? 'fa-solid fa-chevron-left' : 'fa-solid fa-chevron-right') : (sidebar.position === 'left' ? 'fa-solid fa-chevron-right' : 'fa-solid fa-chevron-left')"></i>
   </span>
   }<!-- TODO: Remove function call from template -->
 
   @for (button of buttons; track button) {
   <span class="hs-sidebar-item list-group-item h-100 d-flex align-items-center flex-fill"
-    [attr.data-cy]="button.panel" [hidden]="!button.visible" (click)="HsSidebarService.buttonClicked(button)"
-    [ngClass]="{'active': HsLayoutService.mainpanel === button.panel,  'hs-panel-hidden' : !button.fits}"
+    [attr.data-cy]="button.panel" [hidden]="!button.visible" (click)="hsSidebarService.buttonClicked(button)"
+    [ngClass]="{'active': hsLayoutService.mainpanel === button.panel,  'hs-panel-hidden' : !button.fits}"
     [class.language]="button.panel === 'language'" [title]="button.description | translate">
     <!-- TODO: Remove function call from template -->
     @if (button.icon) {
@@ -29,10 +29,10 @@
   </span>
   }
   <!-- TODO: Remove function call from template -->
-  @if (HsLayoutService.minisidebar) {
+  @if (hsLayoutService.minisidebar) {
   <span class="hs-sidebar-item d-flex list-group-item hs-sidebar-additional-items flex-fill align-items-center"
-    (click)="HsLayoutService.setMainPanel('sidebar', true)"
-    [ngClass]="{'active': HsLayoutService.mainpanel === 'sidebar'}">
+    (click)="hsLayoutService.setMainPanel('sidebar', true)"
+    [ngClass]="{'active': hsLayoutService.mainpanel === 'sidebar'}">
     <i class="menu-icon fa-solid fa-equals" data-toggle="tooltip" data-container="body" data-placement="auto"
       title="Menu"></i>
     <span class="hs-sidebar-item-title">{{miniSidebarButton.title | translate }}</span>

--- a/projects/hslayers/components/styler/add-colormap.component.ts
+++ b/projects/hslayers/components/styler/add-colormap.component.ts
@@ -1,4 +1,11 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  inject,
+} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Vector as VectorLayer} from 'ol/layer';
@@ -14,6 +21,9 @@ import {listNumericAttributes} from 'hslayers-ng/services/utils';
   standalone: false,
 })
 export class HsAddColormapComponent implements OnInit {
+  hsLanguageService = inject(HsLanguageService);
+  private hsStylerService = inject(HsStylerService);
+
   name = 'add-colormap';
   @Input() layer: VectorLayer<VectorSource<Feature>>;
   weightAttribute: string;
@@ -23,11 +33,6 @@ export class HsAddColormapComponent implements OnInit {
   max: number | string = '';
   categories: number = 10;
   @Output() canceled = new EventEmitter<void>();
-
-  constructor(
-    public HsLanguageService: HsLanguageService,
-    private hsStylerService: HsStylerService,
-  ) {}
 
   ngOnInit(): void {
     const src = this.layer.getSource();

--- a/projects/hslayers/components/styler/edit-dialog/edit-dialog.component.ts
+++ b/projects/hslayers/components/styler/edit-dialog/edit-dialog.component.ts
@@ -1,20 +1,14 @@
 import {Component} from '@angular/core';
 import {HsConfirmDialogComponent} from 'hslayers-ng/common/confirm';
-import {HsDialogContainerService} from 'hslayers-ng/common/dialogs';
 
 @Component({
   selector: 'hs-styles-edit-dialog',
   templateUrl: './edit-dialog.component.html',
-  styleUrls: ['./edit-dialog.component.css'],
   standalone: false,
 })
 export class HsStylerEditDialogComponent extends HsConfirmDialogComponent {
-  constructor(public HsDialogContainerService: HsDialogContainerService) {
-    super(HsDialogContainerService);
-  }
-
   exitWithoutSave() {
-    this.HsDialogContainerService.destroy(this);
+    this.hsDialogContainerService.destroy(this);
     this.dialogItem.resolve('exit');
   }
 }

--- a/projects/hslayers/components/styler/rule/rule-list-item/rule-list-item.component.ts
+++ b/projects/hslayers/components/styler/rule/rule-list-item/rule-list-item.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 
 import LegendRenderer from 'geostyler-legend/dist/LegendRenderer/LegendRenderer';
@@ -13,14 +13,12 @@ import {HsStylerService} from 'hslayers-ng/services/styler';
   standalone: false,
 })
 export class HsRuleListItemComponent implements OnInit {
+  hsStylerService = inject(HsStylerService);
+  private sanitizer = inject(DomSanitizer);
+
   @Input() rule: any;
   ruleVisible = false;
   svg: SafeHtml;
-
-  constructor(
-    public hsStylerService: HsStylerService,
-    private sanitizer: DomSanitizer,
-  ) {}
 
   ngOnInit(): void {
     this.generateLegend();

--- a/projects/hslayers/components/styler/rule/rule.component.ts
+++ b/projects/hslayers/components/styler/rule/rule.component.ts
@@ -24,6 +24,8 @@ import {Kinds} from '../symbolizers/symbolizer-kind.enum';
   standalone: false,
 })
 export class HsRuleComponent extends HsStylerPartBaseComponent {
+  hsStylerService = inject(HsStylerService);
+
   @Input() rule;
   @Output() changes = new EventEmitter<void>();
   @ViewChild('addSymMenu') menuRef;
@@ -32,9 +34,6 @@ export class HsRuleComponent extends HsStylerPartBaseComponent {
 
   filtersVisible = false;
   scalesVisible = false;
-  constructor(public hsStylerService: HsStylerService) {
-    super();
-  }
   async addSymbolizer(kind: SymbolizerKind): Promise<void> {
     const symbolizer = {kind, color: '#000000'};
     if (kind === Kinds.text) {

--- a/projects/hslayers/components/styler/styler.component.ts
+++ b/projects/hslayers/components/styler/styler.component.ts
@@ -1,5 +1,5 @@
 import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
-import {Component, computed} from '@angular/core';
+import {Component, computed, inject} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
@@ -27,6 +27,12 @@ import {HsUploadedFiles} from 'hslayers-ng/common/upload';
   standalone: false,
 })
 export class HsStylerComponent extends HsPanelBaseComponent {
+  hsStylerService = inject(HsStylerService);
+  hsEventBusService = inject(HsEventBusService);
+  sanitizer = inject(DomSanitizer);
+  hsSaveMapService = inject(HsSaveMapService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+
   layerTitle: string;
   uploaderVisible = false;
 
@@ -42,13 +48,7 @@ export class HsStylerComponent extends HsPanelBaseComponent {
   name = 'styler';
   colormaps = Object.keys(colorScales);
 
-  constructor(
-    public hsStylerService: HsStylerService,
-    public hsEventBusService: HsEventBusService,
-    public sanitizer: DomSanitizer,
-    public hsSaveMapService: HsSaveMapService,
-    public hsDialogContainerService: HsDialogContainerService,
-  ) {
+  constructor() {
     super();
     this.hsEventBusService.layerSelectedFromUrl
       .pipe(takeUntilDestroyed())

--- a/projects/hslayers/components/styler/symbolizers/color-picker/color-picker.component.ts
+++ b/projects/hslayers/components/styler/symbolizers/color-picker/color-picker.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, inject} from '@angular/core';
 
 import {ColorEvent} from 'ngx-color';
 import {FillSymbolizer, MarkSymbolizer, TextSymbolizer} from 'geostyler-style';
@@ -24,12 +24,16 @@ export class HsColorPickerComponent
   extends HsStylerPartBaseComponent
   implements OnInit
 {
-  constructor(
-    public hsColorPickerService: HsColorPickerService,
-    private hsLog: HsLogService,
-  ) {
-    super();
-  }
+  hsColorPickerService = inject(HsColorPickerService);
+  private hsLog = inject(HsLogService);
+
+  @Input() symbolizer: MarkSymbolizer | FillSymbolizer | TextSymbolizer;
+  @Input() attribute: string;
+  @Input() opacityAttribute?: string;
+  @Input() label: string;
+  fontColor = 'white';
+  pickerVisible = false;
+
   ngOnInit(): void {
     const rgb = this.hsColorPickerService.hex2Rgb(
       this.symbolizer[this.attribute],
@@ -40,12 +44,6 @@ export class HsColorPickerComponent
       rgb.b,
     ]);
   }
-  @Input() symbolizer: MarkSymbolizer | FillSymbolizer | TextSymbolizer;
-  @Input() attribute: string;
-  @Input() opacityAttribute?: string;
-  @Input() label: string;
-  fontColor = 'white';
-  pickerVisible = false;
 
   onPick($event: ColorEvent): void {
     this.symbolizer[this.attribute] = $event.color.hex;

--- a/projects/hslayers/components/styler/symbolizers/icon-symbolizer/icon-symbolizer.component.ts
+++ b/projects/hslayers/components/styler/symbolizers/icon-symbolizer/icon-symbolizer.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 import {take} from 'rxjs';
 
 import {IconSymbolizer} from 'geostyler-style';
@@ -14,13 +14,11 @@ import {SymbolizerIcon} from 'hslayers-ng/config';
   standalone: false,
 })
 export class HsIconSymbolizerComponent extends HsStylerPartBaseComponent {
+  private hsDialogContainerService = inject(HsDialogContainerService);
+
   @Input() symbolizer: IconSymbolizer;
   @Input() submenu = false;
   selectedIcon?: SymbolizerIcon;
-
-  constructor(private hsDialogContainerService: HsDialogContainerService) {
-    super();
-  }
 
   anchors = [
     'center',

--- a/projects/hslayers/components/styler/symbolizers/select-icon-dialog/select-icon-dialog.component.ts
+++ b/projects/hslayers/components/styler/symbolizers/select-icon-dialog/select-icon-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewRef} from '@angular/core';
+import {Component, ViewRef, inject} from '@angular/core';
 
 import {HsConfig, SymbolizerIcon} from 'hslayers-ng/config';
 import {
@@ -14,14 +14,12 @@ import {HsIconSymbolizerComponent} from '../icon-symbolizer/icon-symbolizer.comp
   standalone: false,
 })
 export class HsSelectIconDialogComponent implements HsDialogComponent {
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  hsConfig = inject(HsConfig);
+
   dialogItem?: HsDialogItem;
   viewRef: ViewRef;
   data: HsIconSymbolizerComponent;
-
-  constructor(
-    private hsDialogContainerService: HsDialogContainerService,
-    public hsConfig: HsConfig,
-  ) {}
 
   cancel(): void {
     this.data.selectedIcon = null;

--- a/projects/hslayers/components/toolbar/toolbar.component.html
+++ b/projects/hslayers/components/toolbar/toolbar.component.html
@@ -1,6 +1,6 @@
 <div class="hs-toolbar" [hidden]="(isVisible$ | async) === false">
     <nav class="navbar navbar-expand p-0">
-        <hs-panel-container class="navbar-nav" [service]="HsToolbarPanelContainerService">
+        <hs-panel-container class="navbar-nav" [service]="hsToolbarPanelContainerService">
         </hs-panel-container>
     </nav>
 </div>

--- a/projects/hslayers/components/toolbar/toolbar.component.ts
+++ b/projects/hslayers/components/toolbar/toolbar.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy} from '@angular/core';
+import {Component, OnDestroy, inject} from '@angular/core';
 
 import {Subscription} from 'rxjs';
 
@@ -15,17 +15,18 @@ export class HsToolbarComponent
   extends HsGuiOverlayBaseComponent
   implements OnDestroy
 {
+  hsEventBusService = inject(HsEventBusService);
+  hsToolbarPanelContainerService = inject(HsToolbarPanelContainerService);
+
   name = 'toolbar';
   collapsed = false;
   composition_title: any;
   composition_abstract: any;
   mapResetsSubscription: Subscription;
-  constructor(
-    public HsEventBusService: HsEventBusService,
-    public HsToolbarPanelContainerService: HsToolbarPanelContainerService,
-  ) {
+
+  constructor() {
     super();
-    this.mapResetsSubscription = this.HsEventBusService.mapResets.subscribe(
+    this.mapResetsSubscription = this.hsEventBusService.mapResets.subscribe(
       () => {
         setTimeout(() => {
           delete this.composition_title;
@@ -34,6 +35,7 @@ export class HsToolbarComponent
       },
     );
   }
+
   ngOnDestroy(): void {
     this.mapResetsSubscription.unsubscribe();
   }

--- a/projects/hslayers/components/trip-planner/layer-selector.component.html
+++ b/projects/hslayers/components/trip-planner/layer-selector.component.html
@@ -8,7 +8,7 @@
         d-flex
         align-items-center
         mw-100
-      " aria-haspopup="true" (click)="layersExpanded = !layersExpanded; HsTripPlannerService.fillVectorLayers() "
+      " aria-haspopup="true" (click)="layersExpanded = !layersExpanded; hsTripPlannerService.fillVectorLayers() "
       [attr.aria-expanded]="layersExpanded">
       @if (selectedWrapper !== undefined) {
         <div class="text-truncate">
@@ -18,10 +18,10 @@
     </button>
     <div ngbDropdownMenu [ngClass]="{'show': layersExpanded}" style="transform: translateX(25%); width: 15em">
       <div class="d-flex align-items-center w-100 flex-column">
-        @for (layer of HsTripPlannerService.vectorLayers; track layer) {
+        @for (layer of hsTripPlannerService.vectorLayers; track layer) {
           <a class="dropdown-item text-truncate"
             data-toggle="tooltip" [title]="'LAYERS.' + layer.title | translate : {fallbackValue: layer.title} "
-            (click)="HsTripPlannerService.selectLayer(layer, usage); layersExpanded = false">
+            (click)="hsTripPlannerService.selectLayer(layer, usage); layersExpanded = false">
             {{'LAYERS.' + layer.title | translate : {fallbackValue: layer.title} }}
           </a>
         }

--- a/projects/hslayers/components/trip-planner/layer-selector.component.ts
+++ b/projects/hslayers/components/trip-planner/layer-selector.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Vector as VectorLayer} from 'ol/layer';
@@ -12,6 +12,8 @@ import {HsTripPlannerService} from './trip-planner.service';
   standalone: false,
 })
 export class HsTripPlannerLayerSelectorComponent {
+  hsTripPlannerService = inject(HsTripPlannerService);
+
   @Input() label: string;
   @Input() usage: 'route' | 'waypoints';
   @Input() selectedWrapper: {
@@ -20,6 +22,4 @@ export class HsTripPlannerLayerSelectorComponent {
   };
 
   layersExpanded: boolean;
-
-  constructor(public HsTripPlannerService: HsTripPlannerService) {}
 }

--- a/projects/hslayers/components/trip-planner/route-profile-selector.component.ts
+++ b/projects/hslayers/components/trip-planner/route-profile-selector.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, inject} from '@angular/core';
 
 import {HsTripPlannerService} from './trip-planner.service';
 import {RouteProfile} from './ors-profiles.const';
@@ -9,8 +9,8 @@ import {RouteProfile} from './ors-profiles.const';
   standalone: false,
 })
 export class HsTripPlannerProfileSelectorComponent {
+  hsTripPlannerService = inject(HsTripPlannerService);
+
   @Input() selectedProfile: RouteProfile;
   profilesExpanded: boolean;
-
-  constructor(public hsTripPlannerService: HsTripPlannerService) {}
 }

--- a/projects/hslayers/components/trip-planner/trip-planner.component.ts
+++ b/projects/hslayers/components/trip-planner/trip-planner.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {HsLanguageService} from 'hslayers-ng/services/language';
@@ -16,16 +16,13 @@ export class HsTripPlannerComponent
   extends HsPanelBaseComponent
   implements OnInit
 {
+  hsConfig = inject(HsConfig);
+  hsLanguageService = inject(HsLanguageService);
+  hsMapService = inject(HsMapService);
+  hsTripPlannerService = inject(HsTripPlannerService);
+
   name = 'tripPlanner';
 
-  constructor(
-    public hsConfig: HsConfig,
-    public hsLanguageService: HsLanguageService,
-    public hsMapService: HsMapService,
-    public hsTripPlannerService: HsTripPlannerService,
-  ) {
-    super();
-  }
   async ngOnInit(): Promise<void> {
     super.ngOnInit();
     if (this.hsConfig.default_layers === undefined) {

--- a/projects/hslayers/components/trip-planner/trip-planner.service.ts
+++ b/projects/hslayers/components/trip-planner/trip-planner.service.ts
@@ -117,7 +117,7 @@ export class HsTripPlannerService {
     });
 
     this.hsMapService.loaded().then((map) => {
-      (feature, resolution) => {
+      this.waypointRouteStyle = (feature, resolution) => {
         return [
           new Style({
             fill: new Fill({

--- a/projects/hslayers/config/config.service.ts
+++ b/projects/hslayers/config/config.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {Feature, View} from 'ol';
@@ -335,6 +335,8 @@ export class HsConfigObject {
   providedIn: 'root',
 })
 export class HsConfig extends HsConfigObject {
+  private validationService = inject(HsConfigValidationService);
+
   id: string;
   configChanges?: Subject<void> = new Subject();
   private defaultSymbolizerIcons? = [
@@ -343,10 +345,6 @@ export class HsConfig extends HsConfigObject {
     {name: 'information', url: 'img/icons/information78.svg'},
     {name: 'wifi', url: 'img/icons/wifi8.svg'},
   ];
-
-  constructor(private validationService: HsConfigValidationService) {
-    super();
-  }
 
   private logConfigWarning(message: string) {
     console.warn('HsConfig Warning:', message);

--- a/projects/hslayers/core/hslayers.component.ts
+++ b/projects/hslayers/core/hslayers.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   DestroyRef,
   ElementRef,
-  Inject,
   Input,
   NgZone,
   OnInit,
@@ -52,6 +51,18 @@ interface PanState {
   standalone: false,
 })
 export class HslayersComponent implements AfterViewInit, OnInit {
+  hsConfig = inject(HsConfig);
+  private elementRef = inject(ElementRef);
+  hsLayoutService = inject(HsLayoutService);
+  private hsLog = inject(HsLogService);
+  hsEventBusService = inject(HsEventBusService);
+  hsPanelContainerService = inject(HsPanelContainerService);
+  hsOverlayContainerService = inject(HsOverlayContainerService);
+  private hsExternalService = inject(HsExternalService);
+  private ngZone = inject(NgZone);
+  private platformId = inject(PLATFORM_ID);
+  private destroyRef = inject(DestroyRef);
+
   @Input() config: HsConfigObject;
   @Input() id: string;
   @ViewChild('hslayout') hslayout: ElementRef;
@@ -60,8 +71,6 @@ export class HslayersComponent implements AfterViewInit, OnInit {
 
   sidebarPosition: Signal<string>;
   sidebarVisible: Signal<boolean>;
-
-  private destroyRef = inject(DestroyRef);
 
   private panState: PanState = {
     /**
@@ -81,23 +90,13 @@ export class HslayersComponent implements AfterViewInit, OnInit {
   private mapSpace: HTMLElement;
 
   toastPosition: Signal<ToastPosition>;
-  constructor(
-    public hsConfig: HsConfig,
-    private elementRef: ElementRef,
-    public HsLayoutService: HsLayoutService,
-    private hsLog: HsLogService,
-    public HsEventBusService: HsEventBusService,
-    public HsPanelContainerService: HsPanelContainerService,
-    public HsOverlayContainerService: HsOverlayContainerService,
-    private hsExternalService: HsExternalService, //Leave this, need to inject somewhere
-    private ngZone: NgZone,
-    @Inject(PLATFORM_ID) private platformId: any,
-  ) {
-    this.sidebarPosition = toSignal(this.HsLayoutService.sidebarPosition);
-    this.sidebarVisible = toSignal(this.HsLayoutService.sidebarVisible);
+
+  constructor() {
+    this.sidebarPosition = toSignal(this.hsLayoutService.sidebarPosition);
+    this.sidebarVisible = toSignal(this.hsLayoutService.sidebarVisible);
 
     this.toastPosition = toSignal(
-      this.HsLayoutService.sidebarPosition$.pipe(
+      this.hsLayoutService.sidebarPosition$.pipe(
         combineLatestWith(
           this.hsConfig.configChanges.pipe(startWith(this.hsConfig)),
         ),
@@ -119,10 +118,10 @@ export class HslayersComponent implements AfterViewInit, OnInit {
       this.hsConfig.setAppId(this.id);
     }
 
-    this.HsLayoutService.layoutElement =
+    this.hsLayoutService.layoutElement =
       this.elementRef.nativeElement.querySelector('.hs-layout');
 
-    this.HsLayoutService.contentWrapper =
+    this.hsLayoutService.contentWrapper =
       this.elementRef.nativeElement.querySelector('.hs-content-wrapper');
 
     if (window.innerWidth < 600 && isPlatformBrowser(this.platformId)) {
@@ -137,18 +136,18 @@ export class HslayersComponent implements AfterViewInit, OnInit {
     //   this.HsLayoutService.scrollTo(this.elementRef);
     // }
 
-    this.HsLayoutService.layoutLoads.next({
+    this.hsLayoutService.layoutLoads.next({
       element: this.elementRef.nativeElement,
       innerElement: '.hs-map-space',
     });
-    this.HsLayoutService.mapSpaceRef.next(this.mapHost.viewContainerRef);
+    this.hsLayoutService.mapSpaceRef.next(this.mapHost.viewContainerRef);
 
-    this.HsLayoutService.sidebarPosition
+    this.hsLayoutService.sidebarPosition
       .pipe(delay(0), takeUntilDestroyed(this.destroyRef))
       .subscribe((position) => {
         if (position === 'left') {
-          this.HsLayoutService.contentWrapper.classList.add('flex-reverse');
-          this.HsLayoutService.sidebarRight = false;
+          this.hsLayoutService.contentWrapper.classList.add('flex-reverse');
+          this.hsLayoutService.sidebarRight = false;
         }
       });
 
@@ -156,8 +155,8 @@ export class HslayersComponent implements AfterViewInit, OnInit {
       'resize',
       debounce(
         () => {
-          this.HsLayoutService.updPanelSpaceWidth();
-          this.HsLayoutService.updSidebarPosition();
+          this.hsLayoutService.updPanelSpaceWidth();
+          this.hsLayoutService.updSidebarPosition();
         },
         50,
         false,
@@ -167,7 +166,7 @@ export class HslayersComponent implements AfterViewInit, OnInit {
   }
 
   async ngAfterViewInit() {
-    this.HsLayoutService.layoutElement = this.hslayout.nativeElement;
+    this.hsLayoutService.layoutElement = this.hslayout.nativeElement;
     const hsapp = this.elementRef.nativeElement;
     hsapp.style.overflow = 'hidden';
 
@@ -208,11 +207,11 @@ export class HslayersComponent implements AfterViewInit, OnInit {
       }
     }
 
-    this.mapSpace = this.HsLayoutService.contentWrapper.querySelector(
+    this.mapSpace = this.hsLayoutService.contentWrapper.querySelector(
       '.hs-map-space',
     ) as HTMLElement;
 
-    this.panelSpace = this.HsLayoutService.contentWrapper.querySelector(
+    this.panelSpace = this.hsLayoutService.contentWrapper.querySelector(
       '.hs-panelspace',
     ) as HTMLElement;
 
@@ -222,7 +221,7 @@ export class HslayersComponent implements AfterViewInit, OnInit {
 
       this.ngZone.runOutsideAngular(() => {
         const panRecognizer = new Hammer(
-          this.HsLayoutService.layoutElement.querySelector(
+          this.hsLayoutService.layoutElement.querySelector(
             '.hs-panelspace-expander',
           ),
           {
@@ -318,7 +317,7 @@ export class HslayersComponent implements AfterViewInit, OnInit {
       .pipe(safeTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.ngZone.run(() => {
-          this.HsEventBusService.mapSizeUpdates.next();
+          this.hsEventBusService.mapSizeUpdates.next();
           this.panState.isProcessing = false;
         });
       });

--- a/projects/hslayers/core/hslayers.html
+++ b/projects/hslayers/core/hslayers.html
@@ -1,7 +1,7 @@
 <div #hslayout class="hs-layout hsl hs-page-wrapper"
   style="display:block; position: relative; width: 100%; height: 100%; min-height: inherit !important;  max-height:100vh;">
   <div class="hs-content-wrapper d-flex w-100 h-100" [ngClass]="{
-            'hs-open': HsLayoutService.sidebarExpanded && sidebarVisible, 
+            'hs-open': hsLayoutService.sidebarExpanded && sidebarVisible, 
             'hs-sb-right': sidebarPosition() === 'right' && sidebarVisible, 
             'hs-sb-left': sidebarPosition() === 'left' && sidebarVisible, 
             'hs-sb-bottom': sidebarPosition() === 'bottom'
@@ -10,23 +10,23 @@
     <div class="hs-map-space d-flex">
       <hs-map class="hs-flex-fill d-flex"/>
       <ng-template hsMapHost></ng-template>
-      <hs-panel-container [service]="HsOverlayContainerService"></hs-panel-container>
+      <hs-panel-container [service]="hsOverlayContainerService"></hs-panel-container>
     </div>
     <div class="hs-panelspace buttons" [hidden]="!sidebarVisible()"
-      [ngClass]="{'labels': HsLayoutService.sidebarLabels}">
+      [ngClass]="{'labels': hsLayoutService.sidebarLabels}">
       <div class="hs-panelspace-expander-container bg-white d-none d-mw-md-block w-100">
         <span class="hs-panelspace-expander bg-transparent text-primary py-0 w-100"
-          [ngClass]="{'disabled': !(HsLayoutService.sidebarExpanded && sidebarVisible)}">
+          [ngClass]="{'disabled': !(hsLayoutService.sidebarExpanded && sidebarVisible)}">
           <div class="drag-handle pt-1"></div>
         </span>
       </div>
       <div class="hs-panelspace-wrapper me-1 d-block">
         <hs-sidebar class="border-0" />
         <div class="hs-panelplace">
-          @if (HsLayoutService.mainpanel === 'sidebar') {
+          @if (hsLayoutService.mainpanel === 'sidebar') {
           <hs-mini-sidebar />
           }
-          <hs-panel-container [service]="HsPanelContainerService" class="hs-panelplace">
+          <hs-panel-container [service]="hsPanelContainerService" class="hs-panelplace">
           </hs-panel-container>
         </div>
       </div>

--- a/projects/hslayers/core/layout.directive.ts
+++ b/projects/hslayers/core/layout.directive.ts
@@ -1,9 +1,9 @@
-import {Directive, ViewContainerRef} from '@angular/core';
+import {Directive, ViewContainerRef, inject} from '@angular/core';
 
 @Directive({
   selector: '[hslayout]',
   standalone: false,
 })
 export class HsLayoutHostDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }

--- a/projects/hslayers/core/map-host.directive.ts
+++ b/projects/hslayers/core/map-host.directive.ts
@@ -1,8 +1,8 @@
-import {Directive, ViewContainerRef} from '@angular/core';
+import {Directive, ViewContainerRef, inject} from '@angular/core';
 @Directive({
   selector: '[hsMapHost]',
   standalone: false,
 })
 export class HsMapHostDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }

--- a/projects/hslayers/core/map/map.directive.ts
+++ b/projects/hslayers/core/map/map.directive.ts
@@ -1,9 +1,9 @@
-import {Directive, ViewContainerRef} from '@angular/core';
+import { Directive, ViewContainerRef, inject } from '@angular/core';
 
 @Directive({
   selector: '[map]',
   standalone: true,
 })
 export class HsMapDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }

--- a/projects/hslayers/services/add-data/add-data.service.ts
+++ b/projects/hslayers/services/add-data/add-data.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {BehaviorSubject, Subject} from 'rxjs';
 import {Layer} from 'ol/layer';
@@ -15,17 +15,16 @@ import {getBase} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsAddDataService {
+  hsMapService = inject(HsMapService);
+  hsConfig = inject(HsConfig);
+  hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+
   sidebarLoad: Subject<void> = new Subject();
   datasetSelected: BehaviorSubject<DatasetType> = new BehaviorSubject(
     undefined,
   );
   datasetTypeSelected = this.datasetSelected.asObservable();
-  constructor(
-    public hsMapService: HsMapService,
-    public hsConfig: HsConfig,
-    public hsCommonEndpointsService: HsCommonEndpointsService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-  ) {}
 
   addLayer(layer: Layer<Source>, underLayer?: Layer<Source>): void {
     if (underLayer) {

--- a/projects/hslayers/services/add-data/catalogue/catalogue-map.service.ts
+++ b/projects/hslayers/services/add-data/catalogue/catalogue-map.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {EventsKey} from 'ol/events';
 import {Feature} from 'ol';
@@ -24,16 +24,16 @@ import {setHighlighted} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsAddDataCatalogueMapService {
+  hsMapService = inject(HsMapService);
+  hsLogService = inject(HsLogService);
+  private hsSaveMapService = inject(HsSaveMapService);
+  private hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  private hsLayoutService = inject(HsLayoutService);
+
   extentLayer: VectorLayer<VectorSource<Feature>>;
   pointerMoveListener: EventsKey;
 
-  constructor(
-    public hsMapService: HsMapService,
-    public hsLogService: HsLogService,
-    private hsSaveMapService: HsSaveMapService,
-    private hsCommonEndpointsService: HsCommonEndpointsService,
-    private hsLayoutService: HsLayoutService,
-  ) {
+  constructor() {
     this.hsLayoutService.mainpanel$.subscribe((which) => {
       if (which === 'addData') {
         this.addPointerMoveListener();

--- a/projects/hslayers/services/add-data/catalogue/catalogue.service.ts
+++ b/projects/hslayers/services/add-data/catalogue/catalogue.service.ts
@@ -1,11 +1,10 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
 import {
   Observable,
   Subject,
-  combineLatest,
   debounceTime,
   filter,
   forkJoin,
@@ -78,21 +77,21 @@ class HsAddDataCatalogueParams {
   providedIn: 'root',
 })
 export class HsAddDataCatalogueService extends HsAddDataCatalogueParams {
-  constructor(
-    public hsConfig: HsConfig,
-    public hsAddDataVectorService: HsAddDataVectorService,
-    public hsEventBusService: HsEventBusService,
-    public hsMickaBrowserService: HsMickaBrowserService,
-    public hsLaymanBrowserService: HsLaymanBrowserService,
-    public hsLayoutService: HsLayoutService,
-    public hsCommonEndpointsService: HsCommonEndpointsService,
-    public hsMapService: HsMapService,
-    public hsAddDataCatalogueMapService: HsAddDataCatalogueMapService,
-    public hsAddDataService: HsAddDataService,
-    private zone: NgZone,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-  ) {
+  hsConfig = inject(HsConfig);
+  hsAddDataVectorService = inject(HsAddDataVectorService);
+  hsEventBusService = inject(HsEventBusService);
+  hsMickaBrowserService = inject(HsMickaBrowserService);
+  hsLaymanBrowserService = inject(HsLaymanBrowserService);
+  hsLayoutService = inject(HsLayoutService);
+  hsCommonEndpointsService = inject(HsCommonEndpointsService);
+  hsMapService = inject(HsMapService);
+  hsAddDataCatalogueMapService = inject(HsAddDataCatalogueMapService);
+  hsAddDataService = inject(HsAddDataService);
+  private zone = inject(NgZone);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+
+  constructor() {
     super();
     this.hsLayoutService.mainpanel$.subscribe((which) => {
       if (this.panelVisible()) {
@@ -191,9 +190,11 @@ export class HsAddDataCatalogueService extends HsAddDataCatalogueParams {
           }
         }
         this.catalogQuery = forkJoin(observables).subscribe(() => {
-          suspendLimitCalculation
-            ? this.createLayerList()
-            : this.calculateEndpointLimits();
+          if (suspendLimitCalculation) {
+            this.createLayerList();
+          } else {
+            this.calculateEndpointLimits();
+          }
         });
       });
     }

--- a/projects/hslayers/services/add-data/catalogue/layman.service.ts
+++ b/projects/hslayers/services/add-data/catalogue/layman.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
@@ -36,17 +36,15 @@ export interface HsLaymanGetLayersWrapper {
 
 @Injectable({providedIn: 'root'})
 export class HsLaymanBrowserService {
-  httpCall;
+  private http = inject(HttpClient);
+  private log = inject(HsLogService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+  hsToastService = inject(HsToastService);
+  hsLanguageService = inject(HsLanguageService);
+  hsMapService = inject(HsMapService);
 
-  constructor(
-    private http: HttpClient,
-    private log: HsLogService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-    public hsToastService: HsToastService,
-    public hsLanguageService: HsLanguageService,
-    public hsMapService: HsMapService,
-  ) {}
+  httpCall;
 
   /**
    * Loads datasets metadata from Layman

--- a/projects/hslayers/services/add-data/catalogue/micka.service.ts
+++ b/projects/hslayers/services/add-data/catalogue/micka.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {catchError, map, timeout} from 'rxjs/operators';
 import {of} from 'rxjs';
@@ -24,16 +24,14 @@ import {
 
 @Injectable({providedIn: 'root'})
 export class HsMickaBrowserService {
-  httpCall;
+  private http = inject(HttpClient);
+  private log = inject(HsLogService);
+  hsMapService = inject(HsMapService);
+  hsToastService = inject(HsToastService);
+  hsLanguageService = inject(HsLanguageService);
+  private hsProxyService = inject(HsProxyService);
 
-  constructor(
-    private http: HttpClient,
-    private log: HsLogService,
-    public hsMapService: HsMapService,
-    public hsToastService: HsToastService,
-    public hsLanguageService: HsLanguageService,
-    private hsProxyService: HsProxyService,
-  ) {}
+  httpCall;
 
   /**
    * @param dataset - Configuration of selected datasource (from app config)
@@ -53,7 +51,6 @@ export class HsMickaBrowserService {
   ): any {
     const url = this.createRequestUrl(endpoint, data, textField);
     endpoint.datasourcePaging.loaded = false;
-
     endpoint.httpCall = this.http
       .get(url, {
         responseType: 'json',

--- a/projects/hslayers/services/add-data/common-file.service.ts
+++ b/projects/hslayers/services/add-data/common-file.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Subject} from 'rxjs';
 
@@ -53,21 +53,17 @@ export class HsAddDataCommonFileServiceParams {
 
 @Injectable({providedIn: 'root'})
 export class HsAddDataCommonFileService extends HsAddDataCommonFileServiceParams {
-  constructor(
-    private hsAddDataOwsService: HsAddDataOwsService,
-    private hsAddDataUrlService: HsAddDataUrlService,
-    private hsAddDataService: HsAddDataService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsLanguageService: HsLanguageService,
-    private hsLaymanService: HsLaymanService,
-    private hsLog: HsLogService,
-    private hsToastService: HsToastService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-    private hsProxyService: HsProxyService,
-  ) {
-    super();
-  }
+  private hsAddDataOwsService = inject(HsAddDataOwsService);
+  private hsAddDataUrlService = inject(HsAddDataUrlService);
+  private hsAddDataService = inject(HsAddDataService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsLaymanService = inject(HsLaymanService);
+  private hsLog = inject(HsLogService);
+  private hsToastService = inject(HsToastService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+  private hsProxyService = inject(HsProxyService);
 
   /**
    * Clear service param values to default values

--- a/projects/hslayers/services/add-data/common.service.ts
+++ b/projects/hslayers/services/add-data/common.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Subject} from 'rxjs';
 
@@ -12,6 +12,13 @@ import {OwsType} from 'hslayers-ng/types';
 
 @Injectable({providedIn: 'root'})
 export class HsAddDataCommonService {
+  hsMapService = inject(HsMapService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsToastService = inject(HsToastService);
+  hsAddDataService = inject(HsAddDataService);
+  hsDimensionService = inject(HsDimensionService);
+  hsEventBusService = inject(HsEventBusService);
+
   layerToSelect: string | string[];
   loadingInfo = false;
   showDetails = false;
@@ -20,14 +27,8 @@ export class HsAddDataCommonService {
   //TODO: all dimension related things need to be refactored into separate module
   getDimensionValues = this.hsDimensionService.getDimensionValues;
   serviceLayersCalled: Subject<string> = new Subject();
-  constructor(
-    public hsMapService: HsMapService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsToastService: HsToastService,
-    public hsAddDataService: HsAddDataService,
-    public hsDimensionService: HsDimensionService,
-    public hsEventBusService: HsEventBusService,
-  ) {
+
+  constructor() {
     this.hsEventBusService.cancelAddDataUrlRequest.subscribe(() => {
       this.clearParams();
     });
@@ -175,7 +176,9 @@ export class HsAddDataCommonService {
           baseNameParts.push(layer[property]);
         } else if (layer.Layer) {
           const nested = this.getGroupedLayerNames(layer.Layer, property);
-          nested.length > 0 ? baseNameParts.push(nested) : null;
+          if (nested.length > 0) {
+            baseNameParts.push(nested);
+          }
         }
       }
     } else {

--- a/projects/hslayers/services/add-data/url/add-data-ows.service.ts
+++ b/projects/hslayers/services/add-data/url/add-data-ows.service.ts
@@ -38,29 +38,28 @@ import {HsAddDataWfsLaymanService} from './wfs-layman.service';
   providedIn: 'root',
 })
 export class HsAddDataOwsService {
-  typeService: HsUrlTypeServiceModel;
-  typeCapabilitiesService: IGetCapabilities;
-
+  hsAddDataService = inject(HsAddDataService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsHistoryListService = inject(HsHistoryListService);
+  hsLog = inject(HsLogService);
+  hsArcgisGetCapabilitiesService = inject(HsArcgisGetCapabilitiesService);
+  hsUrlArcGisService = inject(HsUrlArcGisService);
+  hsUrlWfsService = inject(HsUrlWfsService);
+  hsWfsGetCapabilitiesService = inject(HsWfsGetCapabilitiesService);
+  hsUrlWmsService = inject(HsUrlWmsService);
+  hsWmsGetCapabilitiesService = inject(HsWmsGetCapabilitiesService);
+  hsWmtsGetCapabilitiesService = inject(HsWmtsGetCapabilitiesService);
+  hsUrlWmtsService = inject(HsUrlWmtsService);
+  hsUrlXyzService = inject(HsUrlXyzService);
+  hsXyzGetCapabilitiesService = inject(HsXyzGetCapabilitiesService);
   private hsAddDataWmsLaymanService = inject(HsAddDataWmsLaymanService);
   private hsAddDataWfsLaymanService = inject(HsAddDataWfsLaymanService);
 
-  constructor(
-    public hsAddDataService: HsAddDataService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsHistoryListService: HsHistoryListService,
-    public hsLog: HsLogService,
-    public hsArcgisGetCapabilitiesService: HsArcgisGetCapabilitiesService,
-    public hsUrlArcGisService: HsUrlArcGisService,
-    public hsUrlWfsService: HsUrlWfsService,
-    public hsWfsGetCapabilitiesService: HsWfsGetCapabilitiesService,
-    public hsUrlWmsService: HsUrlWmsService,
-    public hsWmsGetCapabilitiesService: HsWmsGetCapabilitiesService,
-    public hsWmtsGetCapabilitiesService: HsWmtsGetCapabilitiesService,
-    public hsUrlWmtsService: HsUrlWmtsService,
-    public hsUrlXyzService: HsUrlXyzService,
-    public hsXyzGetCapabilitiesService: HsXyzGetCapabilitiesService,
-  ) {
+  typeService: HsUrlTypeServiceModel;
+  typeCapabilitiesService: IGetCapabilities;
+
+  constructor() {
     this.hsAddDataCommonService.serviceLayersCalled.subscribe((url) => {
       this.setUrlAndConnect({uri: url});
     });

--- a/projects/hslayers/services/add-data/url/add-data-url.service.ts
+++ b/projects/hslayers/services/add-data/url/add-data-url.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -15,17 +15,15 @@ import {HsToastService} from 'hslayers-ng/common/toast';
   providedIn: 'root',
 })
 export class HsAddDataUrlService {
+  hsLog = inject(HsLogService);
+  hsLanguageService = inject(HsLanguageService);
+  hsLayoutService = inject(HsLayoutService);
+  private hsMapService = inject(HsMapService);
+  private hsToastService = inject(HsToastService);
+
   typeSelected: AddDataUrlType;
   addingAllowed: boolean;
   connectFromParams = true;
-
-  constructor(
-    public hsLog: HsLogService,
-    public hsLanguageService: HsLanguageService,
-    public hsLayoutService: HsLayoutService,
-    private hsMapService: HsMapService,
-    private hsToastService: HsToastService,
-  ) {}
 
   /**
    * Selects a service layer to be added (WMS | WMTS | ArcGIS Map Server)

--- a/projects/hslayers/services/add-data/url/arcgis.service.ts
+++ b/projects/hslayers/services/add-data/url/arcgis.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import TileGrid from 'ol/tilegrid/TileGrid';
 import {createXYZ} from 'ol/tilegrid';
@@ -40,19 +40,19 @@ import {HsToastService} from 'hslayers-ng/common/toast';
 
 @Injectable({providedIn: 'root'})
 export class HsUrlArcGisService implements HsUrlTypeServiceModel {
-  data: UrlDataObject;
+  hsArcgisGetCapabilitiesService = inject(HsArcgisGetCapabilitiesService);
+  hsLayoutService = inject(HsLayoutService);
+  hsMapService = inject(HsMapService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
 
+  data: UrlDataObject;
   hasCachedTiles = false;
   tileGrid: TileGrid;
-  constructor(
-    public hsArcgisGetCapabilitiesService: HsArcgisGetCapabilitiesService,
-    public hsLayoutService: HsLayoutService,
-    public hsMapService: HsMapService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-    public hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-  ) {
+
+  constructor() {
     this.setDataToDefault();
   }
 

--- a/projects/hslayers/services/add-data/url/wfs.service.ts
+++ b/projects/hslayers/services/add-data/url/wfs.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {computed, Injectable} from '@angular/core';
+import {computed, Injectable, inject} from '@angular/core';
 import {Subject, finalize, takeUntil} from 'rxjs';
 
 import * as xml2Json from 'xml-js';
@@ -53,6 +53,17 @@ export type HsWfsCapabilitiesLayer = WfsCapabilitiesLayer & {
   providedIn: 'root',
 })
 export class HsUrlWfsService implements HsUrlTypeServiceModel {
+  private http = inject(HttpClient);
+  hsWfsGetCapabilitiesService = inject(HsWfsGetCapabilitiesService);
+  private hsLog = inject(HsLogService);
+  hsMapService = inject(HsMapService);
+  hsEventBusService = inject(HsEventBusService);
+  hsLayoutService = inject(HsLayoutService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+  private hsAddDataUrlService = inject(HsAddDataUrlService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsProxyService = inject(HsProxyService);
+
   data: UrlDataObject;
   definedProjections: string[];
   loadingFeatures: boolean;
@@ -65,18 +76,7 @@ export class HsUrlWfsService implements HsUrlTypeServiceModel {
     return isLaymanUrl(url, this.hsCommonLaymanService.layman());
   });
 
-  constructor(
-    private http: HttpClient,
-    public hsWfsGetCapabilitiesService: HsWfsGetCapabilitiesService,
-    private hsLog: HsLogService,
-    public hsMapService: HsMapService,
-    public hsEventBusService: HsEventBusService,
-    public hsLayoutService: HsLayoutService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-    private hsAddDataUrlService: HsAddDataUrlService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsProxyService: HsProxyService,
-  ) {
+  constructor() {
     this.setDataToDefault();
   }
 

--- a/projects/hslayers/services/add-data/url/wms.service.ts
+++ b/projects/hslayers/services/add-data/url/wms.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import ImageSource from 'ol/source/Image';
 import TileSource from 'ol/source/Tile';
@@ -41,19 +41,19 @@ import {HsLayoutService} from 'hslayers-ng/services/layout';
 
 @Injectable({providedIn: 'root'})
 export class HsUrlWmsService implements HsUrlTypeServiceModel {
+  private hsMapService = inject(HsMapService);
+  private hsWmsGetCapabilitiesService = inject(HsWmsGetCapabilitiesService);
+  private hsDimensionService = inject(HsDimensionService);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsConfig = inject(HsConfig);
+  private hsAddDataService = inject(HsAddDataService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsAddDataUrlService = inject(HsAddDataUrlService);
+  private hsAddDataCommonService = inject(HsAddDataCommonService);
+
   data: UrlDataObject;
 
-  constructor(
-    private hsMapService: HsMapService,
-    private hsWmsGetCapabilitiesService: HsWmsGetCapabilitiesService,
-    private hsDimensionService: HsDimensionService,
-    private hsLayoutService: HsLayoutService,
-    private hsConfig: HsConfig,
-    private hsAddDataService: HsAddDataService,
-    private hsEventBusService: HsEventBusService,
-    private hsAddDataUrlService: HsAddDataUrlService,
-    private hsAddDataCommonService: HsAddDataCommonService,
-  ) {
+  constructor() {
     this.hsEventBusService.olMapLoads.subscribe((map) => {
       this.data.map_projection = this.hsMapService.map
         .getView()

--- a/projects/hslayers/services/add-data/url/wmts.service.ts
+++ b/projects/hslayers/services/add-data/url/wmts.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import WMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
 import {Extent} from 'ol/extent';
@@ -24,14 +24,14 @@ import {addAnchors} from 'hslayers-ng/services/utils';
 
 @Injectable({providedIn: 'root'})
 export class HsUrlWmtsService implements HsUrlTypeServiceModel {
+  hsMapService = inject(HsMapService);
+  hsLayoutService = inject(HsLayoutService);
+  hsAddDataUrlService = inject(HsAddDataUrlService);
+  hsAddDataCommonService = inject(HsAddDataCommonService);
+
   data: UrlDataObject;
 
-  constructor(
-    public hsMapService: HsMapService,
-    public hsLayoutService: HsLayoutService,
-    public hsAddDataUrlService: HsAddDataUrlService,
-    public hsAddDataCommonService: HsAddDataCommonService,
-  ) {
+  constructor() {
     this.setDataToDefault();
   }
 

--- a/projects/hslayers/services/add-data/url/xyz.service.ts
+++ b/projects/hslayers/services/add-data/url/xyz.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Layer, Tile} from 'ol/layer';
 import {Source, XYZ} from 'ol/source';
 import {Options as TileOptions} from 'ol/layer/BaseTile';
@@ -17,15 +17,15 @@ import {HsEventBusService} from 'hslayers-ng/services/event-bus';
 
 @Injectable({providedIn: 'root'})
 export class HsUrlXyzService implements HsUrlTypeServiceModel {
+  private hsMapService = inject(HsMapService);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsAddDataService = inject(HsAddDataService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsAddDataCommonService = inject(HsAddDataCommonService);
+
   data: UrlDataObject;
 
-  constructor(
-    private hsMapService: HsMapService,
-    private hsLayoutService: HsLayoutService,
-    private hsAddDataService: HsAddDataService,
-    private hsEventBusService: HsEventBusService,
-    private hsAddDataCommonService: HsAddDataCommonService,
-  ) {
+  constructor() {
     this.hsEventBusService.olMapLoads.subscribe((map) => {
       this.data.map_projection = this.hsMapService.map
         .getView()

--- a/projects/hslayers/services/add-data/vector/vector-upload.service.ts
+++ b/projects/hslayers/services/add-data/vector/vector-upload.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Projection, get as getProjection} from 'ol/proj';
@@ -13,6 +13,10 @@ import {HsAddDataVectorUtilsService} from './vector-utils.service';
   providedIn: 'root',
 })
 export class HsAddDataVectorUploadService {
+  private hsLog = inject(HsLogService);
+  private hsMapService = inject(HsMapService);
+  private hsAddDataVectorUtilsService = inject(HsAddDataVectorUtilsService);
+
   readUploadedFileAsText = (inputFile: any) => {
     const temporaryFileReader = new FileReader();
     return new Promise((resolve, reject) => {
@@ -39,12 +43,6 @@ export class HsAddDataVectorUploadService {
       temporaryFileReader.readAsDataURL(inputFile);
     });
   };
-
-  constructor(
-    private hsLog: HsLogService,
-    private hsMapService: HsMapService,
-    private hsAddDataVectorUtilsService: HsAddDataVectorUtilsService,
-  ) {}
 
   /**
    * Create a object containing data from XML dataset

--- a/projects/hslayers/services/add-data/vector/vector-utils.service.ts
+++ b/projects/hslayers/services/add-data/vector/vector-utils.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Projection, get as getProjection} from 'ol/proj';
 import {PROJECTIONS as epsg4326Aliases} from 'ol/proj/epsg4326';
@@ -9,7 +9,8 @@ import {HsLaymanService} from 'hslayers-ng/services/save-map';
   providedIn: 'root',
 })
 export class HsAddDataVectorUtilsService {
-  constructor(private hsLaymanService: HsLaymanService) {}
+  private hsLaymanService = inject(HsLaymanService);
+
   /**
    * Tries to guess file type based on the file extension
    * @param extension - Parsed file extension from uploaded file

--- a/projects/hslayers/services/add-data/vector/vector.service.ts
+++ b/projects/hslayers/services/add-data/vector/vector.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {Layer, Vector as VectorLayer} from 'ol/layer';
@@ -37,29 +37,26 @@ import {undefineEmptyString, HsProxyService} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsAddDataVectorService {
-  constructor(
-    private hsAddDataCommonFileService: HsAddDataCommonFileService,
-    private hsAddDataService: HsAddDataService,
-    private hsLaymanService: HsLaymanService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-    private hsMapService: HsMapService,
-    private hsStylerService: HsStylerService,
-    private hsAddDataVectorUtilsService: HsAddDataVectorUtilsService,
-    private hsToastService: HsToastService,
-    private hsProxyService: HsProxyService,
-  ) {}
+  private hsAddDataCommonFileService = inject(HsAddDataCommonFileService);
+  private hsAddDataService = inject(HsAddDataService);
+  private hsLaymanService = inject(HsLaymanService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+  private hsMapService = inject(HsMapService);
+  private hsStylerService = inject(HsStylerService);
+  private hsAddDataVectorUtilsService = inject(HsAddDataVectorUtilsService);
+  private hsToastService = inject(HsToastService);
+  private hsProxyService = inject(HsProxyService);
 
   /**
    * Load non-wms OWS data and create layer
    * @param type - Type of data to load (supports Kml, Geojson, Wfs and Sparql)
    * @param url - Url of data/service localization
-   
    * @param title - Title of new layer
    * @param abstract - Abstract of new layer
-   
    * @param srs - EPSG code of selected projection (eg. "EPSG:4326")
    * @param options - Other options
+   * @param addUnder - Layer to add new layer under
    * @returns Promise which return OpenLayers vector layer
    */
   addVectorLayer(
@@ -113,7 +110,7 @@ export class HsAddDataVectorService {
    * Load non-wms OWS data and create layer
    * @param type - Type of data to load (supports KML, GeoJSON, WFS and SPARQL)
    * @param url - Url of data/service localization
-   
+   * @param name - Name of new layer
    * @param title - Title of new layer
    * @param abstract - Abstract of new layer
    * @param srs - EPSG code of selected projection (eg. "EPSG:4326")

--- a/projects/hslayers/services/compositions/compositions-parser.service.ts
+++ b/projects/hslayers/services/compositions/compositions-parser.service.ts
@@ -1,7 +1,8 @@
-import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
-
 import * as xml2Json from 'xml-js';
+
+import {HttpClient} from '@angular/common/http';
+import {Injectable, inject} from '@angular/core';
+
 import {Layer} from 'ol/layer';
 import {
   Observable,
@@ -61,6 +62,25 @@ import {
   providedIn: 'root',
 })
 export class HsCompositionsParserService {
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+  private $http = inject(HttpClient);
+  private hsProxyService = inject(HsProxyService);
+  private hsCompositionsLayerParserService = inject(
+    HsCompositionsLayerParserService,
+  );
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsLayoutService = inject(HsLayoutService);
+  private $log = inject(HsLogService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsLayerManagerService = inject(HsLayerManagerService);
+  private hsToastService = inject(HsToastService);
+  private hsLayerManagerVisibilityService = inject(
+    HsLayerManagerVisibilityService,
+  );
+
   /**
    * Layman composition record
    * holds access_rights
@@ -83,22 +103,9 @@ export class HsCompositionsParserService {
     suspendZoomingToExtent: false,
     suspendPanelChange: false,
   };
-  constructor(
-    private hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    private $http: HttpClient,
-    private hsProxyService: HsProxyService,
-    private hsCompositionsLayerParserService: HsCompositionsLayerParserService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsLayoutService: HsLayoutService,
-    private $log: HsLogService,
-    private hsEventBusService: HsEventBusService,
-    private hsLanguageService: HsLanguageService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsLayerManagerService: HsLayerManagerService,
-    private hsToastService: HsToastService,
-    private HsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-  ) {
+  constructor() {
+    const $log = this.$log;
+
     /**
      * Composition opened -> request its descriptor
      * in order to get access_rights and workspace properties
@@ -122,9 +129,9 @@ export class HsCompositionsParserService {
             })
             .pipe(
               catchError((e) => {
-                fromLayman
-                  ? $log.error('Could not get composition metadata')
-                  : undefined;
+                if (fromLayman) {
+                  $log.error('Could not get composition metadata');
+                }
                 return of(e);
               }),
             );
@@ -451,7 +458,7 @@ export class HsCompositionsParserService {
             take(1),
           )
           .subscribe((currentBaseLayer) => {
-            this.HsLayerManagerVisibilityService.changeBaseLayerVisibility(
+            this.hsLayerManagerVisibilityService.changeBaseLayerVisibility(
               true,
               currentBaseLayer,
             );
@@ -492,7 +499,7 @@ export class HsCompositionsParserService {
                     lyr,
                     true,
                   );
-                this.HsLayerManagerVisibilityService.changeBaseLayerVisibility(
+                this.hsLayerManagerVisibilityService.changeBaseLayerVisibility(
                   true,
                   layerDescriptor,
                 );
@@ -634,9 +641,11 @@ export class HsCompositionsParserService {
       });
     }
     if (keywordsInfo !== undefined) {
-      Array.isArray(keywordsInfo)
-        ? (infoDetails.keywords = keywordsInfo.map((kw) => kw._text))
-        : (infoDetails.keywords = keywordsInfo._text);
+      if (Array.isArray(keywordsInfo)) {
+        infoDetails.keywords = keywordsInfo.map((kw) => kw._text);
+      } else {
+        infoDetails.keywords = keywordsInfo._text;
+      }
     }
     return infoDetails;
   }

--- a/projects/hslayers/services/compositions/layer-parser.service.ts
+++ b/projects/hslayers/services/compositions/layer-parser.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Feature} from 'ol';
 import {GeoJSON} from 'ol/format';
@@ -27,17 +27,15 @@ import {setDefinition} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsCompositionsLayerParserService {
-  constructor(
-    private hsMapService: HsMapService,
-    private HsAddDataVectorService: HsAddDataVectorService,
-    private HsStylerService: HsStylerService,
-    private HsLanguageService: HsLanguageService,
-    private hsLog: HsLogService,
-    private HsToastService: HsToastService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-    private hsAddDataOwsService: HsAddDataOwsService,
-  ) {}
+  private hsMapService = inject(HsMapService);
+  private hsAddDataVectorService = inject(HsAddDataVectorService);
+  private hsStylerService = inject(HsStylerService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsLog = inject(HsLogService);
+  private hsToastService = inject(HsToastService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+  private hsAddDataOwsService = inject(HsAddDataOwsService);
 
   /**
    * Initiate creation of WFS layer through HsUrlWfsService
@@ -117,12 +115,12 @@ export class HsCompositionsLayerParserService {
       newLayer[0].setVisible(lyr_def.visibility);
       return newLayer[0];
     } catch (error) {
-      this.HsToastService.createToastPopupMessage(
-        this.HsLanguageService.getTranslation(
+      this.hsToastService.createToastPopupMessage(
+        this.hsLanguageService.getTranslation(
           'ADDLAYERS.capabilitiesParsingProblem',
           undefined,
         ),
-        this.HsLanguageService.getTranslationIgnoreNonExisting(
+        this.hsLanguageService.getTranslationIgnoreNonExisting(
           'ERRORMESSAGES',
           error,
         ),
@@ -350,7 +348,7 @@ export class HsCompositionsLayerParserService {
 
       let style = null;
       if (lyr_def.style) {
-        style = (await this.HsStylerService.parseStyle(lyr_def.style)).style;
+        style = (await this.hsStylerService.parseStyle(lyr_def.style)).style;
       }
 
       const src = new SparqlJson({
@@ -429,7 +427,7 @@ export class HsCompositionsLayerParserService {
           }
         }
         // Parse the style definition (SLD, QML, or standard style object)
-        const styleType = await this.HsStylerService.guessStyleFormat(
+        const styleType = await this.hsStylerService.guessStyleFormat(
           lyr_def.style,
         );
         // Assign the appropriate style property to options
@@ -462,7 +460,7 @@ export class HsCompositionsLayerParserService {
       switch (format) {
         case 'ol.format.KML': //backwards compatibility
         case 'KML':
-          layer = await this.HsAddDataVectorService.createVectorLayer(
+          layer = await this.hsAddDataVectorService.createVectorLayer(
             'kml',
             lyr_def.protocol.url,
             lyr_def.name || title,
@@ -474,7 +472,7 @@ export class HsCompositionsLayerParserService {
           break;
         case 'ol.format.GeoJSON': //backwards compatibility
         case 'GeoJSON':
-          layer = await this.HsAddDataVectorService.createVectorLayer(
+          layer = await this.hsAddDataVectorService.createVectorLayer(
             'geojson',
             lyr_def.protocol.url,
             lyr_def.name || title,
@@ -486,7 +484,7 @@ export class HsCompositionsLayerParserService {
           break;
         case 'hs.format.WFS': //backwards compatibility
         case 'WFS':
-          layer = await this.HsAddDataVectorService.createVectorLayer(
+          layer = await this.hsAddDataVectorService.createVectorLayer(
             'wfs',
             lyr_def.protocol.url,
             //lyr_def.protocol.LAYERS
@@ -508,7 +506,7 @@ export class HsCompositionsLayerParserService {
                 featureProjection: this.hsMapService.getCurrentProj(),
               })
             : undefined;
-          layer = await this.HsAddDataVectorService.createVectorLayer(
+          layer = await this.hsAddDataVectorService.createVectorLayer(
             '',
             undefined,
             lyr_def.name || title,

--- a/projects/hslayers/services/draw/draw.service.ts
+++ b/projects/hslayers/services/draw/draw.service.ts
@@ -1,4 +1,4 @@
-import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
+import {Injectable, NgZone, PLATFORM_ID, inject} from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
 import {lastValueFrom, merge} from 'rxjs';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
@@ -71,30 +71,30 @@ export const TMP_LAYER_TITLE = 'tmpDrawLayer';
   providedIn: 'root',
 })
 export class HsDrawService extends HsDrawServiceParams {
-  isAuthenticated = this.hsCommonLaymanService.isAuthenticated;
+  hsMapService = inject(HsMapService);
+  hsEventBusService = inject(HsEventBusService);
+  hsLayoutService = inject(HsLayoutService);
+  hsDialogContainerService = inject(HsDialogContainerService);
+  hsLogService = inject(HsLogService);
+  hsConfig = inject(HsConfig);
+  hsQueryBaseService = inject(HsQueryBaseService);
+  hsQueryVectorService = inject(HsQueryVectorService);
+  hsLaymanService = inject(HsLaymanService);
+  hsLanguageService = inject(HsLanguageService);
+  hsLaymanBrowserService = inject(HsLaymanBrowserService);
+  hsAddDataVectorService = inject(HsAddDataVectorService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+  hsToastService = inject(HsToastService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  private hsRemoveLayerDialogService = inject(HsRemoveLayerDialogService);
+  private zone = inject(NgZone);
+  private platformId = inject(PLATFORM_ID);
 
+  isAuthenticated = this.hsCommonLaymanService.isAuthenticated;
   pendingLayers = this.hsCommonLaymanLayerService.pendingLayers;
-  constructor(
-    public hsMapService: HsMapService,
-    public hsEventBusService: HsEventBusService,
-    public hsLayoutService: HsLayoutService,
-    public hsDialogContainerService: HsDialogContainerService,
-    public hsLogService: HsLogService,
-    public hsConfig: HsConfig,
-    public hsQueryBaseService: HsQueryBaseService,
-    public hsQueryVectorService: HsQueryVectorService,
-    public hsLaymanService: HsLaymanService,
-    public hsLanguageService: HsLanguageService,
-    public hsLaymanBrowserService: HsLaymanBrowserService,
-    public hsAddDataVectorService: HsAddDataVectorService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    public hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-    public hsToastService: HsToastService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    private hsRemoveLayerDialogService: HsRemoveLayerDialogService,
-    private zone: NgZone,
-    @Inject(PLATFORM_ID) private platformId: any,
-  ) {
+
+  constructor() {
     super();
     this.keyUp = this.keyUp.bind(this);
     this.hsMapService.loaded().then((map) => {

--- a/projects/hslayers/services/external/external.service.ts
+++ b/projects/hslayers/services/external/external.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import BaseLayer from 'ol/layer/Base';
 import {Cluster, Source, Vector as VectorSource} from 'ol/source';
@@ -43,15 +43,16 @@ export interface FeatureDomEventLinkDict {
   providedIn: 'root',
 })
 export class HsExternalService {
+  hsMapService = inject(HsMapService);
+  private hsLog = inject(HsLogService);
+  private hsQueryPopupService = inject(HsQueryPopupService);
+  private hsQueryBaseService = inject(HsQueryBaseService);
+  private hsQueryVectorService = inject(HsQueryVectorService);
+  private hsLayoutService = inject(HsLayoutService);
+
   featureLinks: FeatureDomEventLinkDict = {};
-  constructor(
-    public hsMapService: HsMapService,
-    private hsLog: HsLogService,
-    private hsQueryPopupService: HsQueryPopupService,
-    private hsQueryBaseService: HsQueryBaseService,
-    private hsQueryVectorService: HsQueryVectorService,
-    private hsLayoutService: HsLayoutService,
-  ) {
+
+  constructor() {
     this.hsMapService.loaded().then((map) => {
       for (const layer of map.getLayers().getArray()) {
         this.layerAdded(layer as Layer<Source>);

--- a/projects/hslayers/services/get-capabilities/arcgis-get-capabilities.service.ts
+++ b/projects/hslayers/services/get-capabilities/arcgis-get-capabilities.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer, Tile} from 'ol/layer';
 import {Source, TileWMS} from 'ol/source';
@@ -19,14 +19,12 @@ import {IGetCapabilities} from './get-capabilities.interface';
 
 @Injectable({providedIn: 'root'})
 export class HsArcgisGetCapabilitiesService implements IGetCapabilities {
-  constructor(
-    private httpClient: HttpClient,
-    public hsEventBusService: HsEventBusService,
-    public hsMapService: HsMapService,
-    public hsLogService: HsLogService,
-    public hsCapabilityCacheService: HsCapabilityCacheService,
-    private hsProxyService: HsProxyService,
-  ) {}
+  private httpClient = inject(HttpClient);
+  hsEventBusService = inject(HsEventBusService);
+  hsMapService = inject(HsMapService);
+  hsLogService = inject(HsLogService);
+  hsCapabilityCacheService = inject(HsCapabilityCacheService);
+  private hsProxyService = inject(HsProxyService);
 
   /**
    * Get WMS service location without parameters from url string

--- a/projects/hslayers/services/get-capabilities/dimension-time.service.ts
+++ b/projects/hslayers/services/get-capabilities/dimension-time.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {ImageWMS, Source, TileWMS} from 'ol/source';
@@ -13,6 +13,8 @@ import {getDimensions, setDimension} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsDimensionTimeService {
+  hsLog = inject(HsLogService);
+
   /**
    * To communicate changes between this service and HsDimensionService
    */
@@ -20,8 +22,6 @@ export class HsDimensionTimeService {
     layer: HsLayerDescriptor;
     time: string;
   }> = new Subject();
-
-  constructor(public hsLog: HsLogService) {}
 
   /**
    * Parse interval string to get interval as a number

--- a/projects/hslayers/services/get-capabilities/dimension.service.ts
+++ b/projects/hslayers/services/get-capabilities/dimension.service.ts
@@ -1,4 +1,5 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
+
 import {Layer} from 'ol/layer';
 import {Source, Vector as VectorSource, XYZ} from 'ol/source';
 
@@ -21,12 +22,12 @@ import {getDimensions} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsDimensionService {
-  constructor(
-    public $log: HsLogService,
-    public hsDimensionTimeService: HsDimensionTimeService,
-    public hsEventBusService: HsEventBusService,
-    public hsMapService: HsMapService,
-  ) {
+  $log = inject(HsLogService);
+  hsDimensionTimeService = inject(HsDimensionTimeService);
+  hsEventBusService = inject(HsEventBusService);
+  hsMapService = inject(HsMapService);
+
+  constructor() {
     this.hsDimensionTimeService.layerTimeChanges.subscribe(
       ({layer: layerDescriptor, time: newTime}) => {
         const dimensions = getDimensions(layerDescriptor.layer);

--- a/projects/hslayers/services/get-capabilities/wfs-get-capabilities.service.ts
+++ b/projects/hslayers/services/get-capabilities/wfs-get-capabilities.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable, WritableSignal, signal} from '@angular/core';
+import {Injectable, WritableSignal, signal, inject} from '@angular/core';
 
 import {lastValueFrom, takeUntil} from 'rxjs';
 
@@ -12,14 +12,13 @@ import {HsCommonLaymanService, isLaymanUrl} from 'hslayers-ng/common/layman';
 
 @Injectable({providedIn: 'root'})
 export class HsWfsGetCapabilitiesService implements IGetCapabilities {
+  private httpClient = inject(HttpClient);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsCapabilityCacheService = inject(HsCapabilityCacheService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsProxyService = inject(HsProxyService);
+
   service_url: WritableSignal<string> = signal('');
-  constructor(
-    private httpClient: HttpClient,
-    private hsEventBusService: HsEventBusService,
-    private hsCapabilityCacheService: HsCapabilityCacheService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsProxyService: HsProxyService,
-  ) {}
 
   /**
    * Get WFS service location without parameters from url string

--- a/projects/hslayers/services/get-capabilities/wms-get-capabilities.service.ts
+++ b/projects/hslayers/services/get-capabilities/wms-get-capabilities.service.ts
@@ -1,10 +1,10 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
+import {lastValueFrom, takeUntil} from 'rxjs';
 
 import {Layer, Tile} from 'ol/layer';
 import {Source, TileWMS} from 'ol/source';
 import {WMSCapabilities} from 'ol/format';
-import {lastValueFrom, takeUntil} from 'rxjs';
 
 import {CapabilitiesResponseWrapper, Metadata} from 'hslayers-ng/types';
 import {HsCapabilityCacheService} from './capability-cache.service';
@@ -20,14 +20,12 @@ import {IGetCapabilities} from './get-capabilities.interface';
 
 @Injectable({providedIn: 'root'})
 export class HsWmsGetCapabilitiesService implements IGetCapabilities {
-  constructor(
-    private httpClient: HttpClient,
-    public hsEventBusService: HsEventBusService,
-    public hsMapService: HsMapService,
-    public hsCommonLaymanService: HsCommonLaymanService,
-    private hsCapabilityCacheService: HsCapabilityCacheService,
-    private hsProxyService: HsProxyService,
-  ) {}
+  private httpClient = inject(HttpClient);
+  hsEventBusService = inject(HsEventBusService);
+  hsMapService = inject(HsMapService);
+  hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCapabilityCacheService = inject(HsCapabilityCacheService);
+  private hsProxyService = inject(HsProxyService);
 
   /**
    * Get WMS service location without parameters from URL string

--- a/projects/hslayers/services/get-capabilities/wmts-get-capabilities.service.ts
+++ b/projects/hslayers/services/get-capabilities/wmts-get-capabilities.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer, Tile} from 'ol/layer';
 import {Source, WMTS} from 'ol/source';
@@ -20,15 +20,14 @@ import {IGetCapabilities} from './get-capabilities.interface';
 
 @Injectable({providedIn: 'root'})
 export class HsWmtsGetCapabilitiesService implements IGetCapabilities {
+  private httpClient = inject(HttpClient);
+  hsEventBusService = inject(HsEventBusService);
+  hsMapService = inject(HsMapService);
+  hsWmsGetCapabilitiesService = inject(HsWmsGetCapabilitiesService);
+  hsCapabilityCacheService = inject(HsCapabilityCacheService);
+  private hsProxyService = inject(HsProxyService);
+
   service_url: any;
-  constructor(
-    private httpClient: HttpClient,
-    public hsEventBusService: HsEventBusService,
-    public hsMapService: HsMapService,
-    public hsWmsGetCapabilitiesService: HsWmsGetCapabilitiesService,
-    public hsCapabilityCacheService: HsCapabilityCacheService,
-    private hsProxyService: HsProxyService,
-  ) {}
 
   /**
    * Get WMTS service location without parameters from URL string

--- a/projects/hslayers/services/get-capabilities/xyz-get-capabilities.service.ts
+++ b/projects/hslayers/services/get-capabilities/xyz-get-capabilities.service.ts
@@ -1,24 +1,20 @@
 import {HttpClient} from '@angular/common/http';
-import {Injectable, WritableSignal, signal} from '@angular/core';
-
-import {lastValueFrom, takeUntil} from 'rxjs';
+import {Injectable, WritableSignal, signal, inject} from '@angular/core';
 
 import {CapabilitiesResponseWrapper} from 'hslayers-ng/types';
 import {HsCapabilityCacheService} from './capability-cache.service';
 import {HsEventBusService} from 'hslayers-ng/services/event-bus';
-import {getParamsFromUrl, HsProxyService} from 'hslayers-ng/services/utils';
+import {HsProxyService} from 'hslayers-ng/services/utils';
 import {IGetCapabilities} from './get-capabilities.interface';
 
 @Injectable({providedIn: 'root'})
 export class HsXyzGetCapabilitiesService implements IGetCapabilities {
-  service_url: WritableSignal<string> = signal('');
+  private httpClient = inject(HttpClient);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsCapabilityCacheService = inject(HsCapabilityCacheService);
+  private hsProxyService = inject(HsProxyService);
 
-  constructor(
-    private httpClient: HttpClient,
-    private hsEventBusService: HsEventBusService,
-    private hsCapabilityCacheService: HsCapabilityCacheService,
-    private hsProxyService: HsProxyService,
-  ) {}
+  service_url: WritableSignal<string> = signal('');
 
   /**
    * Get XYZ service location without parameters from url string

--- a/projects/hslayers/services/layer-manager/layer-editor-vector-layer.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-editor-vector-layer.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Circle, LineString, Point, Polygon} from 'ol/geom';
 import {Cluster, Source, Vector as VectorSource} from 'ol/source';
@@ -14,12 +14,11 @@ import {instOf} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsLayerEditorVectorLayerService {
+  hsConfig = inject(HsConfig);
+  hsMapService = inject(HsMapService);
+  hsStylerService = inject(HsStylerService);
+
   layersClusteredFromStart = [];
-  constructor(
-    public hsConfig: HsConfig,
-    public hsMapService: HsMapService,
-    public hsStylerService: HsStylerService,
-  ) {}
 
   /**
    * Convert layer to clustered state where its source gets nested in another

--- a/projects/hslayers/services/layer-manager/layer-manager-copy-layer.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager-copy-layer.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Cluster, Vector as VectorSource} from 'ol/source';
 import {Feature} from 'ol';
@@ -29,12 +29,10 @@ import {
   providedIn: 'root',
 })
 export class HsLayerManagerCopyLayerService {
-  constructor(
-    public hsLayerSelectorService: HsLayerSelectorService,
-    public hsMapService: HsMapService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    private hsLayerManagerUtilsService: HsLayerManagerUtilsService,
-  ) {}
+  hsLayerSelectorService = inject(HsLayerSelectorService);
+  hsMapService = inject(HsMapService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  private hsLayerManagerUtilsService = inject(HsLayerManagerUtilsService);
 
   /**
     Creates a copy of the currentLayer

--- a/projects/hslayers/services/layer-manager/layer-manager-folder.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager-folder.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject, debounceTime} from 'rxjs';
 
 import {HsConfig} from 'hslayers-ng/config';
@@ -48,6 +48,9 @@ type FolderAction =
   providedIn: 'root',
 })
 export class HsLayerManagerFolderService {
+  private hsLanguageService = inject(HsLanguageService);
+  private hsConfig = inject(HsConfig);
+
   private sortDebounceTime = 300;
   private sortSubject = new Subject<void>();
 
@@ -55,10 +58,8 @@ export class HsLayerManagerFolderService {
   folderAction$ = new Subject<FolderAction>();
 
   data: HsLayermanagerDataObject;
-  constructor(
-    private hsLanguageService: HsLanguageService,
-    private hsConfig: HsConfig,
-  ) {
+
+  constructor() {
     this.sortSubject.pipe(debounceTime(this.sortDebounceTime)).subscribe(() => {
       this.folderAction$.next(this.sortByZ({debounce: false}));
     });

--- a/projects/hslayers/services/layer-manager/layer-manager-loading-progress.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager-loading-progress.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 import {Subject, buffer, debounceTime, pairwise} from 'rxjs';
 
 import {Cluster, Source} from 'ol/source';
@@ -22,14 +22,12 @@ import {
   providedIn: 'root',
 })
 export class HsLayerManagerLoadingProgressService {
-  constructor(
-    private hsConfig: HsConfig,
-    private hsLog: HsLogService,
-    private zone: NgZone,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsEventBusService: HsEventBusService,
-  ) {}
+  private hsConfig = inject(HsConfig);
+  private hsLog = inject(HsLogService);
+  private zone = inject(NgZone);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsEventBusService = inject(HsEventBusService);
 
   /**
    * Create events for checking whether the layer is being loaded or is loaded

--- a/projects/hslayers/services/layer-manager/layer-manager-utils.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager-utils.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {Cluster, Source, Vector as VectorSource} from 'ol/source';
@@ -32,16 +32,13 @@ import {getThumbnail, getTitle} from 'hslayers-ng/common/extensions';
   providedIn: 'root',
 })
 export class HsLayerManagerUtilsService {
+  private hsConfig = inject(HsConfig);
+  private hsLayerSelectorService = inject(HsLayerSelectorService);
+  private hsMapService = inject(HsMapService);
+  private hsLog = inject(HsLogService);
+
   currentLayer: HsLayerDescriptor;
-
   layerSelected: Subject<HsLayerDescriptor> = new Subject();
-
-  constructor(
-    private hsConfig: HsConfig,
-    private hsLayerSelectorService: HsLayerSelectorService,
-    private hsMapService: HsMapService,
-    private hsLog: HsLogService,
-  ) {}
 
   /**
    * DEPRECATED?

--- a/projects/hslayers/services/layer-manager/layer-manager-visibility.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager-visibility.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -15,17 +15,16 @@ import {isLayerVectorLayer} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsLayerManagerVisibilityService {
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+  private hsEventBusService = inject(HsEventBusService);
+
   /**
    * Store if baselayers are visible (more precisely one of baselayers)
    */
   baselayersVisible = true;
   currentResolution: number;
   data: HsLayermanagerDataObject;
-  constructor(
-    private hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    private hsEventBusService: HsEventBusService,
-  ) {}
 
   layerVisibilityChanged(e) {
     if (getBase(e.target) != true) {

--- a/projects/hslayers/services/layer-manager/layer-manager.service.ts
+++ b/projects/hslayers/services/layer-manager/layer-manager.service.ts
@@ -1,5 +1,5 @@
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
-import {Injectable, Signal} from '@angular/core';
+import {Injectable, Signal, inject} from '@angular/core';
 import {
   Observable,
   filter as rxjsFilter,
@@ -99,32 +99,36 @@ export class HsLayermanagerDataObject {
   providedIn: 'root',
 })
 export class HsLayerManagerService {
+  hsConfig = inject(HsConfig);
+  hsDimensionTimeService = inject(HsDimensionTimeService);
+  hsEventBusService = inject(HsEventBusService);
+  hsLanguageService = inject(HsLanguageService);
+  hsLayerEditorVectorLayerService = inject(HsLayerEditorVectorLayerService);
+  hsLayerManagerMetadata = inject(HsLayerManagerMetadataService);
+  hsLayerSelectorService = inject(HsLayerSelectorService);
+  hsLayoutService = inject(HsLayoutService);
+  hsLog = inject(HsLogService);
+  hsMapService = inject(HsMapService);
+  hsQueuesService = inject(HsQueuesService);
+  hsAddDataOwsService = inject(HsAddDataOwsService);
+  private hsShareUrlService = inject(HsShareUrlService);
+  hsToastService = inject(HsToastService);
+  sanitizer = inject(DomSanitizer);
+  private hsLayerManagerUtilsService = inject(HsLayerManagerUtilsService);
+  private hsLayerManagerVisibilityService = inject(
+    HsLayerManagerVisibilityService,
+  );
+  private folderService = inject(HsLayerManagerFolderService);
+  private hsLoadingProgressService = inject(
+    HsLayerManagerLoadingProgressService,
+  );
+
   data = new HsLayermanagerDataObject();
   timer: any;
   zIndexValue = 0;
 
   mapEventHandlers: EventsKey[];
-  constructor(
-    public hsConfig: HsConfig,
-    public hsDimensionTimeService: HsDimensionTimeService,
-    public hsEventBusService: HsEventBusService,
-    public hsLanguageService: HsLanguageService,
-    public hsLayerEditorVectorLayerService: HsLayerEditorVectorLayerService,
-    public hsLayerManagerMetadata: HsLayerManagerMetadataService,
-    public hsLayerSelectorService: HsLayerSelectorService,
-    public hsLayoutService: HsLayoutService,
-    public hsLog: HsLogService,
-    public hsMapService: HsMapService,
-    public hsQueuesService: HsQueuesService,
-    public hsAddDataOwsService: HsAddDataOwsService,
-    private hsShareUrlService: HsShareUrlService,
-    public hsToastService: HsToastService,
-    public sanitizer: DomSanitizer,
-    private hsLayerManagerUtilsService: HsLayerManagerUtilsService,
-    private hsLayerManagerVisibilityService: HsLayerManagerVisibilityService,
-    private folderService: HsLayerManagerFolderService,
-    private hsLoadingProgressService: HsLayerManagerLoadingProgressService,
-  ) {
+  constructor() {
     //Keeps 'data' object intact and in one place while allowing to split method between more services
     this.hsLayerManagerVisibilityService.data = this.data;
     this.folderService.data = this.data;

--- a/projects/hslayers/services/layer-shifting/layer-shifting.service.ts
+++ b/projects/hslayers/services/layer-shifting/layer-shifting.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 import {Layer} from 'ol/layer';
 import {Source} from 'ol/source';
@@ -23,13 +23,12 @@ export class LayerListItem {
   providedIn: 'root',
 })
 export class HsLayerShiftingService {
+  private hsMapService = inject(HsMapService);
+  private hsLayerManagerService = inject(HsLayerManagerService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsFolderService = inject(HsLayerManagerFolderService);
+
   layersCopy: LayerListItem[] = [];
-  constructor(
-    private hsMapService: HsMapService,
-    private hsLayerManagerService: HsLayerManagerService,
-    private hsEventBusService: HsEventBusService,
-    private hsFolderService: HsLayerManagerFolderService,
-  ) {}
 
   /**
    * Function by which to filter the displayed layers.

--- a/projects/hslayers/services/layout/layout.service.ts
+++ b/projects/hslayers/services/layout/layout.service.ts
@@ -1,5 +1,11 @@
 import {BehaviorSubject, Observable, Subject, delay, map, skip} from 'rxjs';
-import {ElementRef, Injectable, Type, ViewContainerRef} from '@angular/core';
+import {
+  ElementRef,
+  Injectable,
+  Type,
+  ViewContainerRef,
+  inject,
+} from '@angular/core';
 
 import {HsConfig, DefaultPanel} from 'hslayers-ng/config';
 import {HsLogService} from 'hslayers-ng/services/log';
@@ -83,6 +89,9 @@ export class HsLayoutParams {
   providedIn: 'root',
 })
 export class HsLayoutService extends HsLayoutParams {
+  hsConfig = inject(HsConfig);
+  $log = inject(HsLogService);
+
   mapSpaceRef: BehaviorSubject<ViewContainerRef> = new BehaviorSubject(
     undefined,
   );
@@ -106,10 +115,7 @@ export class HsLayoutService extends HsLayoutParams {
 
   layoutLoads: Subject<{element: any; innerElement: string}> = new Subject();
 
-  constructor(
-    public hsConfig: HsConfig,
-    public $log: HsLogService,
-  ) {
+  constructor() {
     super();
     Object.defineProperty(this, 'panelListElement', {
       get: function () {

--- a/projects/hslayers/services/map/map.service.ts
+++ b/projects/hslayers/services/map/map.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-eq-null */
-import {Injectable, Renderer2, RendererFactory2} from '@angular/core';
+import {Injectable, Renderer2, RendererFactory2, inject} from '@angular/core';
 import {filter} from 'rxjs';
 
 import ImageWrapper from 'ol/Image';
@@ -71,6 +71,16 @@ type VectorAndSource = {
   providedIn: 'root',
 })
 export class HsMapService {
+  hsConfig = inject(HsConfig);
+  hsLayoutService = inject(HsLayoutService);
+  private hsLog = inject(HsLogService);
+  hsEventBusService = inject(HsEventBusService);
+  hsLanguageService = inject(HsLanguageService);
+  private hsQueuesService = inject(HsQueuesService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private rendererFactory = inject(RendererFactory2);
+  private hsProxyService = inject(HsProxyService);
+
   map: Map;
   mapElement?: any;
   renderer?: Renderer2;
@@ -101,17 +111,8 @@ export class HsMapService {
    * Keeps track of zoomWithModifier listener so it's not registered multiple times when using router
    */
   zoomWithModifierListener;
-  constructor(
-    public hsConfig: HsConfig,
-    public hsLayoutService: HsLayoutService,
-    private hsLog: HsLogService,
-    public hsEventBusService: HsEventBusService,
-    public hsLanguageService: HsLanguageService,
-    private hsQueuesService: HsQueuesService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private rendererFactory: RendererFactory2,
-    private hsProxyService: HsProxyService,
-  ) {
+
+  constructor() {
     /**
      * Set pure map
      */

--- a/projects/hslayers/services/panel-constructor/overlay-constructor.service.ts
+++ b/projects/hslayers/services/panel-constructor/overlay-constructor.service.ts
@@ -1,11 +1,11 @@
-import {HsQueryPopupService} from 'hslayers-ng/common/query-popup';
 import {
   Injectable,
   Injector,
   inject,
   runInInjectionContext,
 } from '@angular/core';
-import {filter, firstValueFrom, map, take, tap} from 'rxjs';
+import {filter, firstValueFrom, map, take} from 'rxjs';
+import {toObservable} from '@angular/core/rxjs-interop';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {
@@ -13,31 +13,29 @@ import {
   HsPanelContainerService,
   HsToolbarPanelContainerService,
 } from 'hslayers-ng/services/panels';
-import {toObservable} from '@angular/core/rxjs-interop';
+import {HsQueryPopupService} from 'hslayers-ng/common/query-popup';
 
 @Injectable({
   providedIn: 'root',
 })
 export class HsOverlayConstructorService extends HsPanelContainerService {
+  private hsConfig = inject(HsConfig);
+  private hsToolbarPanelContainerService = inject(
+    HsToolbarPanelContainerService,
+  );
+  private hsOverlayContainerService = inject(HsOverlayContainerService);
+  private hsQueryPopupService = inject(HsQueryPopupService);
+
   private injector = inject(Injector);
 
   panels$ = toObservable(this.hsToolbarPanelContainerService.panels);
-
-  constructor(
-    private hsConfig: HsConfig,
-    private hsToolbarPanelContainerService: HsToolbarPanelContainerService,
-    private HsOverlayContainerService: HsOverlayContainerService,
-    private hsQueryPopupService: HsQueryPopupService,
-  ) {
-    super();
-  }
 
   /**
    * Create GUI component based on name string.
    */
   private async _createGuiComponent(
     name: string,
-    service: HsPanelContainerService = this.HsOverlayContainerService,
+    service: HsPanelContainerService = this.hsOverlayContainerService,
   ) {
     const cName = `Hs${this.capitalizeFirstLetter(name)}Component`;
     const data =

--- a/projects/hslayers/services/panel-constructor/panel-constructor.service.ts
+++ b/projects/hslayers/services/panel-constructor/panel-constructor.service.ts
@@ -1,5 +1,5 @@
 import {HsConfig} from 'hslayers-ng/config';
-import {Injectable, Type} from '@angular/core';
+import {Injectable, Type, inject} from '@angular/core';
 
 import {HsButton} from 'hslayers-ng/types';
 import {HsPanelContainerService} from 'hslayers-ng/services/panels';
@@ -11,11 +11,11 @@ import {skip} from 'rxjs';
   providedIn: 'root',
 })
 export class HsPanelConstructorService {
-  constructor(
-    private hsConfig: HsConfig,
-    private HsPanelContainerService: HsPanelContainerService,
-    private hsSidebarService: HsSidebarService,
-  ) {
+  private hsConfig = inject(HsConfig);
+  private hsPanelContainerService = inject(HsPanelContainerService);
+  private hsSidebarService = inject(HsSidebarService);
+
+  constructor() {
     this.hsConfig.configChanges.pipe(skip(1)).subscribe(async () => {
       /**
        * Create panels activated after app init. Buttons are handled in sidebarService
@@ -24,7 +24,7 @@ export class HsPanelConstructorService {
         (acc, [panel, isEnabled]) => (isEnabled ? [...acc, panel] : acc),
         [],
       );
-      const created = this.HsPanelContainerService.panels().map((p) => p.name);
+      const created = this.hsPanelContainerService.panels().map((p) => p.name);
       const toBeCreated = activePanels.filter((p) => !created.includes(p));
       for (const panel of toBeCreated) {
         await this._createPanel(panel);
@@ -94,7 +94,7 @@ export class HsPanelConstructorService {
       default:
         break;
     }
-    this.HsPanelContainerService.create(i[cName], data || {});
+    this.hsPanelContainerService.create(i[cName], data || {});
   }
 
   /**
@@ -129,7 +129,7 @@ export class HsPanelConstructorService {
     buttonDefinition: HsButton,
     data?: any,
   ) {
-    this.HsPanelContainerService.create(component, data || {});
+    this.hsPanelContainerService.create(component, data || {});
     this.hsSidebarService.addButton(buttonDefinition);
   }
 

--- a/projects/hslayers/services/query/query-base.service.ts
+++ b/projects/hslayers/services/query/query-base.service.ts
@@ -1,5 +1,5 @@
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
-import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
+import {Injectable, NgZone, PLATFORM_ID, inject} from '@angular/core';
 import {Subject} from 'rxjs';
 import {isPlatformBrowser} from '@angular/common';
 
@@ -46,6 +46,16 @@ export type HsCoordinateDescription = {
   providedIn: 'root',
 })
 export class HsQueryBaseService {
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+  private hsLayoutService = inject(HsLayoutService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsSaveMapService = inject(HsSaveMapService);
+  private domSanitizer = inject(DomSanitizer);
+  private zone = inject(NgZone);
+  private platformId = inject(PLATFORM_ID);
+
   attributes = [];
   features: HsFeatureDescriptor[] = [];
   featureInfoHtmls: SafeHtml[] = [];
@@ -79,17 +89,7 @@ export class HsQueryBaseService {
   multiWmsQuery = false;
   wmsFeatureInfoLoading = false;
 
-  constructor(
-    private hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    private hsLayoutService: HsLayoutService,
-    private hsLanguageService: HsLanguageService,
-    private hsEventBusService: HsEventBusService,
-    private hsSaveMapService: HsSaveMapService,
-    private domSanitizer: DomSanitizer,
-    private zone: NgZone,
-    @Inject(PLATFORM_ID) private platformId: any,
-  ) {
+  constructor() {
     this.vectorSelectorCreated.subscribe((selector) => {
       this.selector = selector;
     });

--- a/projects/hslayers/services/query/query-vector.service.ts
+++ b/projects/hslayers/services/query/query-vector.service.ts
@@ -1,5 +1,5 @@
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Subject, debounceTime} from 'rxjs';
 
 import * as extent from 'ol/extent';
@@ -57,16 +57,17 @@ export const defaultSelectStyle = [
   providedIn: 'root',
 })
 export class HsQueryVectorService {
+  private hsQueryBaseService = inject(HsQueryBaseService);
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+  private hsEventBusService = inject(HsEventBusService);
+  private domSanitizer = inject(DomSanitizer);
+
   featureRemovals: Subject<Feature<Geometry>> = new Subject();
   selector: Select = null;
   private setSelectorTrigger = new Subject<void>();
-  constructor(
-    private hsQueryBaseService: HsQueryBaseService,
-    private hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    private hsEventBusService: HsEventBusService,
-    private domSanitizer: DomSanitizer,
-  ) {
+
+  constructor() {
     this.hsQueryBaseService.getFeatureInfoStarted.subscribe((evt) => {
       this.hsQueryBaseService.clear('features');
       if (!this.hsQueryBaseService.queryActive) {

--- a/projects/hslayers/services/save-map/layer-synchronizer.service.ts
+++ b/projects/hslayers/services/save-map/layer-synchronizer.service.ts
@@ -1,8 +1,9 @@
-import {Injectable, DestroyRef} from '@angular/core';
-import {filter, switchMap} from 'rxjs/operators';
-import {from, fromEvent} from 'rxjs';
-
 import * as xml2Json from 'xml-js';
+
+import {Injectable, DestroyRef, inject} from '@angular/core';
+import {filter, switchMap} from 'rxjs/operators';
+import {fromEvent} from 'rxjs';
+
 import {Feature} from 'ol';
 import {Geometry} from 'ol/geom';
 import {ObjectEvent} from 'ol/Object';
@@ -37,20 +38,21 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
   providedIn: 'root',
 })
 export class HsLayerSynchronizerService {
+  private hsLaymanService = inject(HsLaymanService);
+  private hsMapService = inject(HsMapService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsLogService = inject(HsLogService);
+  private hsEventBusService = inject(HsEventBusService);
+  private destroyRef = inject(DestroyRef);
+
   debounceInterval = 1000;
   crs: string;
   syncedLayers: VectorLayer<VectorSource<Feature>>[] = [];
-  constructor(
-    private hsLaymanService: HsLaymanService,
-    private hsMapService: HsMapService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsLogService: HsLogService,
-    private hsEventBusService: HsEventBusService,
-    private destroyRef: DestroyRef,
-  ) {
+
+  constructor() {
     this.hsMapService.loaded().then((map) => {
       const layerAdded = (e) => this.addLayer(e.element);
       map.getLayers().on('add', layerAdded);

--- a/projects/hslayers/services/save-map/layman.service.ts
+++ b/projects/hslayers/services/save-map/layman.service.ts
@@ -1,7 +1,8 @@
-import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {computed, Injectable} from '@angular/core';
-
 import Resumable from 'resumablejs';
+
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {computed, Injectable, inject} from '@angular/core';
+
 import {
   Observable,
   Subscription,
@@ -66,6 +67,14 @@ import {normalizeSldComparisonOperators} from 'hslayers-ng/services/utils';
   providedIn: 'root',
 })
 export class HsLaymanService implements HsSaverService {
+  private http = inject(HttpClient);
+  private hsMapService = inject(HsMapService);
+  private hsLogService = inject(HsLogService);
+  private hsToastService = inject(HsToastService);
+  private hsLanguageService = inject(HsLanguageService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsCommonLaymanLayerService = inject(HsCommonLaymanLayerService);
+
   crs: string;
   totalProgress = 0;
   deleteQuery: Subscription;
@@ -76,16 +85,6 @@ export class HsLaymanService implements HsSaverService {
     }
     return SUPPORTED_SRS_LIST;
   });
-
-  constructor(
-    private http: HttpClient,
-    private hsMapService: HsMapService,
-    private hsLogService: HsLogService,
-    private hsToastService: HsToastService,
-    private hsLanguageService: HsLanguageService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsCommonLaymanLayerService: HsCommonLaymanLayerService,
-  ) {}
 
   /**
    * Update composition's access rights

--- a/projects/hslayers/services/save-map/save-map.service.ts
+++ b/projects/hslayers/services/save-map/save-map.service.ts
@@ -1,3 +1,5 @@
+import {Injectable, inject} from '@angular/core';
+
 import {Circle, Icon, RegularShape, Style} from 'ol/style';
 import {
   Cluster,
@@ -10,12 +12,12 @@ import {
   XYZ,
   Vector as VectorSource,
 } from 'ol/source';
-import {Feature, Map} from 'ol';
 import {EsriJSON, GeoJSON} from 'ol/format';
+import {Feature, Map} from 'ol';
+import {FeatureUrlFunction} from 'ol/featureloader';
 import {GeoJSONFeatureCollection} from 'ol/format/GeoJSON';
 import {Geometry} from 'ol/geom';
 import {Image as ImageLayer, Tile, Layer} from 'ol/layer';
-import {Injectable} from '@angular/core';
 import {transformExtent} from 'ol/proj';
 
 import {
@@ -65,7 +67,6 @@ import {
   getWorkspace,
 } from 'hslayers-ng/common/extensions';
 import {HsCommonLaymanService} from 'hslayers-ng/common/layman';
-import {FeatureUrlFunction} from 'ol/featureloader';
 
 const LOCAL_STORAGE_EXPIRE = 5000;
 
@@ -73,14 +74,13 @@ const LOCAL_STORAGE_EXPIRE = 5000;
   providedIn: 'root',
 })
 export class HsSaveMapService {
+  private hsMapService = inject(HsMapService);
+  private hsLogService = inject(HsLogService);
+  private hsShareThumbnailService = inject(HsShareThumbnailService);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsProxyService = inject(HsProxyService);
+
   public internalLayers: Layer<Source>[] = [];
-  constructor(
-    private hsMapService: HsMapService,
-    private hsLogService: HsLogService,
-    private hsShareThumbnailService: HsShareThumbnailService,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsProxyService: HsProxyService,
-  ) {}
 
   /**
    * Create JSON object, which stores information about composition, user, map state and map layers (including layer data)

--- a/projects/hslayers/services/share/share-thumbnail.service.ts
+++ b/projects/hslayers/services/share/share-thumbnail.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, Renderer2, RendererFactory2} from '@angular/core';
+import {Injectable, Renderer2, RendererFactory2, inject} from '@angular/core';
 
 import {HsConfig} from 'hslayers-ng/config';
 import {HsLogService} from 'hslayers-ng/services/log';
@@ -8,16 +8,18 @@ import {HsMapService} from 'hslayers-ng/services/map';
   providedIn: 'root',
 })
 export class HsShareThumbnailService {
+  hsMapService = inject(HsMapService);
+  hsLogService = inject(HsLogService);
+  private hsConfig = inject(HsConfig);
+
   private readonly THUMBNAIL_SIZE = 200;
   private readonly SCALE_FACTOR = 2.5;
 
   private renderer: Renderer2;
-  constructor(
-    public HsMapService: HsMapService,
-    public HsLogService: HsLogService,
-    rendererFactory: RendererFactory2,
-    private hsConfig: HsConfig,
-  ) {
+
+  constructor() {
+    const rendererFactory = inject(RendererFactory2);
+
     this.renderer = rendererFactory.createRenderer(null, null);
   }
 
@@ -41,9 +43,9 @@ export class HsShareThumbnailService {
     }
 
     const canvasLayers =
-      this.HsMapService.mapElement.querySelectorAll('.ol-layer canvas');
+      this.hsMapService.mapElement.querySelectorAll('.ol-layer canvas');
     if (canvasLayers.length === 0) {
-      this.HsLogService.warn('No canvas layers found to generate thumbnail.');
+      this.hsLogService.warn('No canvas layers found to generate thumbnail.');
       // Optionally set a default image or return early
       $element.setAttribute(
         'src',
@@ -139,12 +141,12 @@ export class HsShareThumbnailService {
       //this.data.thumbnail
       thumbnail = targetCanvas.toDataURL('image/jpeg', 0.85);
     } catch (e) {
-      this.HsLogService.log(
+      this.hsLogService.log(
         'catch, is tainted?',
         this.isCanvasTainted(targetCanvas),
       );
       //console.log(targetCanvas);
-      this.HsLogService.warn(e);
+      this.hsLogService.warn(e);
       $element.setAttribute(
         'src',
         this.hsConfig.assetsPath + 'img/notAvailable.png',

--- a/projects/hslayers/services/styler/styler.service.ts
+++ b/projects/hslayers/services/styler/styler.service.ts
@@ -1,8 +1,15 @@
+import colormap from 'colormap';
+
 import {DomSanitizer} from '@angular/platform-browser';
-import {computed, Injectable, signal, WritableSignal} from '@angular/core';
+import {
+  computed,
+  Injectable,
+  signal,
+  WritableSignal,
+  inject,
+} from '@angular/core';
 import {Subject} from 'rxjs';
 
-import colormap from 'colormap';
 import {Cluster, Vector as VectorSource} from 'ol/source';
 import {
   ConstructorParams,
@@ -60,6 +67,17 @@ import {
   providedIn: 'root',
 })
 export class HsStylerService {
+  hsQueryVectorService = inject(HsQueryVectorService);
+  private hsEventBusService = inject(HsEventBusService);
+  private hsLogService = inject(HsLogService);
+  sanitizer = inject(DomSanitizer);
+  private hsMapService = inject(HsMapService);
+  private hsConfig = inject(HsConfig);
+  private hsCommonLaymanService = inject(HsCommonLaymanService);
+  private hsLayerSynchronizerService = inject(HsLayerSynchronizerService);
+  private hsDialogContainerService = inject(HsDialogContainerService);
+  private hsToastService = inject(HsToastService);
+
   layer: WritableSignal<VectorLayer<VectorSource<Feature>>> = signal(null);
   layerBeingMonitored: boolean;
   onSet: Subject<VectorLayer<VectorSource<Feature>>> = new Subject();
@@ -94,18 +112,7 @@ export class HsStylerService {
   //in order to be able to sync layer style and sld prop
   sldParsingError = false;
 
-  constructor(
-    public hsQueryVectorService: HsQueryVectorService,
-    private hsEventBusService: HsEventBusService,
-    private hsLogService: HsLogService,
-    public sanitizer: DomSanitizer,
-    private hsMapService: HsMapService,
-    private hsConfig: HsConfig,
-    private hsCommonLaymanService: HsCommonLaymanService,
-    private hsLayerSynchronizerService: HsLayerSynchronizerService,
-    private hsDialogContainerService: HsDialogContainerService,
-    private hsToastService: HsToastService,
-  ) {
+  constructor() {
     this.pin_white_blue = new Style({
       image: new Icon({
         src: this.hsConfig.assetsPath + 'img/pin_white_blue32.png',

--- a/projects/test-app/src/hslayers-app/hslayers-app.component.ts
+++ b/projects/test-app/src/hslayers-app/hslayers-app.component.ts
@@ -1,5 +1,6 @@
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
+import {catchError, lastValueFrom, takeUntil} from 'rxjs';
 
 import {Circle, Fill, Stroke, Style} from 'ol/style';
 import {Feature} from 'ol';
@@ -7,7 +8,6 @@ import {GeoJSON} from 'ol/format';
 import {Image as ImageLayer, Vector as VectorLayer, Tile} from 'ol/layer';
 import {OSM, TileWMS, Vector as VectorSource, XYZ} from 'ol/source';
 import {Point} from 'ol/geom';
-import {catchError, lastValueFrom, takeUntil} from 'rxjs';
 import {transformExtent} from 'ol/proj';
 
 import {HsConfig} from 'hslayers-ng/config';
@@ -31,16 +31,16 @@ import {SomeComponent} from './some-panel/some-panel.component';
   standalone: false,
 })
 export class HslayersAppComponent {
-  constructor(
-    public hsConfig: HsConfig,
-    private hsProxyService: HsProxyService,
-    private hsEventBusService: HsEventBusService,
-    private httpClient: HttpClient,
-    public hsSidebarService: HsSidebarService,
-    public hsPanelConstructorService: HsPanelConstructorService,
-    public hsLayoutService: HsLayoutService,
-    private hsOverlayConstructorService: HsOverlayConstructorService,
-  ) {
+  hsConfig = inject(HsConfig);
+  private hsProxyService = inject(HsProxyService);
+  private hsEventBusService = inject(HsEventBusService);
+  private httpClient = inject(HttpClient);
+  hsSidebarService = inject(HsSidebarService);
+  hsPanelConstructorService = inject(HsPanelConstructorService);
+  hsLayoutService = inject(HsLayoutService);
+  private hsOverlayConstructorService = inject(HsOverlayConstructorService);
+
+  constructor() {
     /* Create new panel and its button in the sidebar */
     this.hsPanelConstructorService.createPanelAndButton(
       SomeComponent,


### PR DESCRIPTION
## Description

Replace constructor-based dependency injection with `inject()` function. It is recommended by angular-eslint. Needs alignment in child classes constructors (calling `super(...)` with injected services is no longer needed).
Technically, this might be a breaking change for applications relying on class inheritance.

## Related issues or pull requests

#4517 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [MIT License]
- [x] I have followed the [guidelines for contributing](https://github.com/hslayers/hslayers-ng/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/hslayers/hslayers-ng/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
